### PR TITLE
v4.0.0 — coverage expansion + scope tier system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,18 @@ GOOGLE_CLIENT_SECRET=your_client_secret_here
 # Comma-separated list of alias:email pairs
 # Example: work:you@company.com,personal:you@gmail.com
 GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
+
+# ─── Optional (v4.0.0) ──────────────────────────────────────────────────
+# Opt in to additional scope bundles. Each bundle enables a tool group and
+# its OAuth scopes. Re-auth all accounts after changing this.
+# Supported: forms, chat
+# GOOGLE_OPTIONAL_SCOPES=forms,chat
+
+# Comma-separated list of account aliases that should be granted Workspace
+# admin scopes (Reports, Alert Center, Directory). Accounts NOT listed here
+# will never request admin scopes — safe for personal Gmail.
+# GOOGLE_ADMIN_ACCOUNTS=work
+
+# Required to unlock destructive admin write operations (admin_users_update).
+# Default refuses to prevent accidents on small orgs.
+# GOOGLE_ALLOW_ADMIN_WRITES=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,115 @@
+# Changelog
+
+All notable changes to this project are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [4.0.0] — 2026-05-11
+
+> **Breaking — re-authenticate every account after upgrading.** The base OAuth scope set grew (Tasks + Meet added); existing tokens lack the new scopes and Tasks/Meet tools will 403 until you re-run `npm run auth -- <alias>` for each account.
+
+### Added
+
+**Drive completers (20 tools)**
+- `drive_untrash` — restore a trashed file (fixes the one-way door)
+- `drive_move` — move a file between folders without delete+recreate
+- `drive_empty_trash` — wipe the trash in one call
+- `drive_permission_update` — change a permission's role/expiration in place
+- `drive_comment_create` / `drive_comment_list` / `drive_comment_get` / `drive_comment_update` / `drive_comment_delete` — full comment CRUD, works on Docs, PDFs and any Drive file
+- `drive_reply_create` (with `action: resolve | reopen`) / `drive_reply_list` / `drive_reply_update` / `drive_reply_delete` — reply threads with programmatic resolve/reopen
+- `drive_revision_list` / `drive_revision_update` (`keepForever`, `published`) / `drive_revision_delete` — version history + pinning
+- `drive_access_proposal_list` / `drive_access_proposal_resolve` — programmatic triage of "Request access" submissions
+- `drive_shared_drives_list` / `drive_shared_drive_get` — shared-drive discovery
+
+**Sheets formatting + CRM completers (19 tools)**
+- `sheets_delete_sheet`, `sheets_duplicate_sheet`, `sheets_update_sheet_properties` (rename, freeze rows/cols, tab color, hide, grid size)
+- `sheets_format_cells` — colors, fonts, alignment, number formats with auto-computed fields mask
+- `sheets_update_borders`, `sheets_merge_cells`, `sheets_unmerge_cells`
+- `sheets_add_conditional_format_rule` (boolean and gradient rules)
+- `sheets_sort_range`, `sheets_set_basic_filter`, `sheets_clear_basic_filter`, `sheets_find_replace` (regex + scope-aware), `sheets_auto_resize_dimensions`
+- `sheets_set_data_validation` (dropdowns, checkboxes, numeric/date/custom rules)
+- `sheets_add_named_range`, `sheets_delete_named_range`
+- `sheets_insert_dimension`, `sheets_delete_dimension`
+- `sheets_batch_clear` (values.batchClear)
+- `sheets_batch_update` — generic Request[] escape hatch covering the ~70 Sheets batchUpdate Request types
+
+**Docs templating + structure (15 tools + 1 extension)**
+- `docs_create_named_range`, `docs_delete_named_range`, `docs_replace_named_range_content` — real mail-merge primitive
+- `docs_update_paragraph_style` (alignment, heading, indents, line spacing) and `docs_update_document_style` (page size, margins, header/footer behavior) with auto-computed fields masks
+- `docs_create_paragraph_bullets`, `docs_delete_paragraph_bullets`
+- `docs_insert_inline_image` (PNG/JPEG/GIF up to 50 MB)
+- `docs_insert_page_break`, `docs_insert_section_break`
+- `docs_create_header`, `docs_delete_header`, `docs_create_footer`, `docs_delete_footer`
+- `docs_modify_table` — single tool with `operation` discriminator for insertRow / insertColumn / deleteRow / deleteColumn / mergeCells / unmergeCells
+- `docs_add_tab`, `docs_delete_tab`, `docs_update_tab_properties` — full tabs CRUD
+- `docs_batch_update` — generic Request[] escape hatch covering the full 40-type Docs Request union
+- `docs_get` extended with `includeTabsContent` and `suggestionsViewMode`
+
+**Tasks API (12 tools)** — new service
+- Tasklists: `tasks_lists_list`, `tasks_list_get`, `tasks_list_insert`, `tasks_list_update`, `tasks_list_delete`
+- Tasks: `tasks_list`, `tasks_get`, `tasks_insert`, `tasks_update`, `tasks_delete`, `tasks_move`, `tasks_clear`
+
+**Meet v2 (5 tools)** — new service
+- `meet_conference_records_list`, `meet_conference_record_get`
+- `meet_recordings_list`, `meet_transcripts_list`, `meet_transcript_entries_list`
+
+**Forms (4 tools, optional scope bundle)** — new service
+- `forms_get`, `forms_responses_list`, `forms_response_get`, `forms_watches_list`
+
+**Chat (4 tools, optional scope bundle)** — new service
+- `chat_spaces_list`, `chat_spaces_get`, `chat_messages_create`, `chat_messages_list`
+
+**Admin SDK (8 tools, admin scope bundle)** — new service
+- Reports: `reports_activities_list` (Workspace audit log across all applications)
+- Alert Center: `alertcenter_alerts_list`, `alertcenter_alert_get`
+- Directory: `admin_users_list`, `admin_users_get`, `admin_users_update` (gated behind `GOOGLE_ALLOW_ADMIN_WRITES`), `admin_groups_list`, `admin_group_members_list`
+
+### Changed
+
+- `drive_share` now accepts `transferOwnership` and `expirationTime`. The `role` enum gained `fileOrganizer` and `organizer`.
+- `drive_search` and `drive_list` now always set `supportsAllDrives` + `includeItemsFromAllDrives`. Every other Drive tool that takes a `fileId` also sets `supportsAllDrives`, so shared-drive content works consistently.
+- `docs_get` accepts `includeTabsContent` and `suggestionsViewMode`.
+- **OAuth scope system is now tiered:**
+  - **Base scopes** (always granted): all v3 scopes + `tasks` + `meetings.space.readonly`.
+  - **Optional scope bundles** via `GOOGLE_OPTIONAL_SCOPES`: `forms`, `chat`.
+  - **Admin scope bundle** per-account via `GOOGLE_ADMIN_ACCOUNTS`: Reports, Alert Center, Directory. Accounts not listed here never request admin scopes — safe for personal Gmail.
+  - Admin write operations require an additional `GOOGLE_ALLOW_ADMIN_WRITES=true` env flag.
+- Forms / Chat / Admin tool registration is conditional in `src/index.ts` — toolset only loads when its scope bundle is enabled, keeping the surface narrow for non-Workspace setups.
+- **Error handling unified** — every service file now delegates 401/403/429/fallback mapping to `handleGoogleApiError` in `src/tools/_errors.ts`. Per-service shims are 3 lines that pass an optional `forbiddenHint` for actionable 403 reasons (admin scope missing, optional bundle not enabled, etc.).
+- **Env parsing centralized** — `auth.ts` exports `getOptionalBundles()` / `getAdminAccounts()` / `adminWritesEnabled()`; `index.ts` consumes those instead of re-parsing.
+- **Drive downloads/exports** switched from manual `.pipe + .on('finish')` to `node:stream/promises.pipeline`, so source-side errors destroy the writer and don't leak partial files.
+
+### Fixed
+
+- `drive_trash` was hardcoded to set `trashed: true` with no inverse path — restoring a trashed file was impossible through the MCP. Now paired with `drive_untrash`.
+- `drive_comment_list` returned `400 Invalid field selection` because the field-mask builder split `replies(...)` across commas, leaking subfields into the top-level selector. Hard-coded the two field lists separately.
+- `McpServer` constructor version no longer hardcoded — now reads from `package.json` at startup.
+
+### Security
+
+- **OAuth callback bound to loopback** — `auth.ts` now `.listen(4242, '127.0.0.1', ...)` instead of binding to all interfaces. CSRF state was already strong (32 random bytes); this hardens the network-attack surface during the brief auth window.
+- **Account alias path-traversal hardened** — `accounts.ts` now requires `[a-zA-Z0-9_-]+` so a malicious `GOOGLE_ACCOUNTS=../../etc/foo:bar@x.com` can't escape the tokens directory.
+- **Drive query injection escape** — `drive_list` escapes `\` and `'` in `folderId` before interpolating into the Drive query literal.
+- **npm audit** — bumped transitive `fast-uri`, `hono`, `ip-address`, `express-rate-limit` (advisories in the MCP SDK's HTTP/JSX/JWT paths, which we don't exercise via stdio transport — clean lockfile-only fix).
+
+### Migration
+
+1. `git pull && npm install && npm run build`.
+2. Re-authenticate every account: `npm run auth -- <alias>` (for each alias). This grants the new base scopes (Tasks + Meet) — required.
+3. If you want Forms/Chat: set `GOOGLE_OPTIONAL_SCOPES=forms,chat` in `.env` before re-authing.
+4. If you're a Workspace admin: list the relevant accounts in `GOOGLE_ADMIN_ACCOUNTS=alias1,alias2` in `.env` before re-authing those accounts. Set `GOOGLE_ALLOW_ADMIN_WRITES=true` only if you actually need destructive admin operations.
+5. In Google Cloud Console, enable the new APIs you plan to use: **Tasks API**, **Google Meet API**, optionally **Forms API**, **Chat API**, **Admin SDK API**, **Alert Center API**.
+
+## [3.0.1] — 2026-04
+
+Re-tag of 3.0.0 after security/lint/CI cleanup.
+
+## [3.0.0] — 2026-04
+
+Added Google Search Console support (10 tools) and the `webmasters` scope.
+
+## [2.0.0] — 2026-04
+
+Added Sheets, Docs, and Contacts support (26 tools across 3 services).
+
+## [1.0.0] — 2026-03
+
+Initial release with multi-account Gmail, Drive, Calendar support and config-driven account definition.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# Working on mcp-google-multi
+
+Conventions for AI assistants modifying this codebase.
+
+## Project shape
+
+- Each Google service lives in `src/tools/<service>.ts` and exports `register<Service>Tools(server: McpServer): void`.
+- `src/index.ts` is the entry point. It wires service registrations into the MCP server, conditional on env-driven scope bundles (Forms/Chat opt-in, Admin opt-in per-account).
+- `src/auth.ts` owns OAuth flow + scope tier resolution. `BASE_SCOPES` are always granted; `OPTIONAL_SCOPE_BUNDLES` are env-gated; `ADMIN_SCOPES` are per-account-gated. `resolveScopesForAccount(alias)` is the authoritative composer.
+- `src/client.ts` is a thin OAuth2Client factory used by every tool handler.
+- `src/accounts.ts` parses the `GOOGLE_ACCOUNTS` env var.
+
+## Adding a new tool
+
+Every tool follows the same skeleton:
+
+```ts
+server.registerTool(
+  'service_action_name',                       // snake_case, prefixed by service
+  {
+    description: '<one sentence; explain when to use this tool>',
+    inputSchema: {
+      account: accountEnum.describe('Google account alias'),  // always first
+      // ...other params as a flat zod object
+    },
+  },
+  async ({ account, /* destructure inputs */ }) => {
+    try {
+      const auth = await getClient(account as Account);
+      const svc = google.<service>({ version: '<v>', auth });
+      const res = await svc.<resource>.<method>({ /* params */ });
+      return {
+        content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+      };
+    } catch (error: any) {
+      return handle<Service>Error(error, account as Account);
+    }
+  },
+);
+```
+
+**Hard rules:**
+- `inputSchema` is a flat object of `zod` schemas. Do not nest into another `z.object` at the top level.
+- `account: accountEnum` is the first field of every input schema.
+- Wrap the handler body in try/catch. Call the file's `handle<Service>Error` helper in the catch.
+- Return `{ content: [{ type: 'text' as const, text: JSON.stringify(...) }] }`. Stringify the response payload so MCP clients can re-parse it.
+- For errors, also set `isError: true`.
+- Every file has a 3-line `handle<Service>Error` shim at the bottom that delegates to `handleGoogleApiError` in `src/tools/_errors.ts` — the shared 401/403/429/fallback mapper. Pass an optional service-specific `forbiddenHint` string to the shared helper for services where 403 has a known fix (e.g. admin scopes, optional scope bundle not enabled).
+
+## Adding a new service
+
+1. Create `src/tools/<service>.ts` exporting `register<Service>Tools(server)`.
+2. Add scope(s) to `src/auth.ts`:
+   - Always-on → append to `BASE_SCOPES`.
+   - Optional bundle → add a new key to `OPTIONAL_SCOPE_BUNDLES`.
+   - Admin-only → append to `ADMIN_SCOPES`.
+3. Wire registration in `src/index.ts`. Always-on calls go in the unconditional block; optional bundles check `optional.has('<key>')` (where `optional` is built from `getOptionalBundles()`); admin tools register only if `getAdminAccounts().length > 0`.
+4. Update README scope table, tool table, and tool count in the Features bullet.
+5. Update CHANGELOG.md.
+
+## Drive-specific: shared drive support
+
+Every Drive API call that takes a `fileId` must pass `supportsAllDrives: true`. List operations also need `includeItemsFromAllDrives: true`. Forgetting these silently breaks shared-drive content. Existing tools already have them — preserve when refactoring.
+
+## Sheets/Docs: fields masks
+
+`spreadsheets.batchUpdate` Request types like `RepeatCell` and `updateParagraphStyle` require explicit `fields` masks. Compute the mask from supplied input keys; never use wildcards. The helpers `buildCellFormat` (in `sheets.ts`), `buildParagraphStyle`, and `buildDocumentStyle` (in `docs.ts`) are the reference implementations and are unit-tested in `tests/field-mask-helpers.test.ts`. If you add a new format dimension, extend the helper, add a test, and bump the input schema.
+
+## Escape hatches
+
+`sheets_batch_update` and `docs_batch_update` accept the full Request union as `z.array(z.record(z.string(), z.any()))`. Don't add a per-Request-type tool unless it's high-frequency or has a high-value default-computing facade (like `format_cells`). The catch-all keeps the tool count tractable.
+
+## Comments / Replies (Drive)
+
+- Comment text field is `content`, not `body`. Confirmed against the Drive v3 Comment resource.
+- `replies.create` accepts `action: 'resolve' | 'reopen'` to close/reopen a thread in the same call.
+- Comments/Replies API **requires** the `fields` query param on every call — never omit. See the `COMMENT_FIELDS`, `COMMENT_LIST_FIELDS`, `REPLY_FIELDS`, `REPLY_LIST_FIELDS` constants at the top of `drive.ts`.
+
+## Admin SDK safety
+
+- Admin tools only register if `GOOGLE_ADMIN_ACCOUNTS` is set.
+- Destructive admin writes (`admin_users_update`) must check `adminWritesEnabled()` (imported from `auth.ts`) and refuse if `GOOGLE_ALLOW_ADMIN_WRITES` is not exactly `'true'`. Do not relax this gate.
+- Admin tools 403 on personal Gmail accounts. The `handleAdminError` helper surfaces this hint clearly — keep it.
+
+## Versioning
+
+- Manual semver in `package.json`.
+- Release commit message format: `chore(release): X.Y.Z` (lowercase, matches existing history).
+- Tag: `vX.Y.Z`.
+- New OAuth scopes in `BASE_SCOPES` = major version bump (tokens become incomplete, requires re-auth).
+- New tools / new optional bundles / new admin scopes = minor version bump.
+- Bug fixes = patch.
+
+## Testing
+
+- `npm run typecheck && npm run lint && npm run test` must all pass before any PR.
+- Pure-logic helpers (fields-mask builders, validation helpers) get unit tests.
+- Do not try to mock `googleapis` for integration tests — manual smoke testing in Claude Code against real accounts is the truth.
+- Always re-auth after editing `BASE_SCOPES` before manual testing.
+
+## Don'ts
+
+- Don't `console.log` from tool handlers in MCP server mode. Stdio is the MCP channel. Use `process.stderr.write` if you really need to.
+- Don't hardcode account aliases. Always read from `ACCOUNTS` / `ACCOUNT_CONFIG`.
+- Don't bypass `getClient(account)` — it handles token refresh persistence.
+- Don't store tokens with permissions wider than `0o600`.
+- Don't expand `BASE_SCOPES` silently. Any scope change is user-visible and requires CHANGELOG documentation + a re-auth note.
+- Don't re-implement error mapping. Always go through `handleGoogleApiError` (via the per-service shim).
+- Don't re-parse `GOOGLE_OPTIONAL_SCOPES` or `GOOGLE_ADMIN_ACCOUNTS` inline. Use `getOptionalBundles()` / `getAdminAccounts()` exported from `auth.ts`.
+- Don't add narrative comments explaining WHAT code does. The CLAUDE.md rule is non-obvious WHY only; section dividers (`// ─── X ───`) are the exception as navigation aids.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # mcp-google-multi
 
-A local [MCP](https://modelcontextprotocol.io) server that gives Claude Code (and any MCP client) access to **Gmail**, **Google Drive**, **Google Calendar**, **Google Sheets**, **Google Docs**, **Google Contacts**, and **Google Search Console** across multiple Google accounts simultaneously.
+A local [MCP](https://modelcontextprotocol.io) server that gives Claude Code (and any MCP client) access to **Gmail**, **Google Drive**, **Google Calendar**, **Google Sheets**, **Google Docs**, **Google Contacts**, **Google Search Console**, **Google Tasks**, **Google Meet**, and optionally **Google Forms**, **Google Chat**, and **Google Workspace Admin** APIs across multiple Google accounts simultaneously.
 
 ## Features
 
-- **Multi-account** -- manage any number of Google accounts from a single server
-- **83 tools** -- Gmail (21), Drive (15), Calendar (11), Sheets (9), Docs (8), Contacts (9), Search Console (10)
-- **Config-driven** -- accounts defined in `.env`, no code changes needed
-- **Auto-refresh** -- OAuth tokens refresh transparently and persist to disk
-- **Stdio transport** -- runs as a local subprocess, no hosting needed
+- **Multi-account** — manage any number of Google accounts from a single server
+- **175 tools** across 12 Google services
+- **Tiered OAuth scopes** — base scopes always granted; Forms/Chat are opt-in; Admin scopes are per-account opt-in with a separate safety flag for destructive writes
+- **Config-driven accounts** — defined in `.env`, no code changes needed
+- **Auto-refresh** — OAuth tokens refresh transparently and persist to disk
+- **Stdio transport** — runs as a local subprocess, no hosting needed
 
 ## Tools
 
@@ -38,11 +39,11 @@ A local [MCP](https://modelcontextprotocol.io) server that gives Claude Code (an
 | `gmail_get_vacation` | Read vacation responder settings |
 | `gmail_set_vacation` | Enable/disable vacation responder |
 
-### Google Drive (15 tools)
+### Google Drive (35 tools)
 
 | Tool | Description |
 |------|-------------|
-| `drive_search` | Search files with Drive query syntax |
+| `drive_search` | Search files with Drive query syntax (shared drives included) |
 | `drive_read` | Read file content (exports Workspace docs as text) |
 | `drive_list` | List files in a folder or root |
 | `drive_upload` | Upload a local file to Drive |
@@ -52,10 +53,19 @@ A local [MCP](https://modelcontextprotocol.io) server that gives Claude Code (an
 | `drive_update` | Rename, move, or replace file content |
 | `drive_delete` | Permanently delete a file (irreversible) |
 | `drive_trash` | Move a file to trash (recoverable) |
+| `drive_untrash` | Restore a trashed file |
+| `drive_empty_trash` | Permanently delete every file in trash |
 | `drive_copy` | Duplicate a file |
-| `drive_share` | Share with user/group/domain/anyone |
+| `drive_move` | Move a file between folders |
+| `drive_share` | Share with user/group/domain/anyone (with `transferOwnership` + `expirationTime`) |
 | `drive_list_permissions` | List who has access to a file |
+| `drive_permission_update` | Change a permission's role / expiration in place |
 | `drive_remove_permission` | Revoke access |
+| `drive_comment_create` / `_list` / `_get` / `_update` / `_delete` | Full comment CRUD with anchor support |
+| `drive_reply_create` / `_list` / `_update` / `_delete` | Reply CRUD; reply.create accepts `action: resolve | reopen` |
+| `drive_revision_list` / `_update` / `_delete` | Version history; `keepForever` pins against the 200-version cap |
+| `drive_access_proposal_list` / `_resolve` | Triage "Request access" submissions |
+| `drive_shared_drives_list` / `drive_shared_drive_get` | Shared drive discovery |
 | `drive_get_about` | Storage quota and account info |
 
 ### Google Calendar (11 tools)
@@ -74,88 +84,159 @@ A local [MCP](https://modelcontextprotocol.io) server that gives Claude Code (an
 | `calendar_get_freebusy` | Check free/busy times for calendars |
 | `calendar_create_calendar` | Create a new calendar |
 
-### Google Sheets (9 tools)
+### Google Sheets (29 tools)
 
 | Tool | Description |
 |------|-------------|
 | `sheets_create` | Create a new spreadsheet |
-| `sheets_get` | Get spreadsheet metadata (title, sheets/tabs, named ranges) |
-| `sheets_read_range` | Read cell values from a range (A1 notation) |
-| `sheets_write_range` | Write values to a range |
-| `sheets_append_rows` | Append rows after existing data |
-| `sheets_clear_range` | Clear values from a range (keeps formatting) |
-| `sheets_batch_read` | Read multiple ranges at once |
-| `sheets_batch_write` | Write to multiple ranges at once |
-| `sheets_add_sheet` | Add a new tab/sheet to a spreadsheet |
+| `sheets_get` | Get spreadsheet metadata |
+| `sheets_read_range` / `sheets_batch_read` | Read values |
+| `sheets_write_range` / `sheets_batch_write` | Write values |
+| `sheets_append_rows` | Append after existing data |
+| `sheets_clear_range` / `sheets_batch_clear` | Clear values (preserves formatting) |
+| `sheets_add_sheet` / `sheets_delete_sheet` / `sheets_duplicate_sheet` | Tab management |
+| `sheets_update_sheet_properties` | Rename, freeze, color, hide, resize |
+| `sheets_format_cells` | Colors, fonts, alignment, number formats |
+| `sheets_update_borders` | Cell borders with style + color |
+| `sheets_merge_cells` / `sheets_unmerge_cells` | Cell merging |
+| `sheets_add_conditional_format_rule` | Boolean and gradient conditional formatting |
+| `sheets_sort_range` | Multi-column sort |
+| `sheets_set_basic_filter` / `sheets_clear_basic_filter` | Filter rows |
+| `sheets_find_replace` | Regex-capable, scope-aware find/replace |
+| `sheets_auto_resize_dimensions` | Fit rows/columns to content |
+| `sheets_set_data_validation` | Dropdowns, checkboxes, custom rules |
+| `sheets_add_named_range` / `sheets_delete_named_range` | Named ranges |
+| `sheets_insert_dimension` / `sheets_delete_dimension` | Insert/delete rows or columns |
+| `sheets_batch_update` | Generic batchUpdate escape hatch (any Request type) |
 
-### Google Docs (8 tools)
+### Google Docs (27 tools)
 
 | Tool | Description |
 |------|-------------|
 | `docs_create` | Create a new document |
-| `docs_get` | Get document metadata (title, revision, named ranges) |
+| `docs_get` | Metadata + optional tab content / suggestionsViewMode |
 | `docs_read` | Read document content as plain text |
-| `docs_insert_text` | Insert text at a position or at the end |
-| `docs_replace_text` | Find and replace all occurrences |
-| `docs_delete_range` | Delete content in an index range |
-| `docs_update_style` | Update text formatting (bold, italic, font, size) |
-| `docs_insert_table` | Insert a table at a position |
+| `docs_insert_text` | Insert text at position or end |
+| `docs_replace_text` | Find and replace |
+| `docs_delete_range` | Delete a character range |
+| `docs_update_style` | Inline text formatting (bold, italic, font, size) |
+| `docs_update_paragraph_style` | Alignment, heading, indents, spacing |
+| `docs_update_document_style` | Page size, margins, header/footer behavior |
+| `docs_insert_table` | Insert a table |
+| `docs_modify_table` | insertRow / insertColumn / deleteRow / deleteColumn / mergeCells / unmergeCells |
+| `docs_create_named_range` / `docs_delete_named_range` / `docs_replace_named_range_content` | Mail-merge primitive |
+| `docs_create_paragraph_bullets` / `docs_delete_paragraph_bullets` | Bulleted/numbered lists |
+| `docs_insert_inline_image` | PNG/JPEG/GIF image insertion |
+| `docs_insert_page_break` / `docs_insert_section_break` | Layout breaks |
+| `docs_create_header` / `docs_delete_header` / `docs_create_footer` / `docs_delete_footer` | Branded headers and footers |
+| `docs_add_tab` / `docs_delete_tab` / `docs_update_tab_properties` | Tabs CRUD |
+| `docs_batch_update` | Generic batchUpdate escape hatch (any Request type) |
 
 ### Google Contacts (9 tools)
 
 | Tool | Description |
 |------|-------------|
-| `contacts_search` | Search contacts by name, email, phone, or organization |
-| `contacts_get` | Get a single contact by resource name |
-| `contacts_list` | List all contacts (paginated) |
-| `contacts_create` | Create a new contact |
-| `contacts_update` | Update an existing contact |
+| `contacts_search` | Search contacts |
+| `contacts_get` | Get one contact |
+| `contacts_list` | List contacts (paginated) |
+| `contacts_create` | Create a contact |
+| `contacts_update` | Update a contact |
 | `contacts_delete` | Delete a contact |
-| `contacts_groups_list` | List all contact groups (labels) |
-| `contacts_group_members` | List members of a contact group |
-| `contacts_group_create` | Create a new contact group |
+| `contacts_groups_list` | List groups |
+| `contacts_group_members` | List members of a group |
+| `contacts_group_create` | Create a group |
 
 ### Google Search Console (10 tools)
 
 | Tool | Description |
 |------|-------------|
-| `searchconsole_sites_list` | List all Search Console properties |
-| `searchconsole_sites_get` | Get details for a specific property |
-| `searchconsole_sites_add` | Add a property to Search Console |
+| `searchconsole_sites_list` | List Search Console properties |
+| `searchconsole_sites_get` | Get a property |
+| `searchconsole_sites_add` | Add a property |
 | `searchconsole_sites_delete` | Remove a property |
-| `searchconsole_sitemaps_list` | List submitted sitemaps |
-| `searchconsole_sitemaps_get` | Get sitemap details (status, errors, indexed count) |
+| `searchconsole_sitemaps_list` | List sitemaps |
+| `searchconsole_sitemaps_get` | Sitemap status |
 | `searchconsole_sitemaps_submit` | Submit a sitemap |
-| `searchconsole_sitemaps_delete` | Delete a submitted sitemap |
-| `searchconsole_searchanalytics_query` | Query search analytics (clicks, impressions, CTR, position) with filtering |
-| `searchconsole_url_inspect` | Inspect a URL (indexing status, crawl info, rich results, mobile usability) |
+| `searchconsole_sitemaps_delete` | Delete a sitemap |
+| `searchconsole_searchanalytics_query` | Query search analytics |
+| `searchconsole_url_inspect` | Inspect a URL |
+
+### Google Tasks (12 tools) — _new in v4_
+
+| Tool | Description |
+|------|-------------|
+| `tasks_lists_list` / `tasks_list_get` / `tasks_list_insert` / `tasks_list_update` / `tasks_list_delete` | Tasklist management |
+| `tasks_list` | List tasks (filter by completion, due, updated time) |
+| `tasks_get` / `tasks_insert` / `tasks_update` / `tasks_delete` | Task CRUD |
+| `tasks_move` | Re-parent / re-position / move to another list |
+| `tasks_clear` | Delete every completed task |
+
+### Google Meet (5 tools) — _new in v4_
+
+| Tool | Description |
+|------|-------------|
+| `meet_conference_records_list` | List past Meet sessions |
+| `meet_conference_record_get` | Get one record |
+| `meet_recordings_list` | Recordings on a record |
+| `meet_transcripts_list` | Transcripts on a record |
+| `meet_transcript_entries_list` | Per-speaker transcript text |
+
+### Google Forms (4 tools, optional bundle) — _new in v4_
+
+Enable with `GOOGLE_OPTIONAL_SCOPES=forms` in `.env`.
+
+| Tool | Description |
+|------|-------------|
+| `forms_get` | Form definition |
+| `forms_responses_list` | List responses with filter |
+| `forms_response_get` | Single response |
+| `forms_watches_list` | List Pub/Sub watches |
+
+### Google Chat (4 tools, optional bundle) — _new in v4_
+
+Enable with `GOOGLE_OPTIONAL_SCOPES=chat` in `.env` (combine: `GOOGLE_OPTIONAL_SCOPES=forms,chat`).
+
+| Tool | Description |
+|------|-------------|
+| `chat_spaces_list` | Spaces the user is in |
+| `chat_spaces_get` | One space |
+| `chat_messages_create` | Send text or Card v2 |
+| `chat_messages_list` | List messages with filter / orderBy |
+
+### Google Workspace Admin (8 tools, admin bundle) — _new in v4_
+
+Enable per-account with `GOOGLE_ADMIN_ACCOUNTS=alias1,alias2` in `.env`. Requires the account to be a Workspace super-admin. Personal `@gmail.com` accounts will 403 — never list them here. Destructive writes additionally require `GOOGLE_ALLOW_ADMIN_WRITES=true`.
+
+| Tool | Description |
+|------|-------------|
+| `reports_activities_list` | Workspace audit log (login, drive, gmail, admin, token, etc.) |
+| `alertcenter_alerts_list` / `alertcenter_alert_get` | Security alerts |
+| `admin_users_list` / `admin_users_get` | User directory reads |
+| `admin_users_update` | User edits (gated, see env flag above) |
+| `admin_groups_list` / `admin_group_members_list` | Group + member reads |
 
 Every tool accepts an `account` parameter matching one of your configured aliases.
 
 ## Prerequisites
 
 - Node.js 18+
-- A Google Cloud project with **Gmail API**, **Google Drive API**, and **Google Calendar API** enabled
+- A Google Cloud project with the relevant APIs enabled (see step 1 below)
 - An OAuth 2.0 Client ID (Desktop app type)
 
 ## Setup
 
 ### 1. Google Cloud Credentials
 
-1. Go to [Google Cloud Console](https://console.cloud.google.com)
-2. Create or select a project
-3. Enable these APIs:
-   - [Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com)
-   - [Google Drive API](https://console.cloud.google.com/apis/library/drive.googleapis.com)
-   - [Google Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com)
-   - [Google Sheets API](https://console.cloud.google.com/apis/library/sheets.googleapis.com)
-   - [Google Docs API](https://console.cloud.google.com/apis/library/docs.googleapis.com)
-   - [People API](https://console.cloud.google.com/apis/library/people.googleapis.com)
-   - [Search Console API](https://console.cloud.google.com/apis/library/searchconsole.googleapis.com)
-4. Go to **APIs & Services > Credentials > Create Credentials > OAuth 2.0 Client ID**
-5. Application type: **Desktop app**
-6. Add authorized redirect URI: `http://localhost:4242/oauth2callback`
-7. Copy the **Client ID** and **Client Secret**
+1. Go to [Google Cloud Console](https://console.cloud.google.com).
+2. Create or select a project.
+3. Enable the APIs you intend to use:
+   - **Always required:** [Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com), [Google Drive API](https://console.cloud.google.com/apis/library/drive.googleapis.com), [Google Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com), [Google Sheets API](https://console.cloud.google.com/apis/library/sheets.googleapis.com), [Google Docs API](https://console.cloud.google.com/apis/library/docs.googleapis.com), [People API](https://console.cloud.google.com/apis/library/people.googleapis.com), [Search Console API](https://console.cloud.google.com/apis/library/searchconsole.googleapis.com), [Google Tasks API](https://console.cloud.google.com/apis/library/tasks.googleapis.com), [Google Meet API](https://console.cloud.google.com/apis/library/meet.googleapis.com).
+   - **Optional bundles (only if you enable them):** [Google Forms API](https://console.cloud.google.com/apis/library/forms.googleapis.com), [Google Chat API](https://console.cloud.google.com/apis/library/chat.googleapis.com).
+   - **Admin bundle (only if you set `GOOGLE_ADMIN_ACCOUNTS`):** [Admin SDK API](https://console.cloud.google.com/apis/library/admin.googleapis.com), [Alert Center API](https://console.cloud.google.com/apis/library/alertcenter.googleapis.com).
+4. Go to **APIs & Services → Credentials → Create Credentials → OAuth 2.0 Client ID**.
+5. Application type: **Desktop app**.
+6. Add authorized redirect URI: `http://localhost:4242/oauth2callback`.
+7. Copy the **Client ID** and **Client Secret**.
 
 ### 2. Install & Configure
 
@@ -174,6 +255,15 @@ GOOGLE_CLIENT_SECRET=your_client_secret_here
 
 # Define your accounts as alias:email pairs (comma-separated)
 GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
+
+# Optional (v4): enable Forms and/or Chat tool bundles
+# GOOGLE_OPTIONAL_SCOPES=forms,chat
+
+# Optional (v4): grant Workspace admin scopes to specific accounts
+# GOOGLE_ADMIN_ACCOUNTS=work
+
+# Optional (v4): unlock destructive admin writes (admin_users_update)
+# GOOGLE_ALLOW_ADMIN_WRITES=true
 ```
 
 ### 3. Build
@@ -184,14 +274,12 @@ npm run build
 
 ### 4. Authenticate Accounts
 
-Run the auth flow for each account alias you defined:
-
 ```bash
-npm run auth -- work       # opens browser -> log in with you@company.com
-npm run auth -- personal   # opens browser -> log in with you@gmail.com
+npm run auth -- work       # opens browser → log in with you@company.com
+npm run auth -- personal   # opens browser → log in with you@gmail.com
 ```
 
-Each saves a token to `tokens/<alias>/token.json`. Tokens auto-refresh -- you should only need to do this once per account.
+Each saves a token to `tokens/<alias>/token.json`. Tokens auto-refresh — you should only need to do this once per account.
 
 ### 5. Register in Claude Code
 
@@ -212,6 +300,16 @@ Or add it manually to your Claude Code MCP config:
 }
 ```
 
+## Migrating from v3
+
+v4.0.0 grows the base OAuth scope set (Tasks and Meet are now included by default). Existing v3 tokens lack those scopes and the corresponding tools will 403.
+
+1. `git pull && npm install && npm run build`.
+2. Re-authenticate every account: `npm run auth -- <alias>` for each alias.
+3. If you want Forms or Chat tools: set `GOOGLE_OPTIONAL_SCOPES=forms,chat` in `.env` **before** re-authing.
+4. If you're a Workspace admin: list relevant accounts in `GOOGLE_ADMIN_ACCOUNTS` **before** re-authing those accounts. Set `GOOGLE_ALLOW_ADMIN_WRITES=true` only if you need destructive admin operations.
+5. In Google Cloud Console, enable any new APIs you'll use (Tasks, Meet, Forms, Chat, Admin SDK, Alert Center).
+
 ## Adding / Removing Accounts
 
 Edit the `GOOGLE_ACCOUNTS` variable in `.env`, rebuild, and authenticate the new account:
@@ -226,6 +324,42 @@ npm run auth -- freelance
 
 No code changes required.
 
+## OAuth Scopes
+
+### Base (always granted)
+
+| Scope | Access |
+|-------|--------|
+| `gmail.modify` | Read, label, trash, delete emails |
+| `gmail.send` | Send emails |
+| `drive` | Full Drive access (read, upload, share, comments, etc.) |
+| `calendar` | Full calendar access |
+| `spreadsheets` | Read/write Google Sheets |
+| `documents` | Read/write Google Docs |
+| `contacts` | Read/write Google Contacts |
+| `webmasters` | Google Search Console |
+| `tasks` | Read/write Google Tasks |
+| `meetings.space.readonly` | Read past Meet conference records and transcripts |
+
+### Optional (per-`GOOGLE_OPTIONAL_SCOPES` env var)
+
+| Bundle key | Scopes |
+|------------|--------|
+| `forms` | `forms.body`, `forms.responses.readonly` |
+| `chat` | `chat.spaces`, `chat.messages`, `chat.messages.create` |
+
+### Admin (per-`GOOGLE_ADMIN_ACCOUNTS` env var)
+
+Only granted to accounts explicitly listed. Personal Gmail accounts will 403 on these scopes — never list them.
+
+| Scope | Access |
+|-------|--------|
+| `admin.reports.audit.readonly` | Workspace audit log |
+| `apps.alerts` | Alert Center |
+| `admin.directory.user` | Read/write Workspace users (writes also gated by `GOOGLE_ALLOW_ADMIN_WRITES`) |
+| `admin.directory.group.readonly` | Read groups |
+| `admin.directory.group.member.readonly` | Read group members |
+
 ## Project Structure
 
 ```
@@ -233,48 +367,50 @@ mcp-google-multi/
 ├── src/
 │   ├── index.ts          # Entry point: MCP server or auth CLI
 │   ├── accounts.ts       # Account config parser (reads from .env)
-│   ├── auth.ts           # OAuth flow with local HTTP callback
+│   ├── auth.ts           # Scope tier resolution + OAuth flow
 │   ├── client.ts         # OAuth2Client factory with auto-refresh
 │   ├── types.ts          # Shared TypeScript types
 │   └── tools/
-│       ├── gmail.ts      # 21 Gmail tools
-│       ├── drive.ts      # 15 Drive tools
-│       ├── calendar.ts   # 11 Calendar tools
-│       ├── sheets.ts     # 9 Sheets tools
-│       ├── docs.ts       # 8 Docs tools
-│       ├── contacts.ts   # 9 Contacts tools
-│       └── searchconsole.ts # 10 Search Console tools
+│       ├── _errors.ts          # Shared googleapis error → MCP response mapper
+│       ├── gmail.ts            # Gmail (21)
+│       ├── drive.ts            # Drive (35)
+│       ├── calendar.ts         # Calendar (11)
+│       ├── sheets.ts           # Sheets (29)
+│       ├── docs.ts             # Docs (27)
+│       ├── contacts.ts         # Contacts (9)
+│       ├── searchconsole.ts    # Search Console (10)
+│       ├── tasks.ts            # Tasks (12) — v4
+│       ├── meet.ts             # Meet (5) — v4
+│       ├── forms.ts            # Forms (4, optional) — v4
+│       ├── chat.ts             # Chat (4, optional) — v4
+│       └── admin.ts            # Admin SDK (8, admin) — v4
+├── tests/                # vitest unit tests (gmail-mime, path-safety, field-mask helpers)
 ├── tokens/               # OAuth tokens per account (gitignored)
 ├── dist/                 # Compiled output (gitignored)
 ├── .env                  # Your credentials (gitignored)
 ├── .env.example          # Template for .env
+├── CHANGELOG.md
+├── CLAUDE.md             # Conventions for AI assistants working on this codebase
 ├── package.json
 ├── tsconfig.json
 └── LICENSE
 ```
 
-## OAuth Scopes
-
-| Scope | Access |
-|-------|--------|
-| `gmail.modify` | Read, label, trash, delete emails |
-| `gmail.send` | Send emails |
-| `drive` | Full Drive access (read, upload, share, delete) |
-| `calendar` | Full calendar access |
-| `spreadsheets` | Read/write Google Sheets |
-| `documents` | Read/write Google Docs |
-| `contacts` | Read/write Google Contacts |
-| `webmasters` | Google Search Console (sites, sitemaps, analytics, URL inspection) |
-
 ## Troubleshooting
 
-**"GOOGLE_ACCOUNTS is not set"** -- Make sure your `.env` file exists in the project root and has the `GOOGLE_ACCOUNTS` variable set.
+**"GOOGLE_ACCOUNTS is not set"** — Make sure your `.env` file exists in the project root and has the `GOOGLE_ACCOUNTS` variable set.
 
-**"No token file found for account X"** -- Run `npm run auth -- <alias>` to authenticate that account.
+**"No token file found for account X"** — Run `npm run auth -- <alias>` to authenticate that account.
 
-**"Port 4242 is already in use"** -- Another process is using port 4242. Close it and retry the auth flow.
+**"Port 4242 is already in use"** — Another process is using port 4242. Close it and retry the auth flow.
 
-**Token refresh errors** -- Delete the token file at `tokens/<alias>/token.json` and re-authenticate.
+**Token refresh errors** — Delete the token file at `tokens/<alias>/token.json` and re-authenticate.
+
+**Tasks / Meet tools return 403 after upgrading from v3** — You haven't re-authed since the base scope set grew. Run `npm run auth -- <alias>` for every account.
+
+**`forms_*` or `chat_*` tools missing from the tool list** — They're only registered when `GOOGLE_OPTIONAL_SCOPES` includes their bundle key. Set `GOOGLE_OPTIONAL_SCOPES=forms,chat` (or one of them) in `.env`, rebuild, and re-auth the accounts that need them.
+
+**Admin tools missing or returning 403** — Admin tools only register if `GOOGLE_ADMIN_ACCOUNTS` is set. The listed accounts must be Workspace super-admins, and you must re-auth them after adding the env var so the new scopes are granted. `admin_users_update` additionally requires `GOOGLE_ALLOW_ADMIN_WRITES=true`.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-google-multi",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-google-multi",
-      "version": "3.0.1",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -35,7 +35,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -48,7 +47,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -739,7 +737,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -1057,7 +1054,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1554,7 +1550,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1780,7 +1775,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1820,12 +1814,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1864,9 +1858,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2216,11 +2210,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.15",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
-      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2301,9 +2294,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3120,7 +3113,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3657,7 +3649,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3737,7 +3728,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3991,7 +3981,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-google-multi",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "MCP server for Gmail, Google Drive, Calendar, Sheets, Docs, and Contacts with multi-account support",
   "type": "module",
   "license": "MIT",

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -2,10 +2,8 @@ import dotenv from 'dotenv';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-// Resolve paths relative to the project root (parent of src/ or dist/)
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-// Load .env from the project root (not CWD) so it works when spawned by Claude Code
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 const tokenDir = path.resolve(__dirname, '..', 'tokens');
 
@@ -48,6 +46,14 @@ function parseAccounts(): { aliases: [string, ...string[]]; configs: Record<stri
     if (!alias || !email) {
       throw new Error(
         `Invalid account entry "${trimmed}". Both alias and email are required.`,
+      );
+    }
+
+    // Restrict alias to a safe charset so it can't escape `tokenDir` via path traversal
+    // (e.g. "../../etc/passwd:foo@bar.com" in .env).
+    if (!/^[a-zA-Z0-9_-]+$/.test(alias)) {
+      throw new Error(
+        `Invalid alias "${alias}". Allowed characters: letters, digits, underscore, hyphen.`,
       );
     }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -8,7 +8,16 @@ import open from 'open';
 import destroyer from 'server-destroy';
 import { ACCOUNTS, ACCOUNT_CONFIG } from './accounts.js';
 
-const SCOPES = [
+// ─── Scope tiers ────────────────────────────────────────────────────────
+//
+// BASE: always granted. Existing v3 surface + Tasks + Meet (added in v4.0.0).
+// OPTIONAL: per-account opt-in via env GOOGLE_OPTIONAL_SCOPES="forms,chat".
+// ADMIN: per-account opt-in via env GOOGLE_ADMIN_ACCOUNTS="alias1,alias2".
+//
+// Personal Gmail accounts will 403 on admin scopes — never grant by default.
+// ────────────────────────────────────────────────────────────────────────
+
+export const BASE_SCOPES = [
   'https://www.googleapis.com/auth/gmail.modify',
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/drive',
@@ -17,7 +26,70 @@ const SCOPES = [
   'https://www.googleapis.com/auth/documents',
   'https://www.googleapis.com/auth/contacts',
   'https://www.googleapis.com/auth/webmasters',
+  'https://www.googleapis.com/auth/tasks',
+  'https://www.googleapis.com/auth/meetings.space.readonly',
 ];
+
+export const OPTIONAL_SCOPE_BUNDLES: Record<string, string[]> = {
+  forms: [
+    'https://www.googleapis.com/auth/forms.body',
+    'https://www.googleapis.com/auth/forms.responses.readonly',
+  ],
+  chat: [
+    'https://www.googleapis.com/auth/chat.spaces',
+    'https://www.googleapis.com/auth/chat.messages',
+    'https://www.googleapis.com/auth/chat.messages.create',
+  ],
+};
+
+export const ADMIN_SCOPES = [
+  'https://www.googleapis.com/auth/admin.reports.audit.readonly',
+  'https://www.googleapis.com/auth/apps.alerts',
+  'https://www.googleapis.com/auth/admin.directory.user',
+  'https://www.googleapis.com/auth/admin.directory.group.readonly',
+  'https://www.googleapis.com/auth/admin.directory.group.member.readonly',
+];
+
+/** Parse comma-separated env value into a deduplicated string array. */
+function parseCsvEnv(name: string): string[] {
+  return (process.env[name]?.trim() ?? '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+/** Bundle keys enabled via GOOGLE_OPTIONAL_SCOPES (e.g. ["forms","chat"]). */
+export function getOptionalBundles(): string[] {
+  return parseCsvEnv('GOOGLE_OPTIONAL_SCOPES').filter(b => b in OPTIONAL_SCOPE_BUNDLES);
+}
+
+/** Account aliases granted ADMIN_SCOPES via GOOGLE_ADMIN_ACCOUNTS. */
+export function getAdminAccounts(): string[] {
+  return parseCsvEnv('GOOGLE_ADMIN_ACCOUNTS');
+}
+
+/**
+ * Compose the scope list for a single account at consent time.
+ * Resolves env flags: GOOGLE_OPTIONAL_SCOPES (global) and GOOGLE_ADMIN_ACCOUNTS (per-account allowlist).
+ */
+export function resolveScopesForAccount(alias: string): string[] {
+  const scopes = [...BASE_SCOPES];
+
+  for (const bundle of getOptionalBundles()) {
+    scopes.push(...OPTIONAL_SCOPE_BUNDLES[bundle]);
+  }
+
+  if (getAdminAccounts().includes(alias)) {
+    scopes.push(...ADMIN_SCOPES);
+  }
+
+  return Array.from(new Set(scopes));
+}
+
+/** True if admin writes are explicitly enabled. Default refuses to prevent accidents on small orgs. */
+export function adminWritesEnabled(): boolean {
+  return process.env.GOOGLE_ALLOW_ADMIN_WRITES === 'true';
+}
 
 export async function runAuthFlow(args: string[]): Promise<void> {
   const accountIdx = args.indexOf('--account');
@@ -34,6 +106,7 @@ export async function runAuthFlow(args: string[]): Promise<void> {
   }
 
   const config = ACCOUNT_CONFIG[alias];
+  const scopes = resolveScopesForAccount(alias);
 
   const oauth2Client = new google.auth.OAuth2(
     process.env.GOOGLE_CLIENT_ID,
@@ -47,12 +120,16 @@ export async function runAuthFlow(args: string[]): Promise<void> {
   const authorizeUrl = oauth2Client.generateAuthUrl({
     access_type: 'offline',
     prompt: 'consent',
-    scope: SCOPES,
+    scope: scopes,
     login_hint: config.email,
     state: expectedState,
   });
 
   console.log(`Authenticating account "${alias}" (${config.email})...`);
+  console.log(`Requesting ${scopes.length} scopes.`);
+  if (getAdminAccounts().includes(alias)) {
+    console.log('  ⚠ Admin scopes included — this account will be granted Workspace admin access.');
+  }
   console.log(`Opening browser for authorization...`);
 
   return new Promise((resolve, reject) => {
@@ -115,7 +192,8 @@ export async function runAuthFlow(args: string[]): Promise<void> {
           reject(e);
         }
       })
-      .listen(4242, () => {
+      // Bind to loopback only — never expose the OAuth callback to the local network.
+      .listen(4242, '127.0.0.1', () => {
         open(authorizeUrl, { wait: false }).then((cp) => cp.unref());
       });
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -42,7 +42,6 @@ export async function getClient(account: Account) {
       const merged = { ...existing, ...tokens };
       await fs.writeFile(config.tokenPath, JSON.stringify(merged, null, 2), { mode: 0o600 });
     } catch {
-      // If we can't read the existing file, just write the new tokens
       await fs.writeFile(config.tokenPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
-// accounts.ts handles dotenv loading (must happen before any other imports that read env)
 import './accounts.js';
 
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { registerGmailTools } from './tools/gmail.js';
@@ -10,9 +12,17 @@ import { registerSheetsTools } from './tools/sheets.js';
 import { registerDocsTools } from './tools/docs.js';
 import { registerContactsTools } from './tools/contacts.js';
 import { registerSearchConsoleTools } from './tools/searchconsole.js';
+import { registerTasksTools } from './tools/tasks.js';
+import { registerMeetTools } from './tools/meet.js';
+import { registerFormsTools } from './tools/forms.js';
+import { registerChatTools } from './tools/chat.js';
+import { registerAdminTools } from './tools/admin.js';
+import { getOptionalBundles, getAdminAccounts } from './auth.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'));
 
 async function main() {
-  // Route: auth CLI or MCP server
   if (process.argv.includes('auth')) {
     const { runAuthFlow } = await import('./auth.js');
     await runAuthFlow(process.argv);
@@ -22,9 +32,8 @@ async function main() {
   // MCP server mode — no console.log (stdio is the MCP channel)
   const server = new McpServer({
     name: 'mcp-google-multi',
-    version: '1.0.0',
+    version: pkg.version,
   });
-
   registerGmailTools(server);
   registerDriveTools(server);
   registerCalendarTools(server);
@@ -32,6 +41,12 @@ async function main() {
   registerDocsTools(server);
   registerContactsTools(server);
   registerSearchConsoleTools(server);
+  registerTasksTools(server);
+  registerMeetTools(server);
+  const optional = new Set(getOptionalBundles());
+  if (optional.has('forms')) registerFormsTools(server);
+  if (optional.has('chat')) registerChatTools(server);
+  if (getAdminAccounts().length > 0) registerAdminTools(server);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -1,0 +1,44 @@
+import type { Account } from '../accounts.js';
+
+/** Maps googleapis errors to MCP tool responses. 401 → re-auth instruction; 403 + hint → structured hint payload; 429 → retry-after; else → {error, code}. */
+export function handleGoogleApiError(error: any, account: Account, forbiddenHint?: string) {
+  if (error.code === 401) {
+    return {
+      content: [{
+        type: 'text' as const,
+        text: `Authentication error for account "${account}". Run: node dist/index.js auth --account ${account}`,
+      }],
+      isError: true as const,
+    };
+  }
+  if (error.code === 403 && forbiddenHint) {
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({
+          error: 'forbidden',
+          hint: forbiddenHint,
+          original: error.message ?? String(error),
+        }),
+      }],
+      isError: true as const,
+    };
+  }
+  if (error.code === 429) {
+    const retryAfter = error.response?.headers?.['retry-after'] ?? 'unknown';
+    return {
+      content: [{
+        type: 'text' as const,
+        text: JSON.stringify({ error: 'rate_limited', retryAfter }),
+      }],
+      isError: true as const,
+    };
+  }
+  return {
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify({ error: error.message ?? String(error), code: error.code }),
+    }],
+    isError: true as const,
+  };
+}

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -1,0 +1,332 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { ACCOUNTS } from '../accounts.js';
+import type { Account } from '../accounts.js';
+import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
+import { adminWritesEnabled } from '../auth.js';
+
+const accountEnum = z.enum(ACCOUNTS);
+
+/**
+ * Admin SDK tools require Workspace super-admin (or delegated admin) privileges on the target account.
+ * Personal `@gmail.com` accounts will 403 on every endpoint.
+ *
+ * Writes are gated behind GOOGLE_ALLOW_ADMIN_WRITES=true to prevent accidents on small orgs
+ * (a stray users.update on a 3-person Workspace is a bad day).
+ */
+export function registerAdminTools(server: McpServer): void {
+  // ─── Reports / audit log ───────────────────────────────────────────────
+
+  server.registerTool(
+    'reports_activities_list',
+    {
+      description: 'List Admin Activity audit log entries. Filter by application (login, drive, gmail, admin, token, etc.), user, date range, event. The single most useful admin endpoint for SMB visibility.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
+        applicationName: z.enum([
+          'access_transparency', 'admin', 'calendar', 'chat', 'drive', 'gcp', 'gmail',
+          'gplus', 'groups', 'groups_enterprise', 'jamboard', 'login', 'meet', 'mobile',
+          'rules', 'saml', 'token', 'user_accounts', 'context_aware_access', 'chrome',
+          'data_studio', 'keep', 'vault', 'classroom', 'assignments', 'cloud_search',
+          'tasks', 'data_migration', 'meet_hardware', 'directory_sync', 'ldap',
+          'profile', 'contacts', 'takeout',
+        ]).describe('Which application\'s activity to query'),
+        userKey: z.string().default('all').optional().describe('User profile ID, email, or "all" (default)'),
+        startTime: z.string().optional().describe('RFC 3339 lower bound'),
+        endTime: z.string().optional().describe('RFC 3339 upper bound'),
+        eventName: z.string().optional().describe('Specific event name to filter'),
+        actorIpAddress: z.string().optional(),
+        filters: z.string().optional().describe('Comma-separated event-parameter filters with relational operators'),
+        orgUnitID: z.string().optional(),
+        groupIdFilter: z.string().optional(),
+        customerId: z.string().optional(),
+        maxResults: z.number().min(1).max(1000).optional(),
+        pageToken: z.string().optional(),
+      },
+    },
+    async ({ account, applicationName, userKey, startTime, endTime, eventName, actorIpAddress, filters, orgUnitID, groupIdFilter, customerId, maxResults, pageToken }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const reports = google.admin({ version: 'reports_v1', auth });
+        const res = await reports.activities.list({
+          applicationName,
+          userKey: userKey ?? 'all',
+          startTime,
+          endTime,
+          eventName,
+          actorIpAddress,
+          filters,
+          orgUnitID,
+          groupIdFilter,
+          customerId,
+          maxResults: maxResults ?? 100,
+          pageToken,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleAdminError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Alert Center ──────────────────────────────────────────────────────
+
+  server.registerTool(
+    'alertcenter_alerts_list',
+    {
+      description: 'List Workspace security alerts (suspicious login, phishing, leaked password, Drive exfil, etc.)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
+        pageSize: z.number().min(1).max(1000).optional(),
+        pageToken: z.string().optional(),
+        filter: z.string().optional().describe('Filter expression, e.g. "type = \\"Suspicious login\\""'),
+        orderBy: z.string().optional(),
+        customerId: z.string().optional(),
+      },
+    },
+    async ({ account, pageSize, pageToken, filter, orderBy, customerId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const alertcenter = google.alertcenter({ version: 'v1beta1', auth });
+        const res = await alertcenter.alerts.list({
+          pageSize: pageSize ?? 50,
+          pageToken,
+          filter,
+          orderBy,
+          customerId,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleAdminError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'alertcenter_alert_get',
+    {
+      description: 'Get a single alert by ID',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
+        alertId: z.string().describe('Alert ID'),
+        customerId: z.string().optional(),
+      },
+    },
+    async ({ account, alertId, customerId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const alertcenter = google.alertcenter({ version: 'v1beta1', auth });
+        const res = await alertcenter.alerts.get({ alertId, customerId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleAdminError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Directory: users ─────────────────────────────────────────────────
+
+  server.registerTool(
+    'admin_users_list',
+    {
+      description: 'List users in the Workspace customer. Filter by domain or customer=my_customer.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
+        customer: z.string().default('my_customer').optional(),
+        domain: z.string().optional(),
+        query: z.string().optional().describe('Search query, e.g. "name:John"'),
+        maxResults: z.number().min(1).max(500).optional(),
+        pageToken: z.string().optional(),
+        orderBy: z.enum(['email', 'familyName', 'givenName']).optional(),
+        showDeleted: z.boolean().optional(),
+        projection: z.enum(['basic', 'custom', 'full']).optional(),
+      },
+    },
+    async ({ account, customer, domain, query, maxResults, pageToken, orderBy, showDeleted, projection }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const directory = google.admin({ version: 'directory_v1', auth });
+        const res = await directory.users.list({
+          customer: customer ?? 'my_customer',
+          domain,
+          query,
+          maxResults: maxResults ?? 100,
+          pageToken,
+          orderBy,
+          showDeleted: showDeleted !== undefined ? (showDeleted ? 'true' : 'false') : undefined,
+          projection: projection ?? 'basic',
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleAdminError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'admin_users_get',
+    {
+      description: 'Get a single Workspace user by email or user ID',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
+        userKey: z.string().describe('User email or ID'),
+        projection: z.enum(['basic', 'custom', 'full']).optional(),
+      },
+    },
+    async ({ account, userKey, projection }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const directory = google.admin({ version: 'directory_v1', auth });
+        const res = await directory.users.get({
+          userKey,
+          projection: projection ?? 'basic',
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleAdminError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'admin_users_update',
+    {
+      description: 'Update a Workspace user (PATCH semantics). GATED: requires GOOGLE_ALLOW_ADMIN_WRITES=true to prevent accidental destructive ops on small orgs.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
+        userKey: z.string().describe('User email or ID'),
+        givenName: z.string().optional(),
+        familyName: z.string().optional(),
+        suspended: z.boolean().optional(),
+        password: z.string().optional(),
+        changePasswordAtNextLogin: z.boolean().optional(),
+        orgUnitPath: z.string().optional(),
+      },
+    },
+    async ({ account, userKey, givenName, familyName, suspended, password, changePasswordAtNextLogin, orgUnitPath }) => {
+      try {
+        if (!adminWritesEnabled()) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'admin_writes_disabled',
+                hint: 'Admin write operations are disabled by default. Set GOOGLE_ALLOW_ADMIN_WRITES=true in .env and restart to enable.',
+              }),
+            }],
+            isError: true,
+          };
+        }
+        const auth = await getClient(account as Account);
+        const directory = google.admin({ version: 'directory_v1', auth });
+        const requestBody: any = {};
+        if (givenName !== undefined || familyName !== undefined) {
+          requestBody.name = {};
+          if (givenName !== undefined) requestBody.name.givenName = givenName;
+          if (familyName !== undefined) requestBody.name.familyName = familyName;
+        }
+        if (suspended !== undefined) requestBody.suspended = suspended;
+        if (password !== undefined) requestBody.password = password;
+        if (changePasswordAtNextLogin !== undefined) requestBody.changePasswordAtNextLogin = changePasswordAtNextLogin;
+        if (orgUnitPath !== undefined) requestBody.orgUnitPath = orgUnitPath;
+
+        if (Object.keys(requestBody).length === 0) {
+          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'No fields to update' }) }], isError: true };
+        }
+
+        const res = await directory.users.patch({ userKey, requestBody });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleAdminError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Directory: groups ────────────────────────────────────────────────
+
+  server.registerTool(
+    'admin_groups_list',
+    {
+      description: 'List groups in the Workspace customer',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
+        customer: z.string().default('my_customer').optional(),
+        domain: z.string().optional(),
+        userKey: z.string().optional().describe('Only return groups containing this user'),
+        query: z.string().optional(),
+        maxResults: z.number().min(1).max(200).optional(),
+        pageToken: z.string().optional(),
+      },
+    },
+    async ({ account, customer, domain, userKey, query, maxResults, pageToken }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const directory = google.admin({ version: 'directory_v1', auth });
+        const res = await directory.groups.list({
+          customer: customer ?? 'my_customer',
+          domain,
+          userKey,
+          query,
+          maxResults: maxResults ?? 100,
+          pageToken,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleAdminError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'admin_group_members_list',
+    {
+      description: 'List members of a Workspace group',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
+        groupKey: z.string().describe('Group email or ID'),
+        roles: z.string().optional().describe('Comma-separated roles to include (OWNER, MANAGER, MEMBER)'),
+        includeDerivedMembership: z.boolean().optional(),
+        maxResults: z.number().min(1).max(200).optional(),
+        pageToken: z.string().optional(),
+      },
+    },
+    async ({ account, groupKey, roles, includeDerivedMembership, maxResults, pageToken }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const directory = google.admin({ version: 'directory_v1', auth });
+        const res = await directory.members.list({
+          groupKey,
+          roles,
+          includeDerivedMembership,
+          maxResults: maxResults ?? 100,
+          pageToken,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleAdminError(error, account as Account);
+      }
+    },
+  );
+}
+
+function handleAdminError(error: any, account: Account) {
+  return handleGoogleApiError(error, account, "Admin tools require Workspace super-admin privileges AND the account must be listed in GOOGLE_ADMIN_ACCOUNTS (then re-authenticated). Personal Gmail accounts cannot use these endpoints.");
+}

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -4,11 +4,11 @@ import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
 export function registerCalendarTools(server: McpServer): void {
-  // calendar_list_calendars
   server.registerTool(
     'calendar_list_calendars',
     {
@@ -41,7 +41,6 @@ export function registerCalendarTools(server: McpServer): void {
     },
   );
 
-  // calendar_list_events
   server.registerTool(
     'calendar_list_events',
     {
@@ -74,8 +73,6 @@ export function registerCalendarTools(server: McpServer): void {
         if (query) params.q = query;
         if (timeMin) params.timeMin = timeMin;
         if (timeMax) params.timeMax = timeMax;
-
-        // Default to upcoming events if no time range specified
         if (!timeMin && !timeMax) {
           params.timeMin = new Date().toISOString();
         }
@@ -92,7 +89,6 @@ export function registerCalendarTools(server: McpServer): void {
     },
   );
 
-  // calendar_get_event
   server.registerTool(
     'calendar_get_event',
     {
@@ -123,7 +119,6 @@ export function registerCalendarTools(server: McpServer): void {
     },
   );
 
-  // calendar_create_event
   server.registerTool(
     'calendar_create_event',
     {
@@ -181,7 +176,6 @@ export function registerCalendarTools(server: McpServer): void {
     },
   );
 
-  // calendar_update_event
   server.registerTool(
     'calendar_update_event',
     {
@@ -247,7 +241,6 @@ export function registerCalendarTools(server: McpServer): void {
     },
   );
 
-  // calendar_delete_event
   server.registerTool(
     'calendar_delete_event',
     {
@@ -278,9 +271,6 @@ export function registerCalendarTools(server: McpServer): void {
     },
   );
 
-  // --- New tools below ---
-
-  // calendar_quick_add
   server.registerTool(
     'calendar_quick_add',
     {
@@ -311,7 +301,6 @@ export function registerCalendarTools(server: McpServer): void {
     },
   );
 
-  // calendar_move_event
   server.registerTool(
     'calendar_move_event',
     {
@@ -343,7 +332,6 @@ export function registerCalendarTools(server: McpServer): void {
     },
   );
 
-  // calendar_list_instances
   server.registerTool(
     'calendar_list_instances',
     {
@@ -380,7 +368,6 @@ export function registerCalendarTools(server: McpServer): void {
     },
   );
 
-  // calendar_get_freebusy
   server.registerTool(
     'calendar_get_freebusy',
     {
@@ -414,7 +401,6 @@ export function registerCalendarTools(server: McpServer): void {
     },
   );
 
-  // calendar_create_calendar
   server.registerTool(
     'calendar_create_calendar',
     {
@@ -468,30 +454,5 @@ function formatEvent(event: any) {
 }
 
 function handleCalendarError(error: any, account: Account) {
-  if (error.code === 401) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: `Authentication error for account "${account}". Run: node dist/index.js auth --account ${account}`,
-      }],
-      isError: true,
-    };
-  }
-  if (error.code === 429) {
-    const retryAfter = error.response?.headers?.['retry-after'] ?? 'unknown';
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({ error: 'rate_limited', retryAfter }),
-      }],
-      isError: true,
-    };
-  }
-  return {
-    content: [{
-      type: 'text' as const,
-      text: JSON.stringify({ error: error.message ?? String(error), code: error.code }),
-    }],
-    isError: true,
-  };
+  return handleGoogleApiError(error, account);
 }

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -1,0 +1,139 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { ACCOUNTS } from '../accounts.js';
+import type { Account } from '../accounts.js';
+import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
+
+const accountEnum = z.enum(ACCOUNTS);
+
+export function registerChatTools(server: McpServer): void {
+  server.registerTool(
+    'chat_spaces_list',
+    {
+      description: 'List Google Chat spaces the user is a member of',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        pageSize: z.number().min(1).max(1000).optional(),
+        pageToken: z.string().optional(),
+        filter: z.string().optional().describe('Filter expression, e.g. "spaceType = \\"DIRECT_MESSAGE\\""'),
+      },
+    },
+    async ({ account, pageSize, pageToken, filter }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const chat = google.chat({ version: 'v1', auth });
+        const res = await chat.spaces.list({
+          pageSize: pageSize ?? 100,
+          pageToken,
+          filter,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleChatError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'chat_spaces_get',
+    {
+      description: 'Get details about a single Chat space',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        name: z.string().describe('Space resource name, format: spaces/{space}'),
+      },
+    },
+    async ({ account, name }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const chat = google.chat({ version: 'v1', auth });
+        const res = await chat.spaces.get({ name });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleChatError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'chat_messages_create',
+    {
+      description: 'Send a message into a Chat space. Supply plain text or a Card v2 in cardsV2.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        parent: z.string().describe('Space resource name, format: spaces/{space}'),
+        text: z.string().optional().describe('Plain message text'),
+        cardsV2: z.array(z.record(z.string(), z.any())).optional().describe('Optional Card v2 payloads'),
+        threadKey: z.string().optional().describe('Thread key to group messages'),
+        messageReplyOption: z.enum(['MESSAGE_REPLY_OPTION_UNSPECIFIED', 'REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD', 'REPLY_MESSAGE_OR_FAIL']).optional(),
+      },
+    },
+    async ({ account, parent, text, cardsV2, threadKey, messageReplyOption }) => {
+      try {
+        if (!text && (!cardsV2 || cardsV2.length === 0)) {
+          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Either text or cardsV2 must be provided' }) }], isError: true };
+        }
+        const auth = await getClient(account as Account);
+        const chat = google.chat({ version: 'v1', auth });
+        const requestBody: any = {};
+        if (text) requestBody.text = text;
+        if (cardsV2) requestBody.cardsV2 = cardsV2;
+        if (threadKey) requestBody.thread = { threadKey };
+
+        const res = await chat.spaces.messages.create({
+          parent,
+          messageReplyOption,
+          requestBody,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleChatError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'chat_messages_list',
+    {
+      description: 'List messages in a Chat space',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        parent: z.string().describe('Space resource name, format: spaces/{space}'),
+        pageSize: z.number().min(1).max(1000).optional(),
+        pageToken: z.string().optional(),
+        filter: z.string().optional().describe('Filter expression, e.g. "createTime > \\"2026-01-01T00:00:00Z\\""'),
+        orderBy: z.string().optional().describe('e.g. "createTime DESC"'),
+      },
+    },
+    async ({ account, parent, pageSize, pageToken, filter, orderBy }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const chat = google.chat({ version: 'v1', auth });
+        const res = await chat.spaces.messages.list({
+          parent,
+          pageSize: pageSize ?? 100,
+          pageToken,
+          filter,
+          orderBy,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleChatError(error, account as Account);
+      }
+    },
+  );
+}
+
+function handleChatError(error: any, account: Account) {
+  return handleGoogleApiError(error, account, "Chat tools require the optional \"chat\" scope bundle. Add GOOGLE_OPTIONAL_SCOPES=chat and re-auth.");
+}

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -4,6 +4,7 @@ import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
@@ -37,7 +38,6 @@ function formatContact(person: any) {
 }
 
 export function registerContactsTools(server: McpServer): void {
-  // contacts_search
   server.registerTool(
     'contacts_search',
     {
@@ -76,7 +76,6 @@ export function registerContactsTools(server: McpServer): void {
     },
   );
 
-  // contacts_get
   server.registerTool(
     'contacts_get',
     {
@@ -103,7 +102,6 @@ export function registerContactsTools(server: McpServer): void {
     },
   );
 
-  // contacts_list
   server.registerTool(
     'contacts_list',
     {
@@ -147,7 +145,6 @@ export function registerContactsTools(server: McpServer): void {
     },
   );
 
-  // contacts_create
   server.registerTool(
     'contacts_create',
     {
@@ -200,7 +197,6 @@ export function registerContactsTools(server: McpServer): void {
     },
   );
 
-  // contacts_update
   server.registerTool(
     'contacts_update',
     {
@@ -282,7 +278,6 @@ export function registerContactsTools(server: McpServer): void {
     },
   );
 
-  // contacts_delete
   server.registerTool(
     'contacts_delete',
     {
@@ -308,7 +303,6 @@ export function registerContactsTools(server: McpServer): void {
     },
   );
 
-  // contacts_groups_list
   server.registerTool(
     'contacts_groups_list',
     {
@@ -342,7 +336,6 @@ export function registerContactsTools(server: McpServer): void {
     },
   );
 
-  // contacts_group_members
   server.registerTool(
     'contacts_group_members',
     {
@@ -358,8 +351,6 @@ export function registerContactsTools(server: McpServer): void {
       try {
         const auth = await getClient(account as Account);
         const people = google.people({ version: 'v1', auth });
-
-        // Get group with member resource names
         const groupRes = await people.contactGroups.get({
           resourceName: groupResourceName,
           maxMembers: maxMembers ?? 100,
@@ -374,8 +365,6 @@ export function registerContactsTools(server: McpServer): void {
             }, null, 2) }],
           };
         }
-
-        // Batch get the actual contact details
         const membersRes = await people.people.getBatchGet({
           resourceNames: memberResourceNames,
           personFields: PERSON_FIELDS,
@@ -397,7 +386,6 @@ export function registerContactsTools(server: McpServer): void {
     },
   );
 
-  // contacts_group_create
   server.registerTool(
     'contacts_group_create',
     {
@@ -431,30 +419,5 @@ export function registerContactsTools(server: McpServer): void {
 }
 
 function handleContactsError(error: any, account: Account) {
-  if (error.code === 401) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: `Authentication error for account "${account}". Run: node dist/index.js auth --account ${account}`,
-      }],
-      isError: true,
-    };
-  }
-  if (error.code === 429) {
-    const retryAfter = error.response?.headers?.['retry-after'] ?? 'unknown';
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({ error: 'rate_limited', retryAfter }),
-      }],
-      isError: true,
-    };
-  }
-  return {
-    content: [{
-      type: 'text' as const,
-      text: JSON.stringify({ error: error.message ?? String(error), code: error.code }),
-    }],
-    isError: true,
-  };
+  return handleGoogleApiError(error, account);
 }

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -4,6 +4,7 @@ import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
@@ -29,7 +30,6 @@ function extractPlainText(body: any): string {
 }
 
 export function registerDocsTools(server: McpServer): void {
-  // docs_create
   server.registerTool(
     'docs_create',
     {
@@ -58,27 +58,39 @@ export function registerDocsTools(server: McpServer): void {
     },
   );
 
-  // docs_get
   server.registerTool(
     'docs_get',
     {
-      description: 'Get document metadata (title, revision, named ranges)',
+      description: 'Get document metadata (title, revision, named ranges). Optionally include tab content and choose a suggestionsViewMode.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         documentId: z.string().describe('Google Docs document ID'),
+        includeTabsContent: z.boolean().optional()
+          .describe('Include full content for every tab (default: false — first tab only)'),
+        suggestionsViewMode: z.enum([
+          'DEFAULT_FOR_CURRENT_ACCESS',
+          'SUGGESTIONS_INLINE',
+          'PREVIEW_SUGGESTIONS_ACCEPTED',
+          'PREVIEW_WITHOUT_SUGGESTIONS',
+        ]).optional().describe('How suggestions render in the returned body'),
       },
     },
-    async ({ account, documentId }) => {
+    async ({ account, documentId, includeTabsContent, suggestionsViewMode }) => {
       try {
         const auth = await getClient(account as Account);
         const docs = google.docs({ version: 'v1', auth });
-        const res = await docs.documents.get({ documentId });
+        const res = await docs.documents.get({
+          documentId,
+          includeTabsContent: includeTabsContent ?? false,
+          suggestionsViewMode,
+        });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({
             documentId: res.data.documentId,
             title: res.data.title,
             revisionId: res.data.revisionId,
             namedRanges: res.data.namedRanges ?? {},
+            tabs: res.data.tabs ?? undefined,
           }, null, 2) }],
         };
       } catch (error: any) {
@@ -87,7 +99,6 @@ export function registerDocsTools(server: McpServer): void {
     },
   );
 
-  // docs_read
   server.registerTool(
     'docs_read',
     {
@@ -116,7 +127,6 @@ export function registerDocsTools(server: McpServer): void {
     },
   );
 
-  // docs_insert_text
   server.registerTool(
     'docs_insert_text',
     {
@@ -157,7 +167,6 @@ export function registerDocsTools(server: McpServer): void {
     },
   );
 
-  // docs_replace_text
   server.registerTool(
     'docs_replace_text',
     {
@@ -199,7 +208,6 @@ export function registerDocsTools(server: McpServer): void {
     },
   );
 
-  // docs_delete_range
   server.registerTool(
     'docs_delete_range',
     {
@@ -237,7 +245,6 @@ export function registerDocsTools(server: McpServer): void {
     },
   );
 
-  // docs_update_style
   server.registerTool(
     'docs_update_style',
     {
@@ -308,7 +315,6 @@ export function registerDocsTools(server: McpServer): void {
     },
   );
 
-  // docs_insert_table
   server.registerTool(
     'docs_insert_table',
     {
@@ -349,33 +355,826 @@ export function registerDocsTools(server: McpServer): void {
       }
     },
   );
+
+  // ─── Named ranges (mail-merge primitive) ───────────────────────────────
+
+  server.registerTool(
+    'docs_create_named_range',
+    {
+      description: 'Tag a range of text with a name. Multiple ranges can share the same name. Used as a template anchor for docs_replace_named_range_content.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        name: z.string().describe('Name (1-256 chars). Need not be unique.'),
+        startIndex: z.number().min(1).describe('Range start (inclusive)'),
+        endIndex: z.number().min(2).describe('Range end (exclusive)'),
+      },
+    },
+    async ({ account, documentId, name, startIndex, endIndex }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const res = await docs.documents.batchUpdate({
+          documentId,
+          requestBody: {
+            requests: [{
+              createNamedRange: {
+                name,
+                range: { startIndex, endIndex },
+              },
+            }],
+          },
+        });
+        const created = (res.data.replies?.[0] as any)?.createNamedRange;
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(created ?? {}, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'docs_delete_named_range',
+    {
+      description: 'Delete a named range by its ID or by name. Removes every range matching the identifier.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        namedRangeId: z.string().optional().describe('Specific named range ID'),
+        name: z.string().optional().describe('Name (deletes ALL named ranges with this name)'),
+      },
+    },
+    async ({ account, documentId, namedRangeId, name }) => {
+      try {
+        if (!namedRangeId && !name) {
+          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Either namedRangeId or name must be supplied' }) }], isError: true };
+        }
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const req: any = {};
+        if (namedRangeId) req.namedRangeId = namedRangeId;
+        else req.name = name;
+
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ deleteNamedRange: req }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'docs_replace_named_range_content',
+    {
+      description: 'Replace the content of every named range matching the identifier with the supplied text. Real mail-merge primitive — far more robust than replaceAllText for templated docs.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        namedRangeId: z.string().optional().describe('Specific named range ID'),
+        namedRangeName: z.string().optional().describe('Name to match (replaces ALL ranges with this name)'),
+        text: z.string().describe('Replacement text'),
+      },
+    },
+    async ({ account, documentId, namedRangeId, namedRangeName, text }) => {
+      try {
+        if (!namedRangeId && !namedRangeName) {
+          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Either namedRangeId or namedRangeName must be supplied' }) }], isError: true };
+        }
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const req: any = { text };
+        if (namedRangeId) req.namedRangeId = namedRangeId;
+        else req.namedRangeName = namedRangeName;
+
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ replaceNamedRangeContent: req }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ replaced: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Paragraph + document style ────────────────────────────────────────
+
+  server.registerTool(
+    'docs_update_paragraph_style',
+    {
+      description: 'Update paragraph styling (alignment, heading, indents, spacing) across a range. Only supplied fields are applied.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        startIndex: z.number().min(1),
+        endIndex: z.number().min(2),
+        namedStyleType: z.enum([
+          'NORMAL_TEXT', 'TITLE', 'SUBTITLE',
+          'HEADING_1', 'HEADING_2', 'HEADING_3', 'HEADING_4', 'HEADING_5', 'HEADING_6',
+        ]).optional(),
+        alignment: z.enum(['START', 'CENTER', 'END', 'JUSTIFIED']).optional(),
+        lineSpacing: z.number().optional().describe('Line spacing as percent (100 = single-space)'),
+        spaceAbove: z.number().optional().describe('Space above paragraph, in points'),
+        spaceBelow: z.number().optional().describe('Space below paragraph, in points'),
+        indentStart: z.number().optional().describe('Start indent in points'),
+        indentEnd: z.number().optional().describe('End indent in points'),
+        indentFirstLine: z.number().optional().describe('First-line indent in points'),
+        direction: z.enum(['LEFT_TO_RIGHT', 'RIGHT_TO_LEFT']).optional(),
+        keepLinesTogether: z.boolean().optional(),
+        keepWithNext: z.boolean().optional(),
+        avoidWidowAndOrphan: z.boolean().optional(),
+      },
+    },
+    async ({ account, documentId, startIndex, endIndex, ...style }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const built = buildParagraphStyle(style);
+        if (built.fields.length === 0) {
+          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'No paragraph style properties supplied' }) }], isError: true };
+        }
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: {
+            requests: [{
+              updateParagraphStyle: {
+                range: { startIndex, endIndex },
+                paragraphStyle: built.paragraphStyle,
+                fields: built.fields,
+              },
+            }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ styled: true, range: { startIndex, endIndex }, applied: built.fields }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'docs_update_document_style',
+    {
+      description: 'Update document-level styling (page size, margins, headers/footers behavior). Only supplied fields are applied.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        pageWidth: z.number().optional().describe('Page width in points (e.g. 595 = A4)'),
+        pageHeight: z.number().optional().describe('Page height in points (e.g. 842 = A4)'),
+        marginTop: z.number().optional().describe('Margin in points'),
+        marginBottom: z.number().optional(),
+        marginLeft: z.number().optional(),
+        marginRight: z.number().optional(),
+        marginHeader: z.number().optional(),
+        marginFooter: z.number().optional(),
+        pageNumberStart: z.number().optional(),
+        useFirstPageHeaderFooter: z.boolean().optional(),
+        useEvenPageHeaderFooter: z.boolean().optional(),
+        useCustomHeaderFooterMargins: z.boolean().optional(),
+      },
+    },
+    async ({ account, documentId, ...style }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const built = buildDocumentStyle(style);
+        if (built.fields.length === 0) {
+          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'No document style properties supplied' }) }], isError: true };
+        }
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: {
+            requests: [{
+              updateDocumentStyle: {
+                documentStyle: built.documentStyle,
+                fields: built.fields,
+              },
+            }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ styled: true, applied: built.fields }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Bullets ───────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'docs_create_paragraph_bullets',
+    {
+      description: 'Turn paragraphs in a range into a bulleted or numbered list',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        startIndex: z.number().min(1),
+        endIndex: z.number().min(2),
+        bulletPreset: z.enum([
+          'BULLET_DISC_CIRCLE_SQUARE',
+          'BULLET_DIAMONDX_ARROW3D_SQUARE',
+          'BULLET_CHECKBOX',
+          'BULLET_ARROW_DIAMOND_DISC',
+          'BULLET_STAR_CIRCLE_SQUARE',
+          'BULLET_ARROW3D_CIRCLE_SQUARE',
+          'BULLET_LEFTTRIANGLE_DIAMOND_DISC',
+          'BULLET_DIAMONDX_HOLLOWDIAMOND_SQUARE',
+          'BULLET_DIAMOND_CIRCLE_SQUARE',
+          'NUMBERED_DECIMAL_ALPHA_ROMAN',
+          'NUMBERED_DECIMAL_ALPHA_ROMAN_PARENS',
+          'NUMBERED_DECIMAL_NESTED',
+          'NUMBERED_UPPERALPHA_ALPHA_ROMAN',
+          'NUMBERED_UPPERROMAN_UPPERALPHA_DECIMAL',
+          'NUMBERED_ZERODECIMAL_ALPHA_ROMAN',
+        ]).describe('Bullet/numbering preset'),
+      },
+    },
+    async ({ account, documentId, startIndex, endIndex, bulletPreset }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: {
+            requests: [{
+              createParagraphBullets: {
+                range: { startIndex, endIndex },
+                bulletPreset,
+              },
+            }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ bulleted: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'docs_delete_paragraph_bullets',
+    {
+      description: 'Strip bullet/number formatting from paragraphs in a range',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        startIndex: z.number().min(1),
+        endIndex: z.number().min(2),
+      },
+    },
+    async ({ account, documentId, startIndex, endIndex }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: {
+            requests: [{
+              deleteParagraphBullets: {
+                range: { startIndex, endIndex },
+              },
+            }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ unbulleted: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Inline images ─────────────────────────────────────────────────────
+
+  server.registerTool(
+    'docs_insert_inline_image',
+    {
+      description: 'Insert a publicly-accessible image (PNG/JPEG/GIF, <50MB, <25MP, URL <2KB) inline at an index or at the document end',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        uri: z.string().url().describe('Public image URL'),
+        index: z.number().min(1).optional().describe('Insert position; omit to append at the end'),
+        width: z.number().optional().describe('Width in points (omit for natural size)'),
+        height: z.number().optional().describe('Height in points'),
+      },
+    },
+    async ({ account, documentId, uri, index, width, height }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const request: any = { uri };
+        if (index !== undefined) request.location = { index };
+        else request.endOfSegmentLocation = { segmentId: '' };
+        if (width !== undefined || height !== undefined) {
+          request.objectSize = {};
+          if (width !== undefined) request.objectSize.width = { magnitude: width, unit: 'PT' };
+          if (height !== undefined) request.objectSize.height = { magnitude: height, unit: 'PT' };
+        }
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ insertInlineImage: request }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ inserted: true, at: index ?? 'end' }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Breaks ────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'docs_insert_page_break',
+    {
+      description: 'Insert a page break at a position or at the document end',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        index: z.number().min(1).optional().describe('Insert position; omit to append'),
+      },
+    },
+    async ({ account, documentId, index }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const request: any = {};
+        if (index !== undefined) request.location = { index };
+        else request.endOfSegmentLocation = { segmentId: '' };
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ insertPageBreak: request }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ inserted: true, at: index ?? 'end' }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'docs_insert_section_break',
+    {
+      description: 'Insert a section break at a position. CONTINUOUS keeps the same page; NEXT_PAGE starts a new page.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        index: z.number().min(1).optional(),
+        sectionType: z.enum(['CONTINUOUS', 'NEXT_PAGE']).default('NEXT_PAGE').optional(),
+      },
+    },
+    async ({ account, documentId, index, sectionType }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const request: any = { sectionType: sectionType ?? 'NEXT_PAGE' };
+        if (index !== undefined) request.location = { index };
+        else request.endOfSegmentLocation = { segmentId: '' };
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ insertSectionBreak: request }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ inserted: true, at: index ?? 'end' }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Headers / footers ────────────────────────────────────────────────
+
+  server.registerTool(
+    'docs_create_header',
+    {
+      description: 'Create a header for the document or for a specific section. The new header is empty; insert text into it with docs_insert_text targeting its segmentId.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        sectionBreakIndex: z.number().min(1).optional().describe('Anchor to a specific section break; omit to apply to the document'),
+      },
+    },
+    async ({ account, documentId, sectionBreakIndex }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const request: any = { type: 'DEFAULT' };
+        if (sectionBreakIndex !== undefined) request.sectionBreakLocation = { index: sectionBreakIndex };
+        const res = await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ createHeader: request }] },
+        });
+        const reply = (res.data.replies?.[0] as any)?.createHeader;
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(reply ?? {}, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'docs_delete_header',
+    {
+      description: 'Delete a header by its headerId',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        headerId: z.string().describe('Header ID (from docs_get or createHeader reply)'),
+      },
+    },
+    async ({ account, documentId, headerId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ deleteHeader: { headerId } }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, headerId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'docs_create_footer',
+    {
+      description: 'Create a footer for the document or a specific section',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        sectionBreakIndex: z.number().min(1).optional(),
+      },
+    },
+    async ({ account, documentId, sectionBreakIndex }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const request: any = { type: 'DEFAULT' };
+        if (sectionBreakIndex !== undefined) request.sectionBreakLocation = { index: sectionBreakIndex };
+        const res = await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ createFooter: request }] },
+        });
+        const reply = (res.data.replies?.[0] as any)?.createFooter;
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(reply ?? {}, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'docs_delete_footer',
+    {
+      description: 'Delete a footer by its footerId',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        footerId: z.string().describe('Footer ID'),
+      },
+    },
+    async ({ account, documentId, footerId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ deleteFooter: { footerId } }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, footerId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Table mutations (one tool with operation discriminator) ───────────
+
+  server.registerTool(
+    'docs_modify_table',
+    {
+      description: 'Mutate a table by operation: insertRow, insertColumn, deleteRow, deleteColumn, mergeCells, unmergeCells. Locate the cell with tableStartIndex (the table\'s start index in the doc) plus rowIndex/columnIndex (0-based).',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        operation: z.enum(['insertRow', 'insertColumn', 'deleteRow', 'deleteColumn', 'mergeCells', 'unmergeCells']),
+        tableStartIndex: z.number().min(1).describe('Start index of the table in the document'),
+        rowIndex: z.number().min(0).describe('Target row (0-based)'),
+        columnIndex: z.number().min(0).describe('Target column (0-based)'),
+        insertBelow: z.boolean().optional().describe('insertRow only: insert below the target row (default: false)'),
+        insertRight: z.boolean().optional().describe('insertColumn only: insert right of the target column (default: false)'),
+        rowSpan: z.number().min(1).optional().describe('mergeCells only: how many rows the merged cell spans (default 1)'),
+        columnSpan: z.number().min(1).optional().describe('mergeCells/unmergeCells: column span (default 1)'),
+      },
+    },
+    async ({ account, documentId, operation, tableStartIndex, rowIndex, columnIndex, insertBelow, insertRight, rowSpan, columnSpan }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const cellLoc = {
+          tableStartLocation: { index: tableStartIndex },
+          rowIndex,
+          columnIndex,
+        };
+        let request: any;
+        switch (operation) {
+          case 'insertRow':
+            request = { insertTableRow: { tableCellLocation: cellLoc, insertBelow: insertBelow ?? false } };
+            break;
+          case 'insertColumn':
+            request = { insertTableColumn: { tableCellLocation: cellLoc, insertRight: insertRight ?? false } };
+            break;
+          case 'deleteRow':
+            request = { deleteTableRow: { tableCellLocation: cellLoc } };
+            break;
+          case 'deleteColumn':
+            request = { deleteTableColumn: { tableCellLocation: cellLoc } };
+            break;
+          case 'mergeCells':
+            request = {
+              mergeTableCells: {
+                tableRange: {
+                  tableCellLocation: cellLoc,
+                  rowSpan: rowSpan ?? 1,
+                  columnSpan: columnSpan ?? 1,
+                },
+              },
+            };
+            break;
+          case 'unmergeCells':
+            request = {
+              unmergeTableCells: {
+                tableRange: {
+                  tableCellLocation: cellLoc,
+                  rowSpan: rowSpan ?? 1,
+                  columnSpan: columnSpan ?? 1,
+                },
+              },
+            };
+            break;
+        }
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [request] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ operation, completed: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Tabs ──────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'docs_add_tab',
+    {
+      description: 'Add a new tab to a document. Can be a top-level tab or nested as a child of an existing tab.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        title: z.string().describe('Tab title'),
+        parentTabId: z.string().optional().describe('Parent tab ID (omit for top-level)'),
+        index: z.number().min(0).optional().describe('Position among siblings'),
+      },
+    },
+    async ({ account, documentId, title, parentTabId, index }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const tabProperties: any = { title };
+        if (parentTabId) tabProperties.parentTabId = parentTabId;
+        if (index !== undefined) tabProperties.index = index;
+        const res = await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ addDocumentTab: { tabProperties } }] },
+        });
+        const reply = (res.data.replies?.[0] as any)?.addDocumentTab;
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(reply ?? {}, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'docs_delete_tab',
+    {
+      description: 'Delete a tab and all of its descendant tabs',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        tabId: z.string().describe('Tab ID'),
+      },
+    },
+    async ({ account, documentId, tabId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: { requests: [{ deleteTab: { tabId } }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, tabId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'docs_update_tab_properties',
+    {
+      description: 'Rename a tab, change its position, or move it under a different parent',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        tabId: z.string().describe('Tab ID'),
+        title: z.string().optional(),
+        index: z.number().min(0).optional(),
+        parentTabId: z.string().optional(),
+      },
+    },
+    async ({ account, documentId, tabId, title, index, parentTabId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const tabProperties: any = { tabId };
+        const fields: string[] = [];
+        if (title !== undefined) { tabProperties.title = title; fields.push('title'); }
+        if (index !== undefined) { tabProperties.index = index; fields.push('index'); }
+        if (parentTabId !== undefined) { tabProperties.parentTabId = parentTabId; fields.push('parentTabId'); }
+        if (fields.length === 0) {
+          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'No tab property supplied' }) }], isError: true };
+        }
+        await docs.documents.batchUpdate({
+          documentId,
+          requestBody: {
+            requests: [{
+              updateDocumentTabProperties: {
+                tabProperties,
+                fields: fields.join(','),
+              },
+            }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ updated: true, tabId, applied: fields }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Batch update escape hatch ─────────────────────────────────────────
+
+  server.registerTool(
+    'docs_batch_update',
+    {
+      description: 'Generic documents.batchUpdate pass-through. Accepts the full Request union (40 types). See https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/request',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        documentId: z.string().describe('Google Docs document ID'),
+        requests: z.array(z.record(z.string(), z.any())).describe('Array of Request objects, each with one request-type key'),
+        writeControl: z.object({
+          requiredRevisionId: z.string().optional(),
+          targetRevisionId: z.string().optional(),
+        }).optional().describe('Optional optimistic concurrency control'),
+      },
+    },
+    async ({ account, documentId, requests, writeControl }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const docs = google.docs({ version: 'v1', auth });
+        const res = await docs.documents.batchUpdate({
+          documentId,
+          requestBody: {
+            requests: requests as any,
+            writeControl,
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({
+            documentId: res.data.documentId,
+            replies: res.data.replies ?? [],
+          }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDocsError(error, account as Account);
+      }
+    },
+  );
+}
+
+// ─── Helpers (exported for unit tests) ───────────────────────────────────
+
+export function buildParagraphStyle(input: {
+  namedStyleType?: string;
+  alignment?: string;
+  lineSpacing?: number;
+  spaceAbove?: number;
+  spaceBelow?: number;
+  indentStart?: number;
+  indentEnd?: number;
+  indentFirstLine?: number;
+  direction?: string;
+  keepLinesTogether?: boolean;
+  keepWithNext?: boolean;
+  avoidWidowAndOrphan?: boolean;
+}): { paragraphStyle: any; fields: string } {
+  const ps: any = {};
+  const fields: string[] = [];
+  if (input.namedStyleType) { ps.namedStyleType = input.namedStyleType; fields.push('namedStyleType'); }
+  if (input.alignment) { ps.alignment = input.alignment; fields.push('alignment'); }
+  if (input.lineSpacing !== undefined) { ps.lineSpacing = input.lineSpacing; fields.push('lineSpacing'); }
+  if (input.spaceAbove !== undefined) { ps.spaceAbove = { magnitude: input.spaceAbove, unit: 'PT' }; fields.push('spaceAbove'); }
+  if (input.spaceBelow !== undefined) { ps.spaceBelow = { magnitude: input.spaceBelow, unit: 'PT' }; fields.push('spaceBelow'); }
+  if (input.indentStart !== undefined) { ps.indentStart = { magnitude: input.indentStart, unit: 'PT' }; fields.push('indentStart'); }
+  if (input.indentEnd !== undefined) { ps.indentEnd = { magnitude: input.indentEnd, unit: 'PT' }; fields.push('indentEnd'); }
+  if (input.indentFirstLine !== undefined) { ps.indentFirstLine = { magnitude: input.indentFirstLine, unit: 'PT' }; fields.push('indentFirstLine'); }
+  if (input.direction) { ps.direction = input.direction; fields.push('direction'); }
+  if (input.keepLinesTogether !== undefined) { ps.keepLinesTogether = input.keepLinesTogether; fields.push('keepLinesTogether'); }
+  if (input.keepWithNext !== undefined) { ps.keepWithNext = input.keepWithNext; fields.push('keepWithNext'); }
+  if (input.avoidWidowAndOrphan !== undefined) { ps.avoidWidowAndOrphan = input.avoidWidowAndOrphan; fields.push('avoidWidowAndOrphan'); }
+  return { paragraphStyle: ps, fields: fields.join(',') };
+}
+
+export function buildDocumentStyle(input: {
+  pageWidth?: number;
+  pageHeight?: number;
+  marginTop?: number;
+  marginBottom?: number;
+  marginLeft?: number;
+  marginRight?: number;
+  marginHeader?: number;
+  marginFooter?: number;
+  pageNumberStart?: number;
+  useFirstPageHeaderFooter?: boolean;
+  useEvenPageHeaderFooter?: boolean;
+  useCustomHeaderFooterMargins?: boolean;
+}): { documentStyle: any; fields: string } {
+  const ds: any = {};
+  const fields: string[] = [];
+  const dim = (m: number) => ({ magnitude: m, unit: 'PT' });
+
+  if (input.pageWidth !== undefined || input.pageHeight !== undefined) {
+    ds.pageSize = {};
+    if (input.pageWidth !== undefined) ds.pageSize.width = dim(input.pageWidth);
+    if (input.pageHeight !== undefined) ds.pageSize.height = dim(input.pageHeight);
+    fields.push('pageSize');
+  }
+  if (input.marginTop !== undefined) { ds.marginTop = dim(input.marginTop); fields.push('marginTop'); }
+  if (input.marginBottom !== undefined) { ds.marginBottom = dim(input.marginBottom); fields.push('marginBottom'); }
+  if (input.marginLeft !== undefined) { ds.marginLeft = dim(input.marginLeft); fields.push('marginLeft'); }
+  if (input.marginRight !== undefined) { ds.marginRight = dim(input.marginRight); fields.push('marginRight'); }
+  if (input.marginHeader !== undefined) { ds.marginHeader = dim(input.marginHeader); fields.push('marginHeader'); }
+  if (input.marginFooter !== undefined) { ds.marginFooter = dim(input.marginFooter); fields.push('marginFooter'); }
+  if (input.pageNumberStart !== undefined) { ds.pageNumberStart = input.pageNumberStart; fields.push('pageNumberStart'); }
+  if (input.useFirstPageHeaderFooter !== undefined) { ds.useFirstPageHeaderFooter = input.useFirstPageHeaderFooter; fields.push('useFirstPageHeaderFooter'); }
+  if (input.useEvenPageHeaderFooter !== undefined) { ds.useEvenPageHeaderFooter = input.useEvenPageHeaderFooter; fields.push('useEvenPageHeaderFooter'); }
+  if (input.useCustomHeaderFooterMargins !== undefined) { ds.useCustomHeaderFooterMargins = input.useCustomHeaderFooterMargins; fields.push('useCustomHeaderFooterMargins'); }
+
+  return { documentStyle: ds, fields: fields.join(',') };
 }
 
 function handleDocsError(error: any, account: Account) {
-  if (error.code === 401) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: `Authentication error for account "${account}". Run: node dist/index.js auth --account ${account}`,
-      }],
-      isError: true,
-    };
-  }
-  if (error.code === 429) {
-    const retryAfter = error.response?.headers?.['retry-after'] ?? 'unknown';
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({ error: 'rate_limited', retryAfter }),
-      }],
-      isError: true,
-    };
-  }
-  return {
-    content: [{
-      type: 'text' as const,
-      text: JSON.stringify({ error: error.message ?? String(error), code: error.code }),
-    }],
-    isError: true,
-  };
+  return handleGoogleApiError(error, account);
 }

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -4,8 +4,10 @@ import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
 import * as fs from 'fs';
 import * as path from 'path';
+import { pipeline } from 'node:stream/promises';
 import mime from 'mime-types';
 
 const accountEnum = z.enum(ACCOUNTS);
@@ -19,8 +21,17 @@ const GOOGLE_WORKSPACE_TYPES = new Set([
   'application/vnd.google-apps.drawing',
 ]);
 
+// Comment/Reply fields list — Drive API requires explicit `fields` on every call.
+const COMMENT_BASE_FIELDS = 'id,kind,content,htmlContent,createdTime,modifiedTime,resolved,anchor,author,deleted,quotedFileContent';
+const REPLY_SUBFIELDS = 'id,content,action,createdTime,modifiedTime,author,deleted';
+const COMMENT_FIELDS = `${COMMENT_BASE_FIELDS},replies(${REPLY_SUBFIELDS})`;
+const COMMENT_LIST_FIELDS = `nextPageToken,comments(${COMMENT_BASE_FIELDS},replies(${REPLY_SUBFIELDS}))`;
+const REPLY_FIELDS = `kind,htmlContent,${REPLY_SUBFIELDS}`;
+const REPLY_LIST_FIELDS = `nextPageToken,replies(${REPLY_FIELDS})`;
+
 export function registerDriveTools(server: McpServer): void {
-  // 10.1 drive_search
+  // ─── Read / search / list ──────────────────────────────────────────────
+
   server.registerTool(
     'drive_search',
     {
@@ -41,13 +52,13 @@ export function registerDriveTools(server: McpServer): void {
         const params: any = {
           q: query,
           pageSize: maxResults ?? 20,
-          fields: 'files(id,name,mimeType,modifiedTime,webViewLink,size)',
+          fields: 'files(id,name,mimeType,modifiedTime,webViewLink,size,parents,driveId)',
+          supportsAllDrives: true,
+          includeItemsFromAllDrives: true,
         };
 
         if (driveId) {
           params.driveId = driveId;
-          params.includeItemsFromAllDrives = true;
-          params.supportsAllDrives = true;
           params.corpora = 'drive';
         }
 
@@ -61,7 +72,6 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // 10.2 drive_read
   server.registerTool(
     'drive_read',
     {
@@ -76,15 +86,14 @@ export function registerDriveTools(server: McpServer): void {
         const auth = await getClient(account as Account);
         const drive = google.drive({ version: 'v3', auth });
 
-        // Get file metadata first
         const meta = await drive.files.get({
           fileId,
           fields: 'id,name,mimeType,size,webViewLink',
+          supportsAllDrives: true,
         });
 
         const { name, mimeType, size, webViewLink } = meta.data;
 
-        // Google Workspace types — export as plain text
         if (mimeType && GOOGLE_WORKSPACE_TYPES.has(mimeType)) {
           const exported = await drive.files.export({
             fileId,
@@ -103,7 +112,6 @@ export function registerDriveTools(server: McpServer): void {
           };
         }
 
-        // PDF — can't export directly
         if (mimeType === 'application/pdf') {
           return {
             content: [{
@@ -119,7 +127,6 @@ export function registerDriveTools(server: McpServer): void {
           };
         }
 
-        // Check size limit
         const fileSize = parseInt(size ?? '0', 10);
         if (fileSize > MAX_FILE_SIZE) {
           return {
@@ -136,10 +143,9 @@ export function registerDriveTools(server: McpServer): void {
           };
         }
 
-        // Text files — download and return content
         if (mimeType?.startsWith('text/')) {
           const downloaded = await drive.files.get(
-            { fileId, alt: 'media' },
+            { fileId, alt: 'media', supportsAllDrives: true },
             { responseType: 'text' },
           );
           return {
@@ -155,7 +161,6 @@ export function registerDriveTools(server: McpServer): void {
           };
         }
 
-        // Other binary files
         return {
           content: [{
             type: 'text' as const,
@@ -174,7 +179,6 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // 10.3 drive_list
   server.registerTool(
     'drive_list',
     {
@@ -191,11 +195,14 @@ export function registerDriveTools(server: McpServer): void {
         const auth = await getClient(account as Account);
         const drive = google.drive({ version: 'v3', auth });
 
-        const parent = folderId ?? 'root';
+        // Escape single quotes per Drive query syntax to prevent breaking out of the literal.
+        const parent = (folderId ?? 'root').replace(/\\/g, '\\\\').replace(/'/g, "\\'");
         const res = await drive.files.list({
           q: `'${parent}' in parents and trashed = false`,
           pageSize: maxResults ?? 50,
-          fields: 'files(id,name,mimeType,modifiedTime,webViewLink,size)',
+          fields: 'files(id,name,mimeType,modifiedTime,webViewLink,size,parents)',
+          supportsAllDrives: true,
+          includeItemsFromAllDrives: true,
         });
 
         return {
@@ -207,9 +214,8 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // --- New tools below ---
+  // ─── Write / upload / download ─────────────────────────────────────────
 
-  // drive_upload
   server.registerTool(
     'drive_upload',
     {
@@ -240,6 +246,7 @@ export function registerDriveTools(server: McpServer): void {
             body: fileStream,
           },
           fields: 'id,name,mimeType,webViewLink,size',
+          supportsAllDrives: true,
         });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
@@ -250,7 +257,6 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_download
   server.registerTool(
     'drive_download',
     {
@@ -267,19 +273,14 @@ export function registerDriveTools(server: McpServer): void {
         const auth = await getClient(account as Account);
         const drive = google.drive({ version: 'v3', auth });
 
-        // Strip path components so callers can't escape savePath via "../".
         const dest = path.join(savePath, path.basename(filename));
         const res = await drive.files.get(
-          { fileId, alt: 'media' },
+          { fileId, alt: 'media', supportsAllDrives: true },
           { responseType: 'stream' },
         );
 
-        await new Promise<void>((resolve, reject) => {
-          const writer = fs.createWriteStream(dest);
-          (res.data as NodeJS.ReadableStream).pipe(writer);
-          writer.on('finish', resolve);
-          writer.on('error', reject);
-        });
+        // pipeline destroys both streams on source/sink error; raw .pipe leaks the partial file.
+        await pipeline(res.data as NodeJS.ReadableStream, fs.createWriteStream(dest));
 
         const { size } = fs.statSync(dest);
         return {
@@ -291,7 +292,6 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_export
   server.registerTool(
     'drive_export',
     {
@@ -309,19 +309,14 @@ export function registerDriveTools(server: McpServer): void {
         const auth = await getClient(account as Account);
         const drive = google.drive({ version: 'v3', auth });
 
-        // Strip path components so callers can't escape savePath via "../".
         const dest = path.join(savePath, path.basename(filename));
         const res = await drive.files.export(
           { fileId, mimeType: exportMime },
           { responseType: 'stream' },
         );
 
-        await new Promise<void>((resolve, reject) => {
-          const writer = fs.createWriteStream(dest);
-          (res.data as NodeJS.ReadableStream).pipe(writer);
-          writer.on('finish', resolve);
-          writer.on('error', reject);
-        });
+        // pipeline destroys both streams on source/sink error; raw .pipe leaks the partial file.
+        await pipeline(res.data as NodeJS.ReadableStream, fs.createWriteStream(dest));
 
         const { size } = fs.statSync(dest);
         return {
@@ -333,7 +328,6 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_create_folder
   server.registerTool(
     'drive_create_folder',
     {
@@ -355,6 +349,7 @@ export function registerDriveTools(server: McpServer): void {
             parents: parentFolderId ? [parentFolderId] : undefined,
           },
           fields: 'id,name,webViewLink',
+          supportsAllDrives: true,
         });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
@@ -365,11 +360,10 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_update
   server.registerTool(
     'drive_update',
     {
-      description: 'Rename, move, or replace content of a Drive file. Any combination in one call.',
+      description: 'Rename, move, or replace content of a Drive file. Any combination in one call. For untrash, use drive_untrash.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
@@ -391,10 +385,11 @@ export function registerDriveTools(server: McpServer): void {
           fileId,
           requestBody,
           fields: 'id,name,parents,modifiedTime',
+          supportsAllDrives: true,
         };
 
         if (newParentFolderId) {
-          const current = await drive.files.get({ fileId, fields: 'parents' });
+          const current = await drive.files.get({ fileId, fields: 'parents', supportsAllDrives: true });
           params.removeParents = (current.data.parents ?? []).join(',');
           params.addParents = newParentFolderId;
         }
@@ -416,7 +411,8 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_delete
+  // ─── Trash / delete ────────────────────────────────────────────────────
+
   server.registerTool(
     'drive_delete',
     {
@@ -430,7 +426,7 @@ export function registerDriveTools(server: McpServer): void {
       try {
         const auth = await getClient(account as Account);
         const drive = google.drive({ version: 'v3', auth });
-        await drive.files.delete({ fileId });
+        await drive.files.delete({ fileId, supportsAllDrives: true });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, fileId }, null, 2) }],
         };
@@ -440,11 +436,10 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_trash
   server.registerTool(
     'drive_trash',
     {
-      description: 'Move a file to Google Drive trash. Recoverable from Drive UI.',
+      description: 'Move a file to Google Drive trash. Recoverable from Drive UI or via drive_untrash.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
@@ -457,6 +452,7 @@ export function registerDriveTools(server: McpServer): void {
         await drive.files.update({
           fileId,
           requestBody: { trashed: true },
+          supportsAllDrives: true,
         });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ trashed: true, fileId }, null, 2) }],
@@ -467,7 +463,58 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_copy
+  server.registerTool(
+    'drive_untrash',
+    {
+      description: 'Restore a trashed file from Google Drive trash back to its previous location.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+      },
+    },
+    async ({ account, fileId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const res = await drive.files.update({
+          fileId,
+          requestBody: { trashed: false },
+          fields: 'id,name,trashed,parents',
+          supportsAllDrives: true,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_empty_trash',
+    {
+      description: 'Permanently delete every file currently in the account\'s trash. Irreversible.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+      },
+    },
+    async ({ account }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        await drive.files.emptyTrash({});
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ emptied: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Copy / move ───────────────────────────────────────────────────────
+
   server.registerTool(
     'drive_copy',
     {
@@ -490,6 +537,7 @@ export function registerDriveTools(server: McpServer): void {
             parents: parentFolderId ? [parentFolderId] : undefined,
           },
           fields: 'id,name,webViewLink',
+          supportsAllDrives: true,
         });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
@@ -500,7 +548,39 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_share
+  server.registerTool(
+    'drive_move',
+    {
+      description: 'Move a file between folders by replacing its parents. To move to multiple parents, list all of them.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        newParentFolderId: z.string().describe('Destination folder ID'),
+      },
+    },
+    async ({ account, fileId, newParentFolderId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const current = await drive.files.get({ fileId, fields: 'parents', supportsAllDrives: true });
+        const res = await drive.files.update({
+          fileId,
+          addParents: newParentFolderId,
+          removeParents: (current.data.parents ?? []).join(','),
+          fields: 'id,name,parents,modifiedTime',
+          supportsAllDrives: true,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Permissions / sharing ─────────────────────────────────────────────
+
   server.registerTool(
     'drive_share',
     {
@@ -509,28 +589,30 @@ export function registerDriveTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
         type: z.enum(['user', 'group', 'domain', 'anyone']).describe('Permission type'),
-        role: z.enum(['reader', 'commenter', 'writer', 'owner']).describe('Permission role'),
+        role: z.enum(['reader', 'commenter', 'writer', 'fileOrganizer', 'organizer', 'owner']).describe('Permission role'),
         emailAddress: z.string().optional().describe('Required when type is "user" or "group"'),
         domain: z.string().optional().describe('Required when type is "domain"'),
         sendNotification: z.boolean().optional().describe('Send notification email (default: true)'),
         emailMessage: z.string().optional().describe('Custom message in notification email'),
+        transferOwnership: z.boolean().optional().describe('Transfer ownership to the recipient. Requires role="owner". Recipient must accept ownership.'),
+        expirationTime: z.string().optional().describe('RFC 3339 timestamp when access expires. Only valid for role="reader" or "commenter".'),
       },
     },
-    async ({ account, fileId, type, role, emailAddress, domain, sendNotification, emailMessage }) => {
+    async ({ account, fileId, type, role, emailAddress, domain, sendNotification, emailMessage, transferOwnership, expirationTime }) => {
       try {
         const auth = await getClient(account as Account);
         const drive = google.drive({ version: 'v3', auth });
+        const requestBody: any = { type, role, emailAddress, domain };
+        if (expirationTime) requestBody.expirationTime = expirationTime;
+
         const res = await drive.permissions.create({
           fileId,
           sendNotificationEmail: sendNotification ?? true,
           emailMessage,
-          requestBody: {
-            type,
-            role,
-            emailAddress,
-            domain,
-          },
-          fields: 'id,type,role,emailAddress',
+          transferOwnership: transferOwnership ?? false,
+          supportsAllDrives: true,
+          requestBody,
+          fields: 'id,type,role,emailAddress,domain,expirationTime',
         });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
@@ -541,7 +623,6 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_list_permissions
   server.registerTool(
     'drive_list_permissions',
     {
@@ -557,7 +638,8 @@ export function registerDriveTools(server: McpServer): void {
         const drive = google.drive({ version: 'v3', auth });
         const res = await drive.permissions.list({
           fileId,
-          fields: 'permissions(id,type,role,emailAddress,displayName)',
+          fields: 'permissions(id,type,role,emailAddress,domain,displayName,expirationTime)',
+          supportsAllDrives: true,
         });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(res.data.permissions ?? [], null, 2) }],
@@ -568,7 +650,50 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_remove_permission
+  server.registerTool(
+    'drive_permission_update',
+    {
+      description: 'Change the role and/or expirationTime of an existing permission without removing it. Use "removeExpiration=true" to clear an existing expirationTime.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        permissionId: z.string().describe('Permission ID from drive_list_permissions'),
+        role: z.enum(['reader', 'commenter', 'writer', 'fileOrganizer', 'organizer', 'owner']).optional()
+          .describe('New role'),
+        expirationTime: z.string().optional()
+          .describe('New RFC 3339 expiration timestamp. Only valid for role "reader" or "commenter".'),
+        removeExpiration: z.boolean().optional()
+          .describe('Clear the existing expirationTime'),
+        transferOwnership: z.boolean().optional()
+          .describe('Promote to owner. Requires role="owner".'),
+      },
+    },
+    async ({ account, fileId, permissionId, role, expirationTime, removeExpiration, transferOwnership }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const requestBody: any = {};
+        if (role) requestBody.role = role;
+        if (expirationTime) requestBody.expirationTime = expirationTime;
+
+        const res = await drive.permissions.update({
+          fileId,
+          permissionId,
+          requestBody,
+          removeExpiration: removeExpiration ?? false,
+          transferOwnership: transferOwnership ?? false,
+          supportsAllDrives: true,
+          fields: 'id,type,role,emailAddress,expirationTime',
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
   server.registerTool(
     'drive_remove_permission',
     {
@@ -583,7 +708,7 @@ export function registerDriveTools(server: McpServer): void {
       try {
         const auth = await getClient(account as Account);
         const drive = google.drive({ version: 'v3', auth });
-        await drive.permissions.delete({ fileId, permissionId });
+        await drive.permissions.delete({ fileId, permissionId, supportsAllDrives: true });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({ removed: true, permissionId }, null, 2) }],
         };
@@ -593,7 +718,516 @@ export function registerDriveTools(server: McpServer): void {
     },
   );
 
-  // drive_get_about
+  // ─── Comments ──────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'drive_comment_create',
+    {
+      description: 'Create a comment on a Drive file. Works on Docs, Sheets, Slides, PDFs, and any Drive file. The optional anchor is a JSON string describing the document region (see Drive "Manage comments" guide).',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        content: z.string().describe('Plain text comment content'),
+        anchor: z.string().optional().describe('Region anchor (JSON string). Optional.'),
+        quotedFileContent: z.object({
+          mimeType: z.string(),
+          value: z.string(),
+        }).optional().describe('Optional reference to quoted file content'),
+      },
+    },
+    async ({ account, fileId, content, anchor, quotedFileContent }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const requestBody: any = { content };
+        if (anchor) requestBody.anchor = anchor;
+        if (quotedFileContent) requestBody.quotedFileContent = quotedFileContent;
+
+        const res = await drive.comments.create({
+          fileId,
+          requestBody,
+          fields: COMMENT_FIELDS,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_comment_list',
+    {
+      description: 'List comments on a Drive file with pagination',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        includeDeleted: z.boolean().optional().describe('Include deleted comments (default: false)'),
+        pageSize: z.number().min(1).max(100).optional().describe('Max comments per page (default: 20)'),
+        pageToken: z.string().optional().describe('Token from a previous page'),
+        startModifiedTime: z.string().optional().describe('Only return comments modified after this RFC 3339 timestamp'),
+      },
+    },
+    async ({ account, fileId, includeDeleted, pageSize, pageToken, startModifiedTime }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const res = await drive.comments.list({
+          fileId,
+          includeDeleted: includeDeleted ?? false,
+          pageSize: pageSize ?? 20,
+          pageToken,
+          startModifiedTime,
+          fields: COMMENT_LIST_FIELDS,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_comment_get',
+    {
+      description: 'Get a single comment by ID',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        commentId: z.string().describe('Comment ID'),
+        includeDeleted: z.boolean().optional(),
+      },
+    },
+    async ({ account, fileId, commentId, includeDeleted }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const res = await drive.comments.get({
+          fileId,
+          commentId,
+          includeDeleted: includeDeleted ?? false,
+          fields: COMMENT_FIELDS,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_comment_update',
+    {
+      description: 'Edit the content of an existing comment (PATCH semantics)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        commentId: z.string().describe('Comment ID'),
+        content: z.string().describe('New plain text content'),
+      },
+    },
+    async ({ account, fileId, commentId, content }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const res = await drive.comments.update({
+          fileId,
+          commentId,
+          requestBody: { content },
+          fields: COMMENT_FIELDS,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_comment_delete',
+    {
+      description: 'Delete a comment from a Drive file',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        commentId: z.string().describe('Comment ID'),
+      },
+    },
+    async ({ account, fileId, commentId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        await drive.comments.delete({ fileId, commentId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, commentId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Replies ───────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'drive_reply_create',
+    {
+      description: 'Reply to a comment. Optionally close or reopen the thread by setting action to "resolve" or "reopen".',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        commentId: z.string().describe('Parent comment ID'),
+        content: z.string().describe('Reply content (required even when only changing action)'),
+        action: z.enum(['resolve', 'reopen']).optional()
+          .describe('Optional action to apply to the thread on this reply'),
+      },
+    },
+    async ({ account, fileId, commentId, content, action }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const requestBody: any = { content };
+        if (action) requestBody.action = action;
+
+        const res = await drive.replies.create({
+          fileId,
+          commentId,
+          requestBody,
+          fields: REPLY_FIELDS,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_reply_list',
+    {
+      description: 'List replies on a comment with pagination',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        commentId: z.string().describe('Parent comment ID'),
+        includeDeleted: z.boolean().optional(),
+        pageSize: z.number().min(1).max(100).optional(),
+        pageToken: z.string().optional(),
+      },
+    },
+    async ({ account, fileId, commentId, includeDeleted, pageSize, pageToken }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const res = await drive.replies.list({
+          fileId,
+          commentId,
+          includeDeleted: includeDeleted ?? false,
+          pageSize: pageSize ?? 20,
+          pageToken,
+          fields: REPLY_LIST_FIELDS,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_reply_update',
+    {
+      description: 'Edit the content of an existing reply',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        commentId: z.string().describe('Parent comment ID'),
+        replyId: z.string().describe('Reply ID'),
+        content: z.string().describe('New plain text content'),
+      },
+    },
+    async ({ account, fileId, commentId, replyId, content }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const res = await drive.replies.update({
+          fileId,
+          commentId,
+          replyId,
+          requestBody: { content },
+          fields: REPLY_FIELDS,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_reply_delete',
+    {
+      description: 'Delete a reply from a comment thread',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        commentId: z.string().describe('Parent comment ID'),
+        replyId: z.string().describe('Reply ID'),
+      },
+    },
+    async ({ account, fileId, commentId, replyId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        await drive.replies.delete({ fileId, commentId, replyId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, replyId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Revisions ─────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'drive_revision_list',
+    {
+      description: 'List version history of a Drive file',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        pageSize: z.number().min(1).max(200).optional(),
+        pageToken: z.string().optional(),
+      },
+    },
+    async ({ account, fileId, pageSize, pageToken }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const res = await drive.revisions.list({
+          fileId,
+          pageSize: pageSize ?? 50,
+          pageToken,
+          fields: 'nextPageToken,revisions(id,mimeType,modifiedTime,keepForever,published,lastModifyingUser,size)',
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_revision_update',
+    {
+      description: 'Pin a revision (keepForever=true) against the 200-version cap, or change its published state for Docs.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        revisionId: z.string().describe('Revision ID'),
+        keepForever: z.boolean().optional().describe('Pin this revision indefinitely'),
+        published: z.boolean().optional().describe('Toggle published state (Docs only)'),
+        publishAuto: z.boolean().optional().describe('Auto-publish subsequent revisions'),
+        publishedOutsideDomain: z.boolean().optional().describe('Allow publish outside domain'),
+      },
+    },
+    async ({ account, fileId, revisionId, keepForever, published, publishAuto, publishedOutsideDomain }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const requestBody: any = {};
+        if (keepForever !== undefined) requestBody.keepForever = keepForever;
+        if (published !== undefined) requestBody.published = published;
+        if (publishAuto !== undefined) requestBody.publishAuto = publishAuto;
+        if (publishedOutsideDomain !== undefined) requestBody.publishedOutsideDomain = publishedOutsideDomain;
+
+        const res = await drive.revisions.update({
+          fileId,
+          revisionId,
+          requestBody,
+          fields: 'id,modifiedTime,keepForever,published',
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_revision_delete',
+    {
+      description: 'Delete a specific revision of a file',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        revisionId: z.string().describe('Revision ID'),
+      },
+    },
+    async ({ account, fileId, revisionId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        await drive.revisions.delete({ fileId, revisionId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, revisionId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Access proposals ──────────────────────────────────────────────────
+
+  server.registerTool(
+    'drive_access_proposal_list',
+    {
+      description: 'List pending "Request access" proposals on a file. Useful for programmatic triage of share requests from external collaborators.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        pageSize: z.number().min(1).max(100).optional(),
+        pageToken: z.string().optional(),
+      },
+    },
+    async ({ account, fileId, pageSize, pageToken }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const res = await drive.accessproposals.list({
+          fileId,
+          pageSize: pageSize ?? 20,
+          pageToken,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_access_proposal_resolve',
+    {
+      description: 'Resolve a pending access proposal. Action ACCEPT requires a role array (e.g. ["reader"]).',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        fileId: z.string().describe('Google Drive file ID'),
+        proposalId: z.string().describe('Access proposal ID'),
+        action: z.enum(['ACCEPT', 'DENY']).describe('Whether to accept or deny the proposal'),
+        role: z.array(z.enum(['reader', 'commenter', 'writer', 'fileOrganizer'])).optional()
+          .describe('Required when action is ACCEPT'),
+        view: z.string().optional().describe('Optional view, e.g. "published"'),
+        sendNotification: z.boolean().optional()
+          .describe('Email the requester about the resolution'),
+      },
+    },
+    async ({ account, fileId, proposalId, action, role, view, sendNotification }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const requestBody: any = { action };
+        if (role) requestBody.role = role;
+        if (view) requestBody.view = view;
+        if (sendNotification !== undefined) requestBody.sendNotification = sendNotification;
+
+        await drive.accessproposals.resolve({
+          fileId,
+          proposalId,
+          requestBody,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ resolved: true, proposalId, action }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Shared drives ─────────────────────────────────────────────────────
+
+  server.registerTool(
+    'drive_shared_drives_list',
+    {
+      description: 'List shared drives the account has access to',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        pageSize: z.number().min(1).max(100).optional(),
+        pageToken: z.string().optional(),
+        q: z.string().optional().describe('Optional filter expression'),
+      },
+    },
+    async ({ account, pageSize, pageToken, q }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const res = await drive.drives.list({
+          pageSize: pageSize ?? 50,
+          pageToken,
+          q,
+          fields: 'nextPageToken,drives(id,name,colorRgb,createdTime,hidden)',
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'drive_shared_drive_get',
+    {
+      description: 'Get metadata for a specific shared drive',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        driveId: z.string().describe('Shared drive ID'),
+      },
+    },
+    async ({ account, driveId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const drive = google.drive({ version: 'v3', auth });
+        const res = await drive.drives.get({
+          driveId,
+          fields: 'id,name,colorRgb,createdTime,hidden,capabilities,restrictions',
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleDriveError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── About ─────────────────────────────────────────────────────────────
+
   server.registerTool(
     'drive_get_about',
     {
@@ -620,30 +1254,5 @@ export function registerDriveTools(server: McpServer): void {
 }
 
 function handleDriveError(error: any, account: Account) {
-  if (error.code === 401) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: `Authentication error for account "${account}". Run: node dist/index.js auth --account ${account}`,
-      }],
-      isError: true,
-    };
-  }
-  if (error.code === 429) {
-    const retryAfter = error.response?.headers?.['retry-after'] ?? 'unknown';
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({ error: 'rate_limited', retryAfter }),
-      }],
-      isError: true,
-    };
-  }
-  return {
-    content: [{
-      type: 'text' as const,
-      text: JSON.stringify({ error: error.message ?? String(error), code: error.code }),
-    }],
-    isError: true,
-  };
+  return handleGoogleApiError(error, account);
 }

--- a/src/tools/forms.ts
+++ b/src/tools/forms.ts
@@ -1,0 +1,116 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { ACCOUNTS } from '../accounts.js';
+import type { Account } from '../accounts.js';
+import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
+
+const accountEnum = z.enum(ACCOUNTS);
+
+export function registerFormsTools(server: McpServer): void {
+  server.registerTool(
+    'forms_get',
+    {
+      description: 'Get a Google Form (definition: questions, sections, settings). Requires forms.body scope.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        formId: z.string().describe('Form ID'),
+      },
+    },
+    async ({ account, formId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const forms = google.forms({ version: 'v1', auth });
+        const res = await forms.forms.get({ formId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleFormsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'forms_responses_list',
+    {
+      description: 'List form responses. Requires forms.responses.readonly scope.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        formId: z.string().describe('Form ID'),
+        pageSize: z.number().min(1).max(1000).optional().describe('Default: 100; max 1000. Responses can be large.'),
+        pageToken: z.string().optional(),
+        filter: z.string().optional().describe('Filter expression (e.g. "timestamp > 2026-01-01T00:00:00Z")'),
+      },
+    },
+    async ({ account, formId, pageSize, pageToken, filter }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const forms = google.forms({ version: 'v1', auth });
+        const res = await forms.forms.responses.list({
+          formId,
+          pageSize: pageSize ?? 100,
+          pageToken,
+          filter,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleFormsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'forms_response_get',
+    {
+      description: 'Get a single form response by ID',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        formId: z.string().describe('Form ID'),
+        responseId: z.string().describe('Response ID'),
+      },
+    },
+    async ({ account, formId, responseId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const forms = google.forms({ version: 'v1', auth });
+        const res = await forms.forms.responses.get({ formId, responseId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleFormsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'forms_watches_list',
+    {
+      description: 'List Pub/Sub watches on a form (notifications for new responses or schema changes)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        formId: z.string().describe('Form ID'),
+      },
+    },
+    async ({ account, formId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const forms = google.forms({ version: 'v1', auth });
+        const res = await forms.forms.watches.list({ formId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleFormsError(error, account as Account);
+      }
+    },
+  );
+}
+
+function handleFormsError(error: any, account: Account) {
+  return handleGoogleApiError(error, account, "Forms tools require the optional \"forms\" scope bundle. Add GOOGLE_OPTIONAL_SCOPES=forms (or include \"forms\" in the list) and re-auth.");
+}

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -4,6 +4,7 @@ import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
 import { encodeAddressHeader, encodeHeaderValue, normalizeBodyLineEndings } from './gmail-mime.js';
 import type { GmailMessageHeader, GmailMessageFull, GmailAttachment } from '../types.js';
 import * as path from 'path';
@@ -21,25 +22,20 @@ function getHeader(
 function decodeBody(
   payload: any,
 ): string {
-  // Try direct body
   if (payload.body?.data) {
     return Buffer.from(payload.body.data, 'base64url').toString('utf-8');
   }
-
-  // Recurse into parts — prefer text/plain
   if (payload.parts) {
     for (const part of payload.parts) {
       if (part.mimeType === 'text/plain' && part.body?.data) {
         return Buffer.from(part.body.data, 'base64url').toString('utf-8');
       }
     }
-    // Fallback to text/html
     for (const part of payload.parts) {
       if (part.mimeType === 'text/html' && part.body?.data) {
         return Buffer.from(part.body.data, 'base64url').toString('utf-8');
       }
     }
-    // Recurse into nested multipart
     for (const part of payload.parts) {
       if (part.parts) {
         const result = decodeBody(part);
@@ -84,7 +80,6 @@ function parseMessage(msg: any): GmailMessageFull {
 }
 
 export function registerGmailTools(server: McpServer): void {
-  // 9.1 gmail_search
   server.registerTool(
     'gmail_search',
     {
@@ -135,8 +130,6 @@ export function registerGmailTools(server: McpServer): void {
       }
     },
   );
-
-  // 9.2 gmail_read
   server.registerTool(
     'gmail_read',
     {
@@ -166,8 +159,6 @@ export function registerGmailTools(server: McpServer): void {
       }
     },
   );
-
-  // 9.3 gmail_read_thread
   server.registerTool(
     'gmail_read_thread',
     {
@@ -197,8 +188,6 @@ export function registerGmailTools(server: McpServer): void {
       }
     },
   );
-
-  // 9.4 gmail_send
   server.registerTool(
     'gmail_send',
     {
@@ -261,8 +250,6 @@ export function registerGmailTools(server: McpServer): void {
       }
     },
   );
-
-  // 9.5 gmail_download_attachment
   server.registerTool(
     'gmail_download_attachment',
     {
@@ -302,8 +289,6 @@ export function registerGmailTools(server: McpServer): void {
       }
     },
   );
-
-  // 9.6 gmail_create_draft
   server.registerTool(
     'gmail_create_draft',
     {
@@ -367,9 +352,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // --- New tools below ---
-
-  // gmail_modify_labels
   server.registerTool(
     'gmail_modify_labels',
     {
@@ -402,7 +384,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_trash
   server.registerTool(
     'gmail_trash',
     {
@@ -426,7 +407,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_delete
   server.registerTool(
     'gmail_delete',
     {
@@ -450,7 +430,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_batch_modify
   server.registerTool(
     'gmail_batch_modify',
     {
@@ -483,7 +462,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_batch_delete
   server.registerTool(
     'gmail_batch_delete',
     {
@@ -510,7 +488,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_list_drafts
   server.registerTool(
     'gmail_list_drafts',
     {
@@ -540,7 +517,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_get_draft
   server.registerTool(
     'gmail_get_draft',
     {
@@ -568,7 +544,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_send_draft
   server.registerTool(
     'gmail_send_draft',
     {
@@ -595,7 +570,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_list_labels
   server.registerTool(
     'gmail_list_labels',
     {
@@ -618,7 +592,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_create_label
   server.registerTool(
     'gmail_create_label',
     {
@@ -653,7 +626,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_delete_label
   server.registerTool(
     'gmail_delete_label',
     {
@@ -677,7 +649,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_get_profile
   server.registerTool(
     'gmail_get_profile',
     {
@@ -700,7 +671,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_list_history
   server.registerTool(
     'gmail_list_history',
     {
@@ -733,7 +703,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_get_vacation
   server.registerTool(
     'gmail_get_vacation',
     {
@@ -756,7 +725,6 @@ export function registerGmailTools(server: McpServer): void {
     },
   );
 
-  // gmail_set_vacation
   server.registerTool(
     'gmail_set_vacation',
     {
@@ -799,30 +767,5 @@ export function registerGmailTools(server: McpServer): void {
 }
 
 function handleGmailError(error: any, account: Account) {
-  if (error.code === 401) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: `Authentication error for account "${account}". Run: node dist/index.js auth --account ${account}`,
-      }],
-      isError: true,
-    };
-  }
-  if (error.code === 429) {
-    const retryAfter = error.response?.headers?.['retry-after'] ?? 'unknown';
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({ error: 'rate_limited', retryAfter }),
-      }],
-      isError: true,
-    };
-  }
-  return {
-    content: [{
-      type: 'text' as const,
-      text: JSON.stringify({ error: error.message ?? String(error), code: error.code }),
-    }],
-    isError: true,
-  };
+  return handleGoogleApiError(error, account);
 }

--- a/src/tools/meet.ts
+++ b/src/tools/meet.ts
@@ -1,0 +1,160 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { ACCOUNTS } from '../accounts.js';
+import type { Account } from '../accounts.js';
+import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
+
+const accountEnum = z.enum(ACCOUNTS);
+
+export function registerMeetTools(server: McpServer): void {
+  // ─── Conference records (past meetings) ────────────────────────────────
+
+  server.registerTool(
+    'meet_conference_records_list',
+    {
+      description: 'List past conference records (completed Meet sessions) the user has access to',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        pageSize: z.number().min(1).max(100).optional(),
+        pageToken: z.string().optional(),
+        filter: z.string().optional().describe('Filter expression, e.g. "space.meeting_code=abc-defg-hij"'),
+      },
+    },
+    async ({ account, pageSize, pageToken, filter }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const meet = google.meet({ version: 'v2', auth });
+        const res = await meet.conferenceRecords.list({
+          pageSize: pageSize ?? 20,
+          pageToken,
+          filter,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleMeetError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'meet_conference_record_get',
+    {
+      description: 'Get a single conference record by resource name (e.g. conferenceRecords/abc123)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        name: z.string().describe('Resource name, format: conferenceRecords/{conference_record}'),
+      },
+    },
+    async ({ account, name }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const meet = google.meet({ version: 'v2', auth });
+        const res = await meet.conferenceRecords.get({ name });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleMeetError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Recordings ────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'meet_recordings_list',
+    {
+      description: 'List recordings within a conference record. Returns Drive file IDs that can be downloaded via drive_download.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        parent: z.string().describe('Parent conference record, format: conferenceRecords/{id}'),
+        pageSize: z.number().min(1).max(100).optional(),
+        pageToken: z.string().optional(),
+      },
+    },
+    async ({ account, parent, pageSize, pageToken }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const meet = google.meet({ version: 'v2', auth });
+        const res = await meet.conferenceRecords.recordings.list({
+          parent,
+          pageSize: pageSize ?? 20,
+          pageToken,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleMeetError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Transcripts ───────────────────────────────────────────────────────
+
+  server.registerTool(
+    'meet_transcripts_list',
+    {
+      description: 'List transcripts within a conference record',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        parent: z.string().describe('Parent conference record, format: conferenceRecords/{id}'),
+        pageSize: z.number().min(1).max(100).optional(),
+        pageToken: z.string().optional(),
+      },
+    },
+    async ({ account, parent, pageSize, pageToken }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const meet = google.meet({ version: 'v2', auth });
+        const res = await meet.conferenceRecords.transcripts.list({
+          parent,
+          pageSize: pageSize ?? 20,
+          pageToken,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleMeetError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'meet_transcript_entries_list',
+    {
+      description: 'List entries (per-speaker text segments) within a transcript. The actual transcript content.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        parent: z.string().describe('Parent transcript, format: conferenceRecords/{id}/transcripts/{id}'),
+        pageSize: z.number().min(1).max(1000).optional(),
+        pageToken: z.string().optional(),
+      },
+    },
+    async ({ account, parent, pageSize, pageToken }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const meet = google.meet({ version: 'v2', auth });
+        const res = await meet.conferenceRecords.transcripts.entries.list({
+          parent,
+          pageSize: pageSize ?? 200,
+          pageToken,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleMeetError(error, account as Account);
+      }
+    },
+  );
+}
+
+function handleMeetError(error: any, account: Account) {
+  return handleGoogleApiError(error, account, "Meet API requires the meetings.space.readonly scope and the Google Meet API enabled in Cloud Console. Confirm both for this account.");
+}

--- a/src/tools/searchconsole.ts
+++ b/src/tools/searchconsole.ts
@@ -4,6 +4,7 @@ import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
@@ -300,39 +301,5 @@ export function registerSearchConsoleTools(server: McpServer): void {
 }
 
 function handleSearchConsoleError(error: any, account: Account) {
-  if (error.code === 401) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: `Authentication error for account "${account}". The "webmasters" scope may be missing. Re-run: node dist/index.js auth --account ${account}`,
-      }],
-      isError: true,
-    };
-  }
-  if (error.code === 403) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: `Permission denied for account "${account}". Ensure the account has access to this Search Console property and the "webmasters" OAuth scope is granted.`,
-      }],
-      isError: true,
-    };
-  }
-  if (error.code === 429) {
-    const retryAfter = error.response?.headers?.['retry-after'] ?? 'unknown';
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({ error: 'rate_limited', retryAfter }),
-      }],
-      isError: true,
-    };
-  }
-  return {
-    content: [{
-      type: 'text' as const,
-      text: JSON.stringify({ error: error.message ?? String(error), code: error.code }),
-    }],
-    isError: true,
-  };
+  return handleGoogleApiError(error, account);
 }

--- a/src/tools/sheets.ts
+++ b/src/tools/sheets.ts
@@ -4,11 +4,11 @@ import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
 export function registerSheetsTools(server: McpServer): void {
-  // sheets_create
   server.registerTool(
     'sheets_create',
     {
@@ -50,7 +50,6 @@ export function registerSheetsTools(server: McpServer): void {
     },
   );
 
-  // sheets_get
   server.registerTool(
     'sheets_get',
     {
@@ -88,7 +87,6 @@ export function registerSheetsTools(server: McpServer): void {
     },
   );
 
-  // sheets_read_range
   server.registerTool(
     'sheets_read_range',
     {
@@ -123,7 +121,6 @@ export function registerSheetsTools(server: McpServer): void {
     },
   );
 
-  // sheets_write_range
   server.registerTool(
     'sheets_write_range',
     {
@@ -161,7 +158,6 @@ export function registerSheetsTools(server: McpServer): void {
     },
   );
 
-  // sheets_append_rows
   server.registerTool(
     'sheets_append_rows',
     {
@@ -200,7 +196,6 @@ export function registerSheetsTools(server: McpServer): void {
     },
   );
 
-  // sheets_clear_range
   server.registerTool(
     'sheets_clear_range',
     {
@@ -231,7 +226,6 @@ export function registerSheetsTools(server: McpServer): void {
     },
   );
 
-  // sheets_batch_read
   server.registerTool(
     'sheets_batch_read',
     {
@@ -267,7 +261,6 @@ export function registerSheetsTools(server: McpServer): void {
     },
   );
 
-  // sheets_batch_write
   server.registerTool(
     'sheets_batch_write',
     {
@@ -308,7 +301,8 @@ export function registerSheetsTools(server: McpServer): void {
     },
   );
 
-  // sheets_add_sheet
+  // ─── Sheet ops ─────────────────────────────────────────────────────────
+
   server.registerTool(
     'sheets_add_sheet',
     {
@@ -357,33 +351,948 @@ export function registerSheetsTools(server: McpServer): void {
       }
     },
   );
+
+  server.registerTool(
+    'sheets_delete_sheet',
+    {
+      description: 'Delete a tab/sheet from a spreadsheet by sheetId',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        sheetId: z.number().describe('Sheet ID (integer, from sheets_get)'),
+      },
+    },
+    async ({ account, spreadsheetId, sheetId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: { requests: [{ deleteSheet: { sheetId } }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, sheetId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_duplicate_sheet',
+    {
+      description: 'Duplicate a tab within the same spreadsheet',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        sourceSheetId: z.number().describe('Source sheet ID'),
+        newSheetName: z.string().optional().describe('Name for the duplicate (default: "Copy of <source>")'),
+        insertSheetIndex: z.number().optional().describe('Where to insert the duplicate (0-based)'),
+      },
+    },
+    async ({ account, spreadsheetId, sourceSheetId, newSheetName, insertSheetIndex }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const res = await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [{
+              duplicateSheet: {
+                sourceSheetId,
+                newSheetName,
+                insertSheetIndex,
+              },
+            }],
+          },
+        });
+        const props = res.data.replies?.[0]?.duplicateSheet?.properties;
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(props ?? {}, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_update_sheet_properties',
+    {
+      description: 'Rename a tab, change tab color, freeze rows/columns, hide/show, or change grid dimensions',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        sheetId: z.number().describe('Sheet ID'),
+        title: z.string().optional().describe('New tab title'),
+        index: z.number().optional().describe('New position among tabs'),
+        hidden: z.boolean().optional().describe('Hide the tab from the UI'),
+        tabColor: rgbColorSchema.optional().describe('Tab color (RGB 0..1)'),
+        frozenRowCount: z.number().min(0).optional().describe('Number of frozen header rows'),
+        frozenColumnCount: z.number().min(0).optional().describe('Number of frozen header columns'),
+        rowCount: z.number().min(1).optional().describe('Total row count'),
+        columnCount: z.number().min(1).optional().describe('Total column count'),
+      },
+    },
+    async ({ account, spreadsheetId, sheetId, title, index, hidden, tabColor, frozenRowCount, frozenColumnCount, rowCount, columnCount }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const properties: any = { sheetId };
+        const fields: string[] = [];
+        if (title !== undefined) { properties.title = title; fields.push('title'); }
+        if (index !== undefined) { properties.index = index; fields.push('index'); }
+        if (hidden !== undefined) { properties.hidden = hidden; fields.push('hidden'); }
+        if (tabColor) {
+          properties.tabColorStyle = { rgbColor: tabColor };
+          fields.push('tabColorStyle');
+        }
+        const grid: any = {};
+        const gridFields: string[] = [];
+        if (frozenRowCount !== undefined) { grid.frozenRowCount = frozenRowCount; gridFields.push('frozenRowCount'); }
+        if (frozenColumnCount !== undefined) { grid.frozenColumnCount = frozenColumnCount; gridFields.push('frozenColumnCount'); }
+        if (rowCount !== undefined) { grid.rowCount = rowCount; gridFields.push('rowCount'); }
+        if (columnCount !== undefined) { grid.columnCount = columnCount; gridFields.push('columnCount'); }
+        if (gridFields.length > 0) {
+          properties.gridProperties = grid;
+          for (const f of gridFields) fields.push(`gridProperties.${f}`);
+        }
+        if (fields.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'No properties supplied' }, null, 2) }],
+            isError: true,
+          };
+        }
+
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [{
+              updateSheetProperties: {
+                properties,
+                fields: fields.join(','),
+              },
+            }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ updated: true, sheetId, applied: fields }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Cell formatting ───────────────────────────────────────────────────
+
+  server.registerTool(
+    'sheets_format_cells',
+    {
+      description: 'Apply uniform formatting (colors, fonts, alignment, number format) to every cell in a range. Uses RepeatCell with a computed fields mask. For borders use sheets_update_borders.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        range: gridRangeSchema.describe('Target range (GridRange, half-open indexes)'),
+        backgroundColor: rgbColorSchema.optional().describe('Cell background (RGB 0..1)'),
+        textFormat: z.object({
+          foregroundColor: rgbColorSchema.optional(),
+          bold: z.boolean().optional(),
+          italic: z.boolean().optional(),
+          underline: z.boolean().optional(),
+          strikethrough: z.boolean().optional(),
+          fontFamily: z.string().optional(),
+          fontSize: z.number().min(1).optional(),
+        }).optional(),
+        horizontalAlignment: z.enum(['LEFT', 'CENTER', 'RIGHT']).optional(),
+        verticalAlignment: z.enum(['TOP', 'MIDDLE', 'BOTTOM']).optional(),
+        wrapStrategy: z.enum(['OVERFLOW_CELL', 'LEGACY_WRAP', 'CLIP', 'WRAP']).optional(),
+        numberFormat: z.object({
+          type: z.enum(['TEXT', 'NUMBER', 'PERCENT', 'CURRENCY', 'DATE', 'TIME', 'DATE_TIME', 'SCIENTIFIC']),
+          pattern: z.string().optional().describe('Optional format string (e.g. "$#,##0.00")'),
+        }).optional(),
+      },
+    },
+    async ({ account, spreadsheetId, range, ...format }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const built = buildCellFormat(format);
+        if (built.fields.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'No format properties supplied' }, null, 2) }],
+            isError: true,
+          };
+        }
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [{
+              repeatCell: {
+                range,
+                cell: { userEnteredFormat: built.format },
+                fields: built.fields,
+              },
+            }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ formatted: true, applied: built.fields }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_update_borders',
+    {
+      description: 'Set borders on a range. Each border specifies style and optional color.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        range: gridRangeSchema,
+        top: borderSchema.optional(),
+        bottom: borderSchema.optional(),
+        left: borderSchema.optional(),
+        right: borderSchema.optional(),
+        innerHorizontal: borderSchema.optional(),
+        innerVertical: borderSchema.optional(),
+      },
+    },
+    async ({ account, spreadsheetId, range, top, bottom, left, right, innerHorizontal, innerVertical }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const borders: any = { range };
+        if (top) borders.top = toBorder(top);
+        if (bottom) borders.bottom = toBorder(bottom);
+        if (left) borders.left = toBorder(left);
+        if (right) borders.right = toBorder(right);
+        if (innerHorizontal) borders.innerHorizontal = toBorder(innerHorizontal);
+        if (innerVertical) borders.innerVertical = toBorder(innerVertical);
+        if (Object.keys(borders).length === 1) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'At least one border edge must be supplied' }, null, 2) }],
+            isError: true,
+          };
+        }
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: { requests: [{ updateBorders: borders }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ borders_applied: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_merge_cells',
+    {
+      description: 'Merge a range of cells. MERGE_ALL collapses the range to one cell; MERGE_COLUMNS merges each column; MERGE_ROWS merges each row.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        range: gridRangeSchema,
+        mergeType: z.enum(['MERGE_ALL', 'MERGE_COLUMNS', 'MERGE_ROWS']).default('MERGE_ALL').optional(),
+      },
+    },
+    async ({ account, spreadsheetId, range, mergeType }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [{ mergeCells: { range, mergeType: mergeType ?? 'MERGE_ALL' } }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ merged: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_unmerge_cells',
+    {
+      description: 'Unmerge any merged cells overlapping the given range',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        range: gridRangeSchema,
+      },
+    },
+    async ({ account, spreadsheetId, range }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: { requests: [{ unmergeCells: { range } }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ unmerged: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Conditional formatting ────────────────────────────────────────────
+
+  server.registerTool(
+    'sheets_add_conditional_format_rule',
+    {
+      description: 'Add a conditional format rule. Specify either booleanRule (single trigger condition + format) or gradientRule (min/mid/max color stops).',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        ranges: z.array(gridRangeSchema).describe('Ranges the rule applies to'),
+        index: z.number().min(0).optional().describe('Where in the rule order to insert (0 = highest priority)'),
+        booleanRule: z.object({
+          conditionType: z.string().describe(BOOLEAN_CONDITION_TYPE_DESC),
+          conditionValues: z.array(z.string()).optional().describe('Values for the condition (e.g. ["100"] for NUMBER_GREATER, or ["=A1>10"] for CUSTOM_FORMULA)'),
+          format: z.object({
+            backgroundColor: rgbColorSchema.optional(),
+            textFormat: z.object({
+              foregroundColor: rgbColorSchema.optional(),
+              bold: z.boolean().optional(),
+              italic: z.boolean().optional(),
+              strikethrough: z.boolean().optional(),
+              underline: z.boolean().optional(),
+            }).optional(),
+          }).describe('Format to apply when condition is true. Conditional formatting only supports bold/italic/strikethrough/underline/foregroundColor/backgroundColor.'),
+        }).optional(),
+        gradientRule: z.object({
+          minpoint: gradientStopSchema,
+          midpoint: gradientStopSchema.optional(),
+          maxpoint: gradientStopSchema,
+        }).optional(),
+      },
+    },
+    async ({ account, spreadsheetId, ranges, index, booleanRule, gradientRule }) => {
+      try {
+        if (!booleanRule && !gradientRule) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({ error: 'Either booleanRule or gradientRule must be supplied' }, null, 2) }],
+            isError: true,
+          };
+        }
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+
+        const rule: any = { ranges };
+        if (booleanRule) {
+          const fmt: any = {};
+          if (booleanRule.format.backgroundColor) fmt.backgroundColorStyle = { rgbColor: booleanRule.format.backgroundColor };
+          if (booleanRule.format.textFormat) {
+            const tf: any = {};
+            const t = booleanRule.format.textFormat;
+            if (t.foregroundColor) tf.foregroundColorStyle = { rgbColor: t.foregroundColor };
+            if (t.bold !== undefined) tf.bold = t.bold;
+            if (t.italic !== undefined) tf.italic = t.italic;
+            if (t.strikethrough !== undefined) tf.strikethrough = t.strikethrough;
+            if (t.underline !== undefined) tf.underline = t.underline;
+            fmt.textFormat = tf;
+          }
+          rule.booleanRule = {
+            condition: {
+              type: booleanRule.conditionType,
+              values: (booleanRule.conditionValues ?? []).map(v => ({ userEnteredValue: v })),
+            },
+            format: fmt,
+          };
+        }
+        if (gradientRule) {
+          rule.gradientRule = {
+            minpoint: toGradientStop(gradientRule.minpoint),
+            midpoint: gradientRule.midpoint ? toGradientStop(gradientRule.midpoint) : undefined,
+            maxpoint: toGradientStop(gradientRule.maxpoint),
+          };
+        }
+
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [{
+              addConditionalFormatRule: { rule, index: index ?? 0 },
+            }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ added: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Filter / sort / find-replace ──────────────────────────────────────
+
+  server.registerTool(
+    'sheets_sort_range',
+    {
+      description: 'Sort a range by one or more columns',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        range: gridRangeSchema,
+        sortSpecs: z.array(sortSpecSchema).describe('One spec per sort column (in priority order)'),
+      },
+    },
+    async ({ account, spreadsheetId, range, sortSpecs }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [{ sortRange: { range, sortSpecs } }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ sorted: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_set_basic_filter',
+    {
+      description: 'Apply a basic filter to a range. Optionally supply sortSpecs to set the default sort, and filterSpecs to hide rows based on per-column criteria.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        range: gridRangeSchema,
+        sortSpecs: z.array(sortSpecSchema).optional(),
+        filterSpecs: z.array(z.object({
+          columnIndex: z.number().min(0),
+          hiddenValues: z.array(z.string()).optional().describe('Values to hide in this column'),
+          conditionType: z.string().optional().describe(BOOLEAN_CONDITION_TYPE_DESC),
+          conditionValues: z.array(z.string()).optional(),
+        })).optional(),
+      },
+    },
+    async ({ account, spreadsheetId, range, sortSpecs, filterSpecs }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const filter: any = { range };
+        if (sortSpecs) filter.sortSpecs = sortSpecs;
+        if (filterSpecs) {
+          filter.filterSpecs = filterSpecs.map(s => {
+            const out: any = { columnIndex: s.columnIndex };
+            const criteria: any = {};
+            if (s.hiddenValues) criteria.hiddenValues = s.hiddenValues;
+            if (s.conditionType) {
+              criteria.condition = {
+                type: s.conditionType,
+                values: (s.conditionValues ?? []).map(v => ({ userEnteredValue: v })),
+              };
+            }
+            out.filterCriteria = criteria;
+            return out;
+          });
+        }
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: { requests: [{ setBasicFilter: { filter } }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ filter_set: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_clear_basic_filter',
+    {
+      description: 'Remove the basic filter from a sheet',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        sheetId: z.number().describe('Sheet ID'),
+      },
+    },
+    async ({ account, spreadsheetId, sheetId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: { requests: [{ clearBasicFilter: { sheetId } }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ cleared: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_find_replace',
+    {
+      description: 'Find and replace text across a range, a sheet, or all sheets. Supports case sensitivity, full-cell match, regex, and formula scope.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        find: z.string().describe('Text to find'),
+        replacement: z.string().describe('Replacement text'),
+        scope: z.enum(['allSheets', 'sheet', 'range']).describe('Search scope'),
+        sheetId: z.number().optional().describe('Required when scope=sheet'),
+        range: gridRangeSchema.optional().describe('Required when scope=range'),
+        matchCase: z.boolean().optional(),
+        matchEntireCell: z.boolean().optional(),
+        searchByRegex: z.boolean().optional(),
+        includeFormulas: z.boolean().optional(),
+      },
+    },
+    async ({ account, spreadsheetId, find, replacement, scope, sheetId, range, matchCase, matchEntireCell, searchByRegex, includeFormulas }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const findReplace: any = {
+          find,
+          replacement,
+          matchCase: matchCase ?? false,
+          matchEntireCell: matchEntireCell ?? false,
+          searchByRegex: searchByRegex ?? false,
+          includeFormulas: includeFormulas ?? false,
+        };
+        if (scope === 'allSheets') findReplace.allSheets = true;
+        else if (scope === 'sheet') {
+          if (sheetId === undefined) {
+            return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'sheetId required when scope=sheet' }) }], isError: true };
+          }
+          findReplace.sheetId = sheetId;
+        } else {
+          if (!range) {
+            return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'range required when scope=range' }) }], isError: true };
+          }
+          findReplace.range = range;
+        }
+        const res = await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: { requests: [{ findReplace }] },
+        });
+        const reply = res.data.replies?.[0]?.findReplace;
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({
+            valuesChanged: reply?.valuesChanged ?? 0,
+            occurrencesChanged: reply?.occurrencesChanged ?? 0,
+            rowsChanged: reply?.rowsChanged ?? 0,
+            sheetsChanged: reply?.sheetsChanged ?? 0,
+            formulasChanged: reply?.formulasChanged ?? 0,
+          }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Dimensions ────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'sheets_auto_resize_dimensions',
+    {
+      description: 'Auto-resize rows or columns to fit content',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        sheetId: z.number().describe('Sheet ID'),
+        dimension: z.enum(['ROWS', 'COLUMNS']).describe('Which dimension to resize'),
+        startIndex: z.number().min(0).optional(),
+        endIndex: z.number().min(1).optional(),
+      },
+    },
+    async ({ account, spreadsheetId, sheetId, dimension, startIndex, endIndex }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const dimensions: any = { sheetId, dimension };
+        if (startIndex !== undefined) dimensions.startIndex = startIndex;
+        if (endIndex !== undefined) dimensions.endIndex = endIndex;
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: { requests: [{ autoResizeDimensions: { dimensions } }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ resized: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_insert_dimension',
+    {
+      description: 'Insert rows or columns at a position. inheritFromBefore=true copies properties from the row/column before the insertion point.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        sheetId: z.number().describe('Sheet ID'),
+        dimension: z.enum(['ROWS', 'COLUMNS']),
+        startIndex: z.number().min(0).describe('0-based, inclusive'),
+        endIndex: z.number().min(1).describe('0-based, exclusive'),
+        inheritFromBefore: z.boolean().optional(),
+      },
+    },
+    async ({ account, spreadsheetId, sheetId, dimension, startIndex, endIndex, inheritFromBefore }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [{
+              insertDimension: {
+                range: { sheetId, dimension, startIndex, endIndex },
+                inheritFromBefore: inheritFromBefore ?? false,
+              },
+            }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ inserted: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_delete_dimension',
+    {
+      description: 'Delete rows or columns from a sheet',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        sheetId: z.number().describe('Sheet ID'),
+        dimension: z.enum(['ROWS', 'COLUMNS']),
+        startIndex: z.number().min(0),
+        endIndex: z.number().min(1),
+      },
+    },
+    async ({ account, spreadsheetId, sheetId, dimension, startIndex, endIndex }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [{
+              deleteDimension: {
+                range: { sheetId, dimension, startIndex, endIndex },
+              },
+            }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Data validation ───────────────────────────────────────────────────
+
+  server.registerTool(
+    'sheets_set_data_validation',
+    {
+      description: 'Apply a data validation rule (dropdown, checkbox, numeric range, etc.) to a range. Pass conditionType=null to clear validation.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        range: gridRangeSchema,
+        conditionType: z.string().describe(BOOLEAN_CONDITION_TYPE_DESC),
+        conditionValues: z.array(z.string()).optional().describe('Values per condition type (list items for ONE_OF_LIST, range A1 for ONE_OF_RANGE, etc.)'),
+        inputMessage: z.string().optional().describe('Tooltip shown when cell is selected'),
+        strict: z.boolean().optional().describe('Reject invalid input (default: false = warning only)'),
+        showCustomUi: z.boolean().optional().describe('Show dropdown UI for list-type validations'),
+      },
+    },
+    async ({ account, spreadsheetId, range, conditionType, conditionValues, inputMessage, strict, showCustomUi }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const rule: any = {
+          condition: {
+            type: conditionType,
+            values: (conditionValues ?? []).map(v => ({ userEnteredValue: v })),
+          },
+          strict: strict ?? false,
+        };
+        if (inputMessage !== undefined) rule.inputMessage = inputMessage;
+        if (showCustomUi !== undefined) rule.showCustomUi = showCustomUi;
+
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [{ setDataValidation: { range, rule } }],
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ validation_set: true }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Named ranges ──────────────────────────────────────────────────────
+
+  server.registerTool(
+    'sheets_add_named_range',
+    {
+      description: 'Define a named range so formulas can reference it by name',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        name: z.string().describe('Named range identifier (no spaces)'),
+        range: gridRangeSchema,
+      },
+    },
+    async ({ account, spreadsheetId, name, range }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const res = await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: [{ addNamedRange: { namedRange: { name, range } } }],
+          },
+        });
+        const added = res.data.replies?.[0]?.addNamedRange?.namedRange;
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(added ?? {}, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_delete_named_range',
+    {
+      description: 'Delete a named range by its ID',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        namedRangeId: z.string().describe('Named range ID (from sheets_get response)'),
+      },
+    },
+    async ({ account, spreadsheetId, namedRangeId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: { requests: [{ deleteNamedRange: { namedRangeId } }] },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, namedRangeId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Values: batchClear + generic batchUpdate ──────────────────────────
+
+  server.registerTool(
+    'sheets_batch_clear',
+    {
+      description: 'Clear values from multiple ranges in one request',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        ranges: z.array(z.string()).describe('Array of A1 notation ranges'),
+      },
+    },
+    async ({ account, spreadsheetId, ranges }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const res = await sheets.spreadsheets.values.batchClear({
+          spreadsheetId,
+          requestBody: { ranges },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({
+            clearedRanges: res.data.clearedRanges ?? [],
+          }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'sheets_batch_update',
+    {
+      description: 'Generic spreadsheets.batchUpdate pass-through. Accepts the full Request union (~70 types). Use this for advanced operations not covered by a dedicated tool. See https://developers.google.com/workspace/sheets/api/reference/rest/v4/spreadsheets/request',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        spreadsheetId: z.string().describe('Spreadsheet ID'),
+        requests: z.array(z.record(z.string(), z.any())).describe('Array of Request objects. Each object has exactly one key (the request type) like {repeatCell: {...}}, {addChart: {...}}, {updateBanding: {...}}, etc.'),
+        includeSpreadsheetInResponse: z.boolean().optional(),
+        responseRanges: z.array(z.string()).optional(),
+        responseIncludeGridData: z.boolean().optional(),
+      },
+    },
+    async ({ account, spreadsheetId, requests, includeSpreadsheetInResponse, responseRanges, responseIncludeGridData }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const sheets = google.sheets({ version: 'v4', auth });
+        const res = await sheets.spreadsheets.batchUpdate({
+          spreadsheetId,
+          requestBody: {
+            requests: requests as any,
+            includeSpreadsheetInResponse,
+            responseRanges,
+            responseIncludeGridData,
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({
+            replies: res.data.replies ?? [],
+          }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSheetsError(error, account as Account);
+      }
+    },
+  );
+}
+
+// ─── Shared schemas & helpers ────────────────────────────────────────────
+
+const rgbColorSchema = z.object({
+  red: z.number().min(0).max(1).optional(),
+  green: z.number().min(0).max(1).optional(),
+  blue: z.number().min(0).max(1).optional(),
+  alpha: z.number().min(0).max(1).optional(),
+});
+
+const sortSpecSchema = z.object({
+  dimensionIndex: z.number().min(0).describe('Column index within the range (0-based)'),
+  sortOrder: z.enum(['ASCENDING', 'DESCENDING']).default('ASCENDING'),
+});
+
+// BooleanCondition.type — kept open (z.string) because Google's enum surface is large and may grow.
+const BOOLEAN_CONDITION_TYPE_DESC =
+  'BooleanCondition.type. Common values: NUMBER_GREATER, NUMBER_BETWEEN, TEXT_CONTAINS, TEXT_EQ, DATE_BEFORE, BLANK, NOT_BLANK, CUSTOM_FORMULA, BOOLEAN, ONE_OF_LIST, ONE_OF_RANGE.';
+
+const gridRangeSchema = z.object({
+  sheetId: z.number().describe('Sheet ID'),
+  startRowIndex: z.number().min(0).optional().describe('0-based, inclusive. Omit = from row 0.'),
+  endRowIndex: z.number().min(0).optional().describe('0-based, exclusive. Omit = to last row.'),
+  startColumnIndex: z.number().min(0).optional(),
+  endColumnIndex: z.number().min(0).optional(),
+});
+
+const borderSchema = z.object({
+  style: z.enum(['DOTTED', 'DASHED', 'SOLID', 'SOLID_MEDIUM', 'SOLID_THICK', 'NONE', 'DOUBLE']),
+  color: rgbColorSchema.optional(),
+});
+
+const gradientStopSchema = z.object({
+  type: z.enum(['MIN', 'MAX', 'NUMBER', 'PERCENT', 'PERCENTILE']),
+  value: z.string().optional().describe('Required when type is NUMBER/PERCENT/PERCENTILE'),
+  color: rgbColorSchema,
+});
+
+function toBorder(b: { style: string; color?: any }) {
+  const out: any = { style: b.style };
+  if (b.color) out.colorStyle = { rgbColor: b.color };
+  return out;
+}
+
+function toGradientStop(s: { type: string; value?: string; color: any }) {
+  const out: any = { type: s.type, colorStyle: { rgbColor: s.color } };
+  if (s.value !== undefined) out.value = s.value;
+  return out;
+}
+
+export function buildCellFormat(input: {
+  backgroundColor?: { red?: number; green?: number; blue?: number; alpha?: number };
+  textFormat?: {
+    foregroundColor?: { red?: number; green?: number; blue?: number; alpha?: number };
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+    strikethrough?: boolean;
+    fontFamily?: string;
+    fontSize?: number;
+  };
+  horizontalAlignment?: string;
+  verticalAlignment?: string;
+  wrapStrategy?: string;
+  numberFormat?: { type: string; pattern?: string };
+}): { format: any; fields: string } {
+  const format: any = {};
+  const fields: string[] = [];
+
+  if (input.backgroundColor) {
+    format.backgroundColorStyle = { rgbColor: input.backgroundColor };
+    fields.push('userEnteredFormat.backgroundColorStyle');
+  }
+
+  if (input.textFormat) {
+    const tf: any = {};
+    const t = input.textFormat;
+    if (t.foregroundColor) { tf.foregroundColorStyle = { rgbColor: t.foregroundColor }; fields.push('userEnteredFormat.textFormat.foregroundColorStyle'); }
+    if (t.bold !== undefined) { tf.bold = t.bold; fields.push('userEnteredFormat.textFormat.bold'); }
+    if (t.italic !== undefined) { tf.italic = t.italic; fields.push('userEnteredFormat.textFormat.italic'); }
+    if (t.underline !== undefined) { tf.underline = t.underline; fields.push('userEnteredFormat.textFormat.underline'); }
+    if (t.strikethrough !== undefined) { tf.strikethrough = t.strikethrough; fields.push('userEnteredFormat.textFormat.strikethrough'); }
+    if (t.fontFamily) { tf.fontFamily = t.fontFamily; fields.push('userEnteredFormat.textFormat.fontFamily'); }
+    if (t.fontSize !== undefined) { tf.fontSize = t.fontSize; fields.push('userEnteredFormat.textFormat.fontSize'); }
+    if (Object.keys(tf).length > 0) format.textFormat = tf;
+  }
+
+  if (input.horizontalAlignment) { format.horizontalAlignment = input.horizontalAlignment; fields.push('userEnteredFormat.horizontalAlignment'); }
+  if (input.verticalAlignment) { format.verticalAlignment = input.verticalAlignment; fields.push('userEnteredFormat.verticalAlignment'); }
+  if (input.wrapStrategy) { format.wrapStrategy = input.wrapStrategy; fields.push('userEnteredFormat.wrapStrategy'); }
+
+  if (input.numberFormat) {
+    format.numberFormat = { type: input.numberFormat.type, pattern: input.numberFormat.pattern };
+    fields.push('userEnteredFormat.numberFormat');
+  }
+
+  return { format, fields: fields.join(',') };
 }
 
 function handleSheetsError(error: any, account: Account) {
-  if (error.code === 401) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: `Authentication error for account "${account}". Run: node dist/index.js auth --account ${account}`,
-      }],
-      isError: true,
-    };
-  }
-  if (error.code === 429) {
-    const retryAfter = error.response?.headers?.['retry-after'] ?? 'unknown';
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({ error: 'rate_limited', retryAfter }),
-      }],
-      isError: true,
-    };
-  }
-  return {
-    content: [{
-      type: 'text' as const,
-      text: JSON.stringify({ error: error.message ?? String(error), code: error.code }),
-    }],
-    isError: true,
-  };
+  return handleGoogleApiError(error, account);
 }

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,0 +1,366 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { ACCOUNTS } from '../accounts.js';
+import type { Account } from '../accounts.js';
+import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
+
+const accountEnum = z.enum(ACCOUNTS);
+
+export function registerTasksTools(server: McpServer): void {
+  // ─── Tasklists ─────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'tasks_lists_list',
+    {
+      description: 'List all tasklists (the user\'s top-level task containers)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        maxResults: z.number().min(1).max(100).optional(),
+        pageToken: z.string().optional(),
+      },
+    },
+    async ({ account, maxResults, pageToken }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        const res = await tasks.tasklists.list({
+          maxResults: maxResults ?? 100,
+          pageToken,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'tasks_list_get',
+    {
+      description: 'Get a single tasklist by ID',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        tasklistId: z.string().describe('Tasklist ID'),
+      },
+    },
+    async ({ account, tasklistId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        const res = await tasks.tasklists.get({ tasklist: tasklistId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'tasks_list_insert',
+    {
+      description: 'Create a new tasklist',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        title: z.string().describe('Tasklist title'),
+      },
+    },
+    async ({ account, title }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        const res = await tasks.tasklists.insert({
+          requestBody: { title },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'tasks_list_update',
+    {
+      description: 'Rename a tasklist (PATCH semantics)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        tasklistId: z.string().describe('Tasklist ID'),
+        title: z.string().describe('New title'),
+      },
+    },
+    async ({ account, tasklistId, title }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        const res = await tasks.tasklists.patch({
+          tasklist: tasklistId,
+          requestBody: { title },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'tasks_list_delete',
+    {
+      description: 'Delete a tasklist and every task inside it',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        tasklistId: z.string().describe('Tasklist ID'),
+      },
+    },
+    async ({ account, tasklistId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        await tasks.tasklists.delete({ tasklist: tasklistId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, tasklistId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  // ─── Tasks ─────────────────────────────────────────────────────────────
+
+  server.registerTool(
+    'tasks_list',
+    {
+      description: 'List tasks within a tasklist with rich filters',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        tasklistId: z.string().describe('Tasklist ID'),
+        maxResults: z.number().min(1).max(100).optional(),
+        pageToken: z.string().optional(),
+        showCompleted: z.boolean().optional().describe('Include completed tasks (default: true)'),
+        showDeleted: z.boolean().optional(),
+        showHidden: z.boolean().optional(),
+        showAssigned: z.boolean().optional(),
+        completedMax: z.string().optional().describe('RFC 3339 upper bound on completion date'),
+        completedMin: z.string().optional(),
+        dueMax: z.string().optional(),
+        dueMin: z.string().optional(),
+        updatedMin: z.string().optional(),
+      },
+    },
+    async ({ account, tasklistId, ...params }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        const res = await tasks.tasks.list({
+          tasklist: tasklistId,
+          ...params,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'tasks_get',
+    {
+      description: 'Get a single task',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        tasklistId: z.string().describe('Tasklist ID'),
+        taskId: z.string().describe('Task ID'),
+      },
+    },
+    async ({ account, tasklistId, taskId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        const res = await tasks.tasks.get({ tasklist: tasklistId, task: taskId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'tasks_insert',
+    {
+      description: 'Create a new task. Use parent to nest under another task, previous to position after a sibling.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        tasklistId: z.string().describe('Tasklist ID'),
+        title: z.string().describe('Task title'),
+        notes: z.string().optional().describe('Task description'),
+        due: z.string().optional().describe('Due date in RFC 3339 (e.g. 2026-06-15T00:00:00.000Z)'),
+        status: z.enum(['needsAction', 'completed']).optional(),
+        parent: z.string().optional().describe('Parent task ID for nesting'),
+        previous: z.string().optional().describe('Position this task immediately after this sibling task ID'),
+      },
+    },
+    async ({ account, tasklistId, title, notes, due, status, parent, previous }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        const requestBody: any = { title };
+        if (notes !== undefined) requestBody.notes = notes;
+        if (due !== undefined) requestBody.due = due;
+        if (status !== undefined) requestBody.status = status;
+
+        const res = await tasks.tasks.insert({
+          tasklist: tasklistId,
+          parent,
+          previous,
+          requestBody,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'tasks_update',
+    {
+      description: 'Update a task (PATCH semantics — only supplied fields change)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        tasklistId: z.string().describe('Tasklist ID'),
+        taskId: z.string().describe('Task ID'),
+        title: z.string().optional(),
+        notes: z.string().optional(),
+        due: z.string().optional().describe('RFC 3339'),
+        status: z.enum(['needsAction', 'completed']).optional(),
+      },
+    },
+    async ({ account, tasklistId, taskId, title, notes, due, status }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        const requestBody: any = {};
+        if (title !== undefined) requestBody.title = title;
+        if (notes !== undefined) requestBody.notes = notes;
+        if (due !== undefined) requestBody.due = due;
+        if (status !== undefined) requestBody.status = status;
+
+        if (Object.keys(requestBody).length === 0) {
+          return { content: [{ type: 'text' as const, text: JSON.stringify({ error: 'No fields to update' }) }], isError: true };
+        }
+
+        const res = await tasks.tasks.patch({
+          tasklist: tasklistId,
+          task: taskId,
+          requestBody,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'tasks_delete',
+    {
+      description: 'Delete a task',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        tasklistId: z.string().describe('Tasklist ID'),
+        taskId: z.string().describe('Task ID'),
+      },
+    },
+    async ({ account, tasklistId, taskId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        await tasks.tasks.delete({ tasklist: tasklistId, task: taskId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ deleted: true, taskId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'tasks_move',
+    {
+      description: 'Reposition a task: change its parent, move it after a sibling, or move it to another tasklist',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        tasklistId: z.string().describe('Source tasklist ID'),
+        taskId: z.string().describe('Task ID'),
+        parent: z.string().optional().describe('New parent task ID'),
+        previous: z.string().optional().describe('New sibling to position after'),
+        destinationTasklist: z.string().optional().describe('Move to a different tasklist'),
+      },
+    },
+    async ({ account, tasklistId, taskId, parent, previous, destinationTasklist }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        const res = await tasks.tasks.move({
+          tasklist: tasklistId,
+          task: taskId,
+          parent,
+          previous,
+          destinationTasklist,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'tasks_clear',
+    {
+      description: 'Permanently delete every completed task in a tasklist',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        tasklistId: z.string().describe('Tasklist ID'),
+      },
+    },
+    async ({ account, tasklistId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const tasks = google.tasks({ version: 'v1', auth });
+        await tasks.tasks.clear({ tasklist: tasklistId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({ cleared: true, tasklistId }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleTasksError(error, account as Account);
+      }
+    },
+  );
+}
+
+function handleTasksError(error: any, account: Account) {
+  return handleGoogleApiError(error, account);
+}

--- a/tests/field-mask-helpers.test.ts
+++ b/tests/field-mask-helpers.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { buildCellFormat } from '../src/tools/sheets.js';
+import { buildParagraphStyle, buildDocumentStyle } from '../src/tools/docs.js';
+
+describe('buildCellFormat (Sheets RepeatCell helper)', () => {
+  it('returns empty fields when nothing supplied', () => {
+    const r = buildCellFormat({});
+    expect(r.fields).toBe('');
+    expect(r.format).toEqual({});
+  });
+
+  it('wraps backgroundColor in backgroundColorStyle.rgbColor', () => {
+    const r = buildCellFormat({ backgroundColor: { red: 1, green: 0.5, blue: 0 } });
+    expect(r.format.backgroundColorStyle).toEqual({ rgbColor: { red: 1, green: 0.5, blue: 0 } });
+    expect(r.fields).toBe('userEnteredFormat.backgroundColorStyle');
+  });
+
+  it('emits dotted-path fields for nested textFormat', () => {
+    const r = buildCellFormat({
+      textFormat: { bold: true, italic: false, fontSize: 12 },
+    });
+    expect(r.format.textFormat).toEqual({ bold: true, italic: false, fontSize: 12 });
+    const fields = r.fields.split(',');
+    expect(fields).toContain('userEnteredFormat.textFormat.bold');
+    expect(fields).toContain('userEnteredFormat.textFormat.italic');
+    expect(fields).toContain('userEnteredFormat.textFormat.fontSize');
+  });
+
+  it('wraps foregroundColor in foregroundColorStyle.rgbColor', () => {
+    const r = buildCellFormat({
+      textFormat: { foregroundColor: { red: 0, green: 0, blue: 1 } },
+    });
+    expect(r.format.textFormat.foregroundColorStyle).toEqual({
+      rgbColor: { red: 0, green: 0, blue: 1 },
+    });
+    expect(r.fields).toBe('userEnteredFormat.textFormat.foregroundColorStyle');
+  });
+
+  it('omits empty textFormat object when no sub-fields are set', () => {
+    const r = buildCellFormat({ textFormat: {}, horizontalAlignment: 'CENTER' });
+    expect(r.format.textFormat).toBeUndefined();
+    expect(r.fields).toBe('userEnteredFormat.horizontalAlignment');
+  });
+
+  it('emits numberFormat as a whole replacement, not per-subfield', () => {
+    const r = buildCellFormat({
+      numberFormat: { type: 'CURRENCY', pattern: '$#,##0.00' },
+    });
+    expect(r.format.numberFormat).toEqual({ type: 'CURRENCY', pattern: '$#,##0.00' });
+    expect(r.fields).toBe('userEnteredFormat.numberFormat');
+  });
+
+  it('combines multiple top-level fields with commas', () => {
+    const r = buildCellFormat({
+      backgroundColor: { red: 1 },
+      horizontalAlignment: 'CENTER',
+      verticalAlignment: 'MIDDLE',
+      wrapStrategy: 'WRAP',
+    });
+    const fields = r.fields.split(',');
+    expect(fields).toContain('userEnteredFormat.backgroundColorStyle');
+    expect(fields).toContain('userEnteredFormat.horizontalAlignment');
+    expect(fields).toContain('userEnteredFormat.verticalAlignment');
+    expect(fields).toContain('userEnteredFormat.wrapStrategy');
+    expect(fields).toHaveLength(4);
+  });
+});
+
+describe('buildParagraphStyle (Docs updateParagraphStyle helper)', () => {
+  it('returns empty fields when nothing supplied', () => {
+    const r = buildParagraphStyle({});
+    expect(r.fields).toBe('');
+    expect(r.paragraphStyle).toEqual({});
+  });
+
+  it('wraps point-valued fields as Dimension {magnitude, unit: PT}', () => {
+    const r = buildParagraphStyle({
+      spaceAbove: 12,
+      indentStart: 36,
+      indentFirstLine: 18,
+    });
+    expect(r.paragraphStyle.spaceAbove).toEqual({ magnitude: 12, unit: 'PT' });
+    expect(r.paragraphStyle.indentStart).toEqual({ magnitude: 36, unit: 'PT' });
+    expect(r.paragraphStyle.indentFirstLine).toEqual({ magnitude: 18, unit: 'PT' });
+  });
+
+  it('preserves scalar fields as-is (lineSpacing, namedStyleType, alignment)', () => {
+    const r = buildParagraphStyle({
+      namedStyleType: 'HEADING_2',
+      alignment: 'CENTER',
+      lineSpacing: 150,
+    });
+    expect(r.paragraphStyle.namedStyleType).toBe('HEADING_2');
+    expect(r.paragraphStyle.alignment).toBe('CENTER');
+    expect(r.paragraphStyle.lineSpacing).toBe(150);
+  });
+
+  it('emits boolean toggles correctly', () => {
+    const r = buildParagraphStyle({
+      keepLinesTogether: true,
+      avoidWidowAndOrphan: false,
+    });
+    expect(r.paragraphStyle.keepLinesTogether).toBe(true);
+    expect(r.paragraphStyle.avoidWidowAndOrphan).toBe(false);
+    expect(r.fields.split(',')).toContain('keepLinesTogether');
+    expect(r.fields.split(',')).toContain('avoidWidowAndOrphan');
+  });
+
+  it('builds fields list flat (no nesting prefix unlike Sheets)', () => {
+    const r = buildParagraphStyle({ alignment: 'JUSTIFIED', namedStyleType: 'NORMAL_TEXT' });
+    expect(r.fields.split(',').sort()).toEqual(['alignment', 'namedStyleType']);
+  });
+});
+
+describe('buildDocumentStyle (Docs updateDocumentStyle helper)', () => {
+  it('returns empty fields when nothing supplied', () => {
+    const r = buildDocumentStyle({});
+    expect(r.fields).toBe('');
+    expect(r.documentStyle).toEqual({});
+  });
+
+  it('groups pageWidth + pageHeight under pageSize with a single fields entry', () => {
+    const r = buildDocumentStyle({ pageWidth: 595, pageHeight: 842 });
+    expect(r.documentStyle.pageSize).toEqual({
+      width: { magnitude: 595, unit: 'PT' },
+      height: { magnitude: 842, unit: 'PT' },
+    });
+    expect(r.fields).toBe('pageSize');
+  });
+
+  it('emits pageSize even if only one dimension is supplied', () => {
+    const r = buildDocumentStyle({ pageWidth: 595 });
+    expect(r.documentStyle.pageSize).toEqual({ width: { magnitude: 595, unit: 'PT' } });
+    expect(r.fields).toBe('pageSize');
+  });
+
+  it('wraps each margin as Dimension and emits per-margin fields', () => {
+    const r = buildDocumentStyle({ marginTop: 72, marginBottom: 72, marginLeft: 90, marginRight: 90 });
+    expect(r.documentStyle.marginTop).toEqual({ magnitude: 72, unit: 'PT' });
+    const fields = r.fields.split(',').sort();
+    expect(fields).toEqual(['marginBottom', 'marginLeft', 'marginRight', 'marginTop']);
+  });
+
+  it('passes pageNumberStart as a raw number, not a Dimension', () => {
+    const r = buildDocumentStyle({ pageNumberStart: 5 });
+    expect(r.documentStyle.pageNumberStart).toBe(5);
+    expect(r.fields).toBe('pageNumberStart');
+  });
+
+  it('emits boolean header/footer toggles as scalar values', () => {
+    const r = buildDocumentStyle({
+      useFirstPageHeaderFooter: true,
+      useEvenPageHeaderFooter: false,
+    });
+    expect(r.documentStyle.useFirstPageHeaderFooter).toBe(true);
+    expect(r.documentStyle.useEvenPageHeaderFooter).toBe(false);
+  });
+});


### PR DESCRIPTION
**Breaking** — re-authenticate every account after upgrading. The base OAuth scope set grew (Tasks + Meet added); existing tokens lack the new scopes and the new tools will 403 until you re-run `npm run auth -- <alias>` for each account.

## Summary

92 new tools across Drive completers (35), Sheets formatting (29), Docs templating (27), and 5 new services: Tasks (12), Meet v2 (5), Forms (4, optional), Chat (4, optional), Admin SDK (8, admin). **Total: 175 tools across 12 services.**

OAuth scopes are now tiered: BASE (always granted), OPTIONAL bundles via `GOOGLE_OPTIONAL_SCOPES` (forms, chat), and ADMIN per-account via `GOOGLE_ADMIN_ACCOUNTS`. Destructive admin writes (`admin_users_update`) further gated by `GOOGLE_ALLOW_ADMIN_WRITES`.

### Highlights

- **Drive**: comments/replies full CRUD with `action: resolve|reopen`, `drive_untrash` (fixes the one-way trash bug), `drive_move`, `drive_permission_update` with `transferOwnership` + `expirationTime`, revisions, access proposals, shared drives, `supportsAllDrives` consistency across every Drive tool.
- **Sheets**: `format_cells` with computed field mask, conditional formatting (boolean + gradient), sort, basic filter, data validation, named ranges, dimension ops, find/replace, generic `batch_update` escape hatch.
- **Docs**: named ranges + `replaceNamedRangeContent` (real mail-merge), paragraph + document style, inline images, page/section breaks, headers + footers, bullets, table mutations (`docs_modify_table` with operation discriminator), full tabs CRUD, generic `batch_update` escape hatch.
- **New services**: Tasks (full CRUD on lists + tasks), Meet v2 (conferenceRecords, recordings, transcripts, transcript entries), Forms (definition + responses), Chat (spaces + messages), Admin SDK (Reports audit log, Alert Center, Directory users/groups).

### Code quality

- Shared `handleGoogleApiError` in `src/tools/_errors.ts` — per-service handlers are 3-line shims with an optional `forbiddenHint`.
- Env parsing centralized via `getOptionalBundles()` / `getAdminAccounts()` / `adminWritesEnabled()`.
- Drive download/export now use `node:stream/promises.pipeline` — source errors destroy the writer instead of leaking partial files.
- Field-mask builders (`buildCellFormat`, `buildParagraphStyle`, `buildDocumentStyle`) are pure functions with 18 unit tests.

### Security

- OAuth callback bound to 127.0.0.1 only (was 0.0.0.0).
- Account alias restricted to `[a-zA-Z0-9_-]+` to prevent token-dir escape via malicious `GOOGLE_ACCOUNTS`.
- `drive_list` escapes single quotes in `folderId` before interpolation.
- `npm audit`: 0 vulnerabilities.

### Bug fixes

- `drive_trash` had no inverse path. Paired with `drive_untrash`.
- `drive_comment_list` returned 400 Invalid field selection due to a comma-split bug in the field-mask builder. Selectors hard-coded separately.
- `McpServer` constructor version now reads from `package.json`.

### Migration

1. `git pull && npm install && npm run build`
2. Re-authenticate every account: `npm run auth -- <alias>` (required — base scopes grew)
3. Optional bundles: set `GOOGLE_OPTIONAL_SCOPES=forms,chat` in `.env` before re-authing
4. Workspace admins: list accounts in `GOOGLE_ADMIN_ACCOUNTS` before re-authing those accounts; set `GOOGLE_ALLOW_ADMIN_WRITES=true` only if you need destructive admin writes
5. Enable in Cloud Console: Tasks API, Google Meet API, optionally Forms / Chat / Admin SDK / Alert Center

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run lint` ✓
- [x] `npm run test` — 51/51 pass (18 new unit tests for field-mask builders)
- [x] `npm run build` ✓
- [x] `npm audit` — 0 vulnerabilities
- [x] Local smoke + E2E on `ic` account: 25+ tools exercised across all work-areas including Tasks + Meet after Cloud Console API enable
- [x] PII audit: clean (no real account aliases, no test artifact IDs, no client identifiers)
- [x] Security audit: 3 hardening fixes applied
- [ ] Reviewers: confirm migration steps work cleanly from a v3 install

🤖 Generated with [Claude Code](https://claude.com/claude-code)