### PR TITLE
fix(admin): gate Alert Center (apps.alerts) behind its own opt-in bundle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,12 +8,17 @@ GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
 # ─── Optional (v4.0.0) ──────────────────────────────────────────────────
 # Opt in to additional scope bundles. Each bundle enables a tool group and
 # its OAuth scopes. Re-auth all accounts after changing this.
-# Supported: forms, chat
+# Supported: forms, chat, alertcenter
+# NOTE: the `alertcenter` bundle (apps.alerts) is NOT grantable via this
+# server's user-consent OAuth flow — it needs a service account with
+# domain-wide delegation, which is not yet supported. Enabling it declares
+# the scope and registers the 2 alert tools, but the API rejects user tokens.
 # GOOGLE_OPTIONAL_SCOPES=forms,chat
 
 # Comma-separated list of account aliases that should be granted Workspace
-# admin scopes (Reports, Alert Center, Directory). Accounts NOT listed here
-# will never request admin scopes — safe for personal Gmail.
+# admin scopes (Reports + Directory). Accounts NOT listed here will never
+# request admin scopes — safe for personal Gmail. (Alert Center is no longer
+# part of this bundle; it is the separate `alertcenter` optional bundle above.)
 # GOOGLE_ADMIN_ACCOUNTS=work
 
 # Required to unlock destructive admin write operations (admin_users_update).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] — 2026-05-20
+
+> **Re-authenticate accounts listed in `GOOGLE_ADMIN_ACCOUNTS`.** The admin scope set shrank — `apps.alerts` is no longer requested by the admin bundle. Re-run `npm run auth -- <alias>` so the token drops it cleanly.
+
+### Fixed
+
+- **Admin consent no longer blocked by Alert Center.** `apps.alerts` was hardcoded into the user-OAuth admin bundle (`ADMIN_SCOPES`), but Google does not grant that scope through the interactive user-consent flow — it requires a service account with domain-wide delegation. Any account in `GOOGLE_ADMIN_ACCOUNTS` therefore failed the *entire* admin consent with `Error 400: invalid_scope` / "Some requested scopes cannot be shown", taking the working Admin SDK Directory + Reports tools down with it.
+
+### Changed
+
+- `apps.alerts` moved out of `ADMIN_SCOPES` into a new `alertcenter` key in `OPTIONAL_SCOPE_BUNDLES`.
+- The two Alert Center tools (`alertcenter_alerts_list`, `alertcenter_alert_get`) now register via `registerAlertCenterTools` behind `GOOGLE_OPTIONAL_SCOPES=alertcenter`, decoupled from the admin bundle. The admin bundle is now 6 tools (Reports + Directory); Alert Center is its own 2-tool optional bundle.
+- Added `handleAlertCenterError` with a hint explaining the service-account / domain-wide-delegation requirement.
+
+### Known limitation
+
+- The `alertcenter` bundle is declared-but-non-functional under user OAuth: enabling it requests the scope and registers the tools, but the Alert Center API rejects user-consent tokens. Full support needs a service-account + domain-wide-delegation auth path (tracked in the linked issue).
+
 ## [4.0.0] — 2026-05-11
 
 > **Breaking — re-authenticate every account after upgrading.** The base OAuth scope set grew (Tasks + Meet added); existing tokens lack the new scopes and Tasks/Meet tools will 403 until you re-run `npm run auth -- <alias>` for each account.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Conventions for AI assistants modifying this codebase.
 ## Project shape
 
 - Each Google service lives in `src/tools/<service>.ts` and exports `register<Service>Tools(server: McpServer): void`.
-- `src/index.ts` is the entry point. It wires service registrations into the MCP server, conditional on env-driven scope bundles (Forms/Chat opt-in, Admin opt-in per-account).
+- `src/index.ts` is the entry point. It wires service registrations into the MCP server, conditional on env-driven scope bundles (Forms/Chat/Alert Center opt-in, Admin opt-in per-account).
 - `src/auth.ts` owns OAuth flow + scope tier resolution. `BASE_SCOPES` are always granted; `OPTIONAL_SCOPE_BUNDLES` are env-gated; `ADMIN_SCOPES` are per-account-gated. `resolveScopesForAccount(alias)` is the authoritative composer.
 - `src/client.ts` is a thin OAuth2Client factory used by every tool handler.
 - `src/accounts.ts` parses the `GOOGLE_ACCOUNTS` env var.
@@ -81,6 +81,12 @@ Every Drive API call that takes a `fileId` must pass `supportsAllDrives: true`. 
 - Admin tools only register if `GOOGLE_ADMIN_ACCOUNTS` is set.
 - Destructive admin writes (`admin_users_update`) must check `adminWritesEnabled()` (imported from `auth.ts`) and refuse if `GOOGLE_ALLOW_ADMIN_WRITES` is not exactly `'true'`. Do not relax this gate.
 - Admin tools 403 on personal Gmail accounts. The `handleAdminError` helper surfaces this hint clearly — keep it.
+
+## Alert Center is NOT an admin scope
+
+- `apps.alerts` (Alert Center) is **not** in `ADMIN_SCOPES`. Google does not grant it through the interactive user-consent OAuth flow this server uses — it requires a service account with domain-wide delegation. Putting it in the user-OAuth admin bundle made the *entire* admin consent fail with `Error 400: invalid_scope`.
+- It lives in the `alertcenter` key of `OPTIONAL_SCOPE_BUNDLES`, and `registerAlertCenterTools` (in `admin.ts`) registers behind `optional.has('alertcenter')` — never behind `getAdminAccounts()`. Keep these decoupled so a missing/ungrantable `apps.alerts` can never block the working Admin SDK tools.
+- Until service-account + domain-wide-delegation auth exists, the `alertcenter` bundle is declared-but-non-functional under user OAuth. `handleAlertCenterError` surfaces this — keep the hint.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A local [MCP](https://modelcontextprotocol.io) server that gives Claude Code (an
 ## Features
 
 - **Multi-account** — manage any number of Google accounts from a single server
-- **175 tools** across 12 Google services
-- **Tiered OAuth scopes** — base scopes always granted; Forms/Chat are opt-in; Admin scopes are per-account opt-in with a separate safety flag for destructive writes
+- **175 tools** across 13 Google services
+- **Tiered OAuth scopes** — base scopes always granted; Forms/Chat/Alert Center are opt-in bundles; Admin scopes are per-account opt-in with a separate safety flag for destructive writes
 - **Config-driven accounts** — defined in `.env`, no code changes needed
 - **Auto-refresh** — OAuth tokens refresh transparently and persist to disk
 - **Stdio transport** — runs as a local subprocess, no hosting needed
@@ -203,19 +203,28 @@ Enable with `GOOGLE_OPTIONAL_SCOPES=chat` in `.env` (combine: `GOOGLE_OPTIONAL_S
 | `chat_messages_create` | Send text or Card v2 |
 | `chat_messages_list` | List messages with filter / orderBy |
 
-### Google Workspace Admin (8 tools, admin bundle) — _new in v4_
+### Google Workspace Admin (6 tools, admin bundle) — _new in v4_
 
 Enable per-account with `GOOGLE_ADMIN_ACCOUNTS=alias1,alias2` in `.env`. Requires the account to be a Workspace super-admin. Personal `@gmail.com` accounts will 403 — never list them here. Destructive writes additionally require `GOOGLE_ALLOW_ADMIN_WRITES=true`.
 
 | Tool | Description |
 |------|-------------|
 | `reports_activities_list` | Workspace audit log (login, drive, gmail, admin, token, etc.) |
-| `alertcenter_alerts_list` / `alertcenter_alert_get` | Security alerts |
 | `admin_users_list` / `admin_users_get` | User directory reads |
 | `admin_users_update` | User edits (gated, see env flag above) |
 | `admin_groups_list` / `admin_group_members_list` | Group + member reads |
 
 Every tool accepts an `account` parameter matching one of your configured aliases.
+
+### Google Alert Center (2 tools, optional bundle) — _new in v4_
+
+Enable with `GOOGLE_OPTIONAL_SCOPES=alertcenter` in `.env`.
+
+| Tool | Description |
+|------|-------------|
+| `alertcenter_alerts_list` / `alertcenter_alert_get` | Security alerts (suspicious login, phishing, leaked password, Drive exfil) |
+
+> **⚠ Requires service-account domain-wide delegation.** Unlike every other bundle, the Alert Center `apps.alerts` scope **cannot** be granted through this server's interactive user-consent OAuth flow — Google rejects it with `Error 400: invalid_scope` / "Some requested scopes cannot be shown". Per [Google's docs](https://developers.google.com/workspace/admin/alertcenter/guides/auth), Alert Center requires a service account with domain-wide delegation. This server is user-OAuth only, so enabling this bundle declares the scope and registers the tools, but the API will reject the resulting tokens until service-account auth is added (see [#4](https://github.com/bakissation/mcp-google-multi/issues/4)). The bundle is kept separate precisely so this limitation never blocks the working admin tools above.
 
 ## Prerequisites
 
@@ -231,8 +240,8 @@ Every tool accepts an `account` parameter matching one of your configured aliase
 2. Create or select a project.
 3. Enable the APIs you intend to use:
    - **Always required:** [Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com), [Google Drive API](https://console.cloud.google.com/apis/library/drive.googleapis.com), [Google Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com), [Google Sheets API](https://console.cloud.google.com/apis/library/sheets.googleapis.com), [Google Docs API](https://console.cloud.google.com/apis/library/docs.googleapis.com), [People API](https://console.cloud.google.com/apis/library/people.googleapis.com), [Search Console API](https://console.cloud.google.com/apis/library/searchconsole.googleapis.com), [Google Tasks API](https://console.cloud.google.com/apis/library/tasks.googleapis.com), [Google Meet API](https://console.cloud.google.com/apis/library/meet.googleapis.com).
-   - **Optional bundles (only if you enable them):** [Google Forms API](https://console.cloud.google.com/apis/library/forms.googleapis.com), [Google Chat API](https://console.cloud.google.com/apis/library/chat.googleapis.com).
-   - **Admin bundle (only if you set `GOOGLE_ADMIN_ACCOUNTS`):** [Admin SDK API](https://console.cloud.google.com/apis/library/admin.googleapis.com), [Alert Center API](https://console.cloud.google.com/apis/library/alertcenter.googleapis.com).
+   - **Optional bundles (only if you enable them):** [Google Forms API](https://console.cloud.google.com/apis/library/forms.googleapis.com), [Google Chat API](https://console.cloud.google.com/apis/library/chat.googleapis.com), [Alert Center API](https://console.cloud.google.com/apis/library/alertcenter.googleapis.com) (the `alertcenter` bundle also needs service-account domain-wide delegation — see the Alert Center section above).
+   - **Admin bundle (only if you set `GOOGLE_ADMIN_ACCOUNTS`):** [Admin SDK API](https://console.cloud.google.com/apis/library/admin.googleapis.com).
 4. Go to **APIs & Services → Credentials → Create Credentials → OAuth 2.0 Client ID**.
 5. Application type: **Desktop app**.
 6. Add authorized redirect URI: `http://localhost:4242/oauth2callback`.
@@ -256,7 +265,8 @@ GOOGLE_CLIENT_SECRET=your_client_secret_here
 # Define your accounts as alias:email pairs (comma-separated)
 GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
 
-# Optional (v4): enable Forms and/or Chat tool bundles
+# Optional (v4): enable Forms, Chat, and/or Alert Center tool bundles
+# (alertcenter additionally requires service-account domain-wide delegation)
 # GOOGLE_OPTIONAL_SCOPES=forms,chat
 
 # Optional (v4): grant Workspace admin scopes to specific accounts
@@ -347,6 +357,7 @@ No code changes required.
 |------------|--------|
 | `forms` | `forms.body`, `forms.responses.readonly` |
 | `chat` | `chat.spaces`, `chat.messages`, `chat.messages.create` |
+| `alertcenter` | `apps.alerts` — ⚠ requires service-account domain-wide delegation; not grantable via user OAuth (see Alert Center section) |
 
 ### Admin (per-`GOOGLE_ADMIN_ACCOUNTS` env var)
 
@@ -355,7 +366,6 @@ Only granted to accounts explicitly listed. Personal Gmail accounts will 403 on 
 | Scope | Access |
 |-------|--------|
 | `admin.reports.audit.readonly` | Workspace audit log |
-| `apps.alerts` | Alert Center |
 | `admin.directory.user` | Read/write Workspace users (writes also gated by `GOOGLE_ALLOW_ADMIN_WRITES`) |
 | `admin.directory.group.readonly` | Read groups |
 | `admin.directory.group.member.readonly` | Read group members |
@@ -383,7 +393,7 @@ mcp-google-multi/
 │       ├── meet.ts             # Meet (5) — v4
 │       ├── forms.ts            # Forms (4, optional) — v4
 │       ├── chat.ts             # Chat (4, optional) — v4
-│       └── admin.ts            # Admin SDK (8, admin) — v4
+│       └── admin.ts            # Admin SDK (6, admin) + Alert Center (2, alertcenter bundle) — v4
 ├── tests/                # vitest unit tests (gmail-mime, path-safety, field-mask helpers)
 ├── tokens/               # OAuth tokens per account (gitignored)
 ├── dist/                 # Compiled output (gitignored)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-google-multi",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "MCP server for Gmail, Google Drive, Calendar, Sheets, Docs, and Contacts with multi-account support",
   "type": "module",
   "license": "MIT",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -40,11 +40,17 @@ export const OPTIONAL_SCOPE_BUNDLES: Record<string, string[]> = {
     'https://www.googleapis.com/auth/chat.messages',
     'https://www.googleapis.com/auth/chat.messages.create',
   ],
+  // Alert Center's apps.alerts scope is NOT grantable through the interactive
+  // user-consent flow this server uses — it requires a service account with
+  // domain-wide delegation. It lives in its own opt-in bundle so it never
+  // blocks the working Admin SDK admin scopes. See README "Alert Center".
+  alertcenter: [
+    'https://www.googleapis.com/auth/apps.alerts',
+  ],
 };
 
 export const ADMIN_SCOPES = [
   'https://www.googleapis.com/auth/admin.reports.audit.readonly',
-  'https://www.googleapis.com/auth/apps.alerts',
   'https://www.googleapis.com/auth/admin.directory.user',
   'https://www.googleapis.com/auth/admin.directory.group.readonly',
   'https://www.googleapis.com/auth/admin.directory.group.member.readonly',

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { registerTasksTools } from './tools/tasks.js';
 import { registerMeetTools } from './tools/meet.js';
 import { registerFormsTools } from './tools/forms.js';
 import { registerChatTools } from './tools/chat.js';
-import { registerAdminTools } from './tools/admin.js';
+import { registerAdminTools, registerAlertCenterTools } from './tools/admin.js';
 import { getOptionalBundles, getAdminAccounts } from './auth.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -46,6 +46,7 @@ async function main() {
   const optional = new Set(getOptionalBundles());
   if (optional.has('forms')) registerFormsTools(server);
   if (optional.has('chat')) registerChatTools(server);
+  if (optional.has('alertcenter')) registerAlertCenterTools(server);
   if (getAdminAccounts().length > 0) registerAdminTools(server);
 
   const transport = new StdioServerTransport();

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -73,65 +73,6 @@ export function registerAdminTools(server: McpServer): void {
     },
   );
 
-  // ─── Alert Center ──────────────────────────────────────────────────────
-
-  server.registerTool(
-    'alertcenter_alerts_list',
-    {
-      description: 'List Workspace security alerts (suspicious login, phishing, leaked password, Drive exfil, etc.)',
-      inputSchema: {
-        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
-        pageSize: z.number().min(1).max(1000).optional(),
-        pageToken: z.string().optional(),
-        filter: z.string().optional().describe('Filter expression, e.g. "type = \\"Suspicious login\\""'),
-        orderBy: z.string().optional(),
-        customerId: z.string().optional(),
-      },
-    },
-    async ({ account, pageSize, pageToken, filter, orderBy, customerId }) => {
-      try {
-        const auth = await getClient(account as Account);
-        const alertcenter = google.alertcenter({ version: 'v1beta1', auth });
-        const res = await alertcenter.alerts.list({
-          pageSize: pageSize ?? 50,
-          pageToken,
-          filter,
-          orderBy,
-          customerId,
-        });
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
-        };
-      } catch (error: any) {
-        return handleAdminError(error, account as Account);
-      }
-    },
-  );
-
-  server.registerTool(
-    'alertcenter_alert_get',
-    {
-      description: 'Get a single alert by ID',
-      inputSchema: {
-        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
-        alertId: z.string().describe('Alert ID'),
-        customerId: z.string().optional(),
-      },
-    },
-    async ({ account, alertId, customerId }) => {
-      try {
-        const auth = await getClient(account as Account);
-        const alertcenter = google.alertcenter({ version: 'v1beta1', auth });
-        const res = await alertcenter.alerts.get({ alertId, customerId });
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
-        };
-      } catch (error: any) {
-        return handleAdminError(error, account as Account);
-      }
-    },
-  );
-
   // ─── Directory: users ─────────────────────────────────────────────────
 
   server.registerTool(
@@ -327,6 +268,76 @@ export function registerAdminTools(server: McpServer): void {
   );
 }
 
+/**
+ * Alert Center tools. Gated behind the `alertcenter` optional bundle, NOT the
+ * admin bundle: the apps.alerts scope cannot be granted via this server's
+ * interactive user-consent OAuth flow — it requires a service account with
+ * domain-wide delegation. Registered separately so a missing/ungrantable
+ * apps.alerts scope never blocks the working Admin SDK admin tools.
+ */
+export function registerAlertCenterTools(server: McpServer): void {
+  server.registerTool(
+    'alertcenter_alerts_list',
+    {
+      description: 'List Workspace security alerts (suspicious login, phishing, leaked password, Drive exfil, etc.). Requires the alertcenter bundle + service-account domain-wide delegation.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
+        pageSize: z.number().min(1).max(1000).optional(),
+        pageToken: z.string().optional(),
+        filter: z.string().optional().describe('Filter expression, e.g. "type = \\"Suspicious login\\""'),
+        orderBy: z.string().optional(),
+        customerId: z.string().optional(),
+      },
+    },
+    async ({ account, pageSize, pageToken, filter, orderBy, customerId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const alertcenter = google.alertcenter({ version: 'v1beta1', auth });
+        const res = await alertcenter.alerts.list({
+          pageSize: pageSize ?? 50,
+          pageToken,
+          filter,
+          orderBy,
+          customerId,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleAlertCenterError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'alertcenter_alert_get',
+    {
+      description: 'Get a single alert by ID. Requires the alertcenter bundle + service-account domain-wide delegation.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
+        alertId: z.string().describe('Alert ID'),
+        customerId: z.string().optional(),
+      },
+    },
+    async ({ account, alertId, customerId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const alertcenter = google.alertcenter({ version: 'v1beta1', auth });
+        const res = await alertcenter.alerts.get({ alertId, customerId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleAlertCenterError(error, account as Account);
+      }
+    },
+  );
+}
+
 function handleAdminError(error: any, account: Account) {
   return handleGoogleApiError(error, account, "Admin tools require Workspace super-admin privileges AND the account must be listed in GOOGLE_ADMIN_ACCOUNTS (then re-authenticated). Personal Gmail accounts cannot use these endpoints.");
+}
+
+function handleAlertCenterError(error: any, account: Account) {
+  return handleGoogleApiError(error, account, "Alert Center (apps.alerts) is not grantable via this server's user-consent OAuth flow — it requires a service account with domain-wide delegation. Enabling GOOGLE_OPTIONAL_SCOPES=alertcenter only declares the scope; the API will reject user-OAuth tokens. See README \"Alert Center\".");
 }


### PR DESCRIPTION
## What

Decouples the Alert Center `apps.alerts` scope from the admin bundle so it can no longer break admin OAuth consent.

Fixes #4.

## Why

`apps.alerts` was hardcoded into `ADMIN_SCOPES`, which are requested via this server's interactive **user-consent** OAuth flow. Google only grants `apps.alerts` to a **service account with domain-wide delegation** ([docs](https://developers.google.com/workspace/admin/alertcenter/guides/auth)), so it is unresolvable on the consent screen. Result: every account in `GOOGLE_ADMIN_ACCOUNTS` failed the *entire* consent with `Error 400: invalid_scope`, blocking the working Admin SDK Directory + Reports tools too.

## Changes

- `auth.ts`: remove `apps.alerts` from `ADMIN_SCOPES`; add `alertcenter` to `OPTIONAL_SCOPE_BUNDLES`.
- `admin.ts`: extract the two Alert Center tools into `registerAlertCenterTools`; add `handleAlertCenterError` with a service-account / domain-wide-delegation hint.
- `index.ts`: register Alert Center tools behind `optional.has('alertcenter')`, not `getAdminAccounts()`.
- Docs: README (admin → 6 tools, new Alert Center section + caveat, scope tables, API-enablement, 13 services), `.env.example`, `CLAUDE.md`, `CHANGELOG.md`.
- Version: 4.1.0 (new optional bundle).

## Effect

- Admin bundle: 6 tools (Reports + Directory), consents cleanly via user OAuth.
- Alert Center: opt-in 2-tool `alertcenter` bundle — declared-but-non-functional under user OAuth until a service-account auth path is added (follow-up).

## Verification

- `npm run typecheck && npm run lint && npm run test` → 51/51 pass, clean.
- `npm run build` → OK.
- Resolved scopes for an admin account: `apps.alerts` gone, 4 Admin SDK scopes intact.

## Re-auth note

Accounts in `GOOGLE_ADMIN_ACCOUNTS` should re-run `npm run auth -- <alias>` to drop `apps.alerts` from their token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
