### PR TITLE
feat(drive): add convertTo to drive_upload for native Workspace import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.2.0] — 2026-05-20
+
+### Added
+
+- `drive_upload` gains an optional `convertTo` parameter. When set to a `application/vnd.google-apps.*` type, Drive converts the upload on import — so you can upload Markdown/HTML/DOCX/TXT and get a native, editable Google Doc/Sheet/Slides/Drawing instead of a stored raw file. Backward compatible: omitting `convertTo` keeps the previous store-as-is behaviour. (#6)
+
 ## [4.1.0] — 2026-05-20
 
 > **Re-authenticate accounts listed in `GOOGLE_ADMIN_ACCOUNTS`.** The admin scope set shrank — `apps.alerts` is no longer requested by the admin bundle. Re-run `npm run auth -- <alias>` so the token drops it cleanly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,10 @@ server.registerTool(
 
 Every Drive API call that takes a `fileId` must pass `supportsAllDrives: true`. List operations also need `includeItemsFromAllDrives: true`. Forgetting these silently breaks shared-drive content. Existing tools already have them — preserve when refactoring.
 
+## Drive-specific: import conversion
+
+To convert an upload into a native Workspace file, set the **resource** (`requestBody`) `mimeType` to a `application/vnd.google-apps.*` type while the `media` carries the importable source type. The media mimeType is the source; the resource mimeType is the target. `drive_upload`'s `convertTo` param does exactly this. Drive v3 has no separate `convert` flag (the v2 one is deprecated). `drive_export` is the reverse direction only.
+
 ## Sheets/Docs: fields masks
 
 `spreadsheets.batchUpdate` Request types like `RepeatCell` and `updateParagraphStyle` require explicit `fields` masks. Compute the mask from supplied input keys; never use wildcards. The helpers `buildCellFormat` (in `sheets.ts`), `buildParagraphStyle`, and `buildDocumentStyle` (in `docs.ts`) are the reference implementations and are unit-tested in `tests/field-mask-helpers.test.ts`. If you add a new format dimension, extend the helper, add a test, and bump the input schema.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A local [MCP](https://modelcontextprotocol.io) server that gives Claude Code (an
 | `drive_search` | Search files with Drive query syntax (shared drives included) |
 | `drive_read` | Read file content (exports Workspace docs as text) |
 | `drive_list` | List files in a folder or root |
-| `drive_upload` | Upload a local file to Drive |
+| `drive_upload` | Upload a local file to Drive (optional `convertTo` imports it as a native Google Doc/Sheet/Slides) |
 | `drive_download` | Download a binary file to local disk |
 | `drive_export` | Export Google Docs/Sheets/Slides to PDF, DOCX, XLSX, Markdown, etc. |
 | `drive_create_folder` | Create a new folder |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-google-multi",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "MCP server for Gmail, Google Drive, Calendar, Sheets, Docs, and Contacts with multi-account support",
   "type": "module",
   "license": "MIT",

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -219,16 +219,22 @@ export function registerDriveTools(server: McpServer): void {
   server.registerTool(
     'drive_upload',
     {
-      description: 'Upload a local file to Google Drive',
+      description: 'Upload a local file to Google Drive. Pass `convertTo` to import it as a native, editable Google Doc/Sheet/Slides/Drawing instead of storing the raw bytes.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         localPath: z.string().describe('Absolute path to file on disk'),
         filename: z.string().describe('Name as it appears in Drive'),
-        mimeType: z.string().optional().describe('MIME type (inferred from extension if omitted)'),
+        mimeType: z.string().optional().describe('Source MIME type of the local file (inferred from extension if omitted). With `convertTo`, this is the format Drive imports from.'),
+        convertTo: z.enum([
+          'application/vnd.google-apps.document',
+          'application/vnd.google-apps.spreadsheet',
+          'application/vnd.google-apps.presentation',
+          'application/vnd.google-apps.drawing',
+        ]).optional().describe('Convert the upload into this native Google Workspace type on import (e.g. upload .md/.html/.docx/.txt with convertTo=...google-apps.document to get a real Google Doc). Source must be an importable format. Omit to store the file as-is.'),
         parentFolderId: z.string().optional().describe('Parent folder ID (defaults to My Drive root)'),
       },
     },
-    async ({ account, localPath, filename, mimeType: mimeTypeArg, parentFolderId }) => {
+    async ({ account, localPath, filename, mimeType: mimeTypeArg, convertTo, parentFolderId }) => {
       try {
         const auth = await getClient(account as Account);
         const drive = google.drive({ version: 'v3', auth });
@@ -240,6 +246,8 @@ export function registerDriveTools(server: McpServer): void {
           requestBody: {
             name: filename,
             parents: parentFolderId ? [parentFolderId] : undefined,
+            // Setting a google-apps target type makes Drive convert the media on import.
+            ...(convertTo ? { mimeType: convertTo } : {}),
           },
           media: {
             mimeType: resolvedMime,


### PR DESCRIPTION
## What

Adds an optional `convertTo` parameter to `drive_upload` so a local file can be imported as a **native, editable** Google Doc/Sheet/Slides/Drawing instead of being stored as raw bytes.

Fixes #6.

## Why

`drive_upload` set `media.mimeType` (source) but never set the resource `mimeType`, so Drive never converted uploads. Producing a formatted Google Doc previously required building it field-by-field via the `docs_*` API. `drive_export` only covers the reverse direction.

## Change

```ts
convertTo: z.enum([
  'application/vnd.google-apps.document',
  'application/vnd.google-apps.spreadsheet',
  'application/vnd.google-apps.presentation',
  'application/vnd.google-apps.drawing',
]).optional()
```

When present it is set as `requestBody.mimeType`; Drive v3 then converts the media (importable source format — `text/html`, `text/markdown`, `text/plain`, `.docx`, `.rtf`, …) into the chosen native type. Backward compatible: omitting `convertTo` is unchanged.

Docs: README tool row, a "Drive-specific: import conversion" note in CLAUDE.md, CHANGELOG; version → 4.2.0.

## Verification

- `npm run typecheck && npm run lint && npm run test` → 51/51 pass, clean.
- `npm run build` → OK.
- Pure API param passthrough; per repo policy (`googleapis` not mocked) it's covered by manual smoke rather than a unit test.

## Example

Write HTML to a temp file → `drive_upload(localPath, convertTo: 'application/vnd.google-apps.document')` → a real formatted Google Doc. LibreOffice (installed locally) can pre-render clean HTML/DOCX from Markdown if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
