### PR TITLE
chore(repo): OSS community health files + multi-branch CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report! **Do not paste OAuth tokens, client secrets, authorization codes, or `.env` contents.** For security vulnerabilities, use private reporting instead — see SECURITY.md.
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `node -p "require('./package.json').version"` (or the release tag).
+      placeholder: "4.2.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: tool
+    attributes:
+      label: Which tool / service?
+      options:
+        - Gmail
+        - Drive
+        - Calendar
+        - Sheets
+        - Docs
+        - Contacts
+        - Search Console
+        - Tasks
+        - Meet
+        - Forms (optional bundle)
+        - Chat (optional bundle)
+        - Admin (admin bundle)
+        - Alert Center (optional bundle)
+        - Auth / setup
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: account-type
+    attributes:
+      label: Account type
+      description: Workspace or personal @gmail.com? (Some tools, e.g. Chat/Admin, are Workspace-only.)
+      placeholder: "Workspace / personal"
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, and what happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact tool call / inputs (with secrets redacted).
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      description: Relevant stderr or error payload. Redact any tokens or emails you don't want public.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/bakissation/mcp-google-multi/security
+    about: Please report security issues privately, not as public issues. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Suggest a new tool, parameter, or capability
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: service
+    attributes:
+      label: Which service does this touch?
+      options:
+        - Gmail
+        - Drive
+        - Calendar
+        - Sheets
+        - Docs
+        - Contacts
+        - Search Console
+        - Tasks
+        - Meet
+        - Forms
+        - Chat
+        - Admin
+        - Alert Center
+        - New service
+        - Cross-cutting / infra
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that you can't today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: New tool, new parameter on an existing tool, etc. Include the Google API method if you know it.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Thanks for contributing! Please target the `dev` branch (not main/staging).
+See CONTRIBUTING.md for the full workflow.
+-->
+
+## What & why
+
+<!-- What does this change and why? Link any related issue: "Fixes #123". -->
+
+## Type of change
+
+- [ ] Bug fix (`fix:`)
+- [ ] New feature / tool / parameter (`feat:`)
+- [ ] Docs / chore
+
+## Checklist
+
+- [ ] PR targets **`dev`**
+- [ ] `npm run typecheck`, `npm run lint`, `npm run test`, `npm run build` all pass
+- [ ] Conventional commit messages
+- [ ] README tables + `CHANGELOG.md` updated; version bumped if warranted
+- [ ] No secrets, tokens, or `.env` committed
+- [ ] New pure-logic helpers have unit tests (handlers verified by manual smoke test)
+
+## How was this tested?
+
+<!-- Unit tests and/or which accounts you smoke-tested against. -->

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging, dev]
   pull_request:
-    branches: [main]
+    branches: [main, staging, dev]
 
 jobs:
   ci:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards and will take appropriate and fair corrective action in response to any behavior they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately through the repository's [Security advisory / private reporting](https://github.com/bakissation/mcp-google-multi/security) channel. All complaints will be reviewed and investigated promptly and fairly. Community leaders are obligated to respect the privacy and security of the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to mcp-google-multi
+
+Thanks for your interest in contributing! This is an MCP server exposing Gmail, Drive, Calendar, Sheets, Docs, Contacts, Search Console, Tasks, Meet, Forms, Chat, Admin SDK, and Alert Center tools with multi-account OAuth.
+
+## Branching model
+
+This repo uses a three-tier promotion flow:
+
+```
+your fork ──PR──▶ dev ──▶ staging ──▶ main (releases tagged here)
+                  ▲         (maintainer-promoted)
+            contributors
+            target dev
+```
+
+- **Open all PRs against `dev`.** PRs to `staging` or `main` from contributors will be redirected.
+- The maintainer promotes `dev → staging → main` and cuts releases from `main`.
+- `dev`, `staging`, and `main` are all protected: CI must pass and changes land via pull request.
+
+## Dev setup
+
+```bash
+git clone https://github.com/bakissation/mcp-google-multi.git
+cd mcp-google-multi
+npm install
+cp .env.example .env          # add your GOOGLE_CLIENT_ID/SECRET and GOOGLE_ACCOUNTS
+npm run build
+node dist/index.js auth --account <alias>   # OAuth each account you'll test with
+```
+
+You need a Google Cloud project with the relevant APIs enabled and an OAuth 2.0 Desktop client — see the README "Setup" section.
+
+**Never commit `.env` or anything under `tokens/`** (both are gitignored). Don't paste tokens, client secrets, or OAuth codes into issues or PRs.
+
+## Before you open a PR
+
+All of these must pass:
+
+```bash
+npm run typecheck
+npm run lint
+npm run test
+npm run build
+```
+
+## Conventions
+
+The full spec lives in [`CLAUDE.md`](./CLAUDE.md). The essentials:
+
+- **One service per file** in `src/tools/<service>.ts`, exporting `register<Service>Tools(server)`.
+- **Tool shape:** `server.registerTool(name, { description, inputSchema }, handler)`. `inputSchema` is a flat `zod` object with `account: accountEnum` as the first field. Tool names are `snake_case`, prefixed by service.
+- **Errors:** wrap handlers in `try/catch` and delegate to the per-service `handle<Service>Error` shim (which calls `handleGoogleApiError`). Set `isError: true` on error responses.
+- **Scopes** are tiered in `src/auth.ts`: `BASE_SCOPES` (always), `OPTIONAL_SCOPE_BUNDLES` (env opt-in), `ADMIN_SCOPES` (per-account opt-in). Any new scope must be documented and noted as requiring re-auth.
+- **No `console.log`** in tool handlers — stdio is the MCP channel; use `process.stderr.write` if needed.
+- **Tests:** pure-logic helpers get unit tests (`vitest`). Handlers are verified by manual smoke testing — we do not mock `googleapis`.
+
+## Commits & versioning
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `docs:`, `chore:`, etc.
+- Semver is manual in `package.json`. New tools / optional bundles / scopes = minor; bug fixes = patch; new `BASE_SCOPES` (forces re-auth) = major.
+- Update `CHANGELOG.md` and the relevant README tables in the same PR.
+
+## PR checklist
+
+- [ ] Targets `dev`
+- [ ] `typecheck`, `lint`, `test`, `build` all pass
+- [ ] Conventional commit messages
+- [ ] README + `CHANGELOG.md` updated; version bumped if warranted
+- [ ] No secrets, tokens, or `.env` committed
+
+## Security
+
+Do **not** report vulnerabilities in public issues. See [`SECURITY.md`](./SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -424,7 +424,9 @@ mcp-google-multi/
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or submit a pull request.
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) first. In short: **open pull requests against the `dev` branch** — changes are promoted `dev → staging → main`, and `main` is release-only. Run `typecheck`/`lint`/`test`/`build` before submitting, and use Conventional Commits.
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). For security issues, **do not open a public issue** — see [SECURITY.md](SECURITY.md).
 
 ## Author
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported versions
+
+This project follows semantic versioning. Security fixes are applied to the **latest released minor version** only. Please upgrade before reporting.
+
+## Reporting a vulnerability
+
+**Do not open a public issue or pull request for security vulnerabilities.**
+
+Report privately via GitHub's **Private Vulnerability Reporting**:
+
+1. Go to the [Security tab](https://github.com/bakissation/mcp-google-multi/security) of this repository.
+2. Click **Report a vulnerability**.
+3. Describe the issue, affected version, and reproduction steps.
+
+You'll get an acknowledgement and can track the fix in the private advisory. Once a fix ships, the advisory is published with credit (unless you prefer to remain anonymous).
+
+## Why this matters here
+
+This server brokers OAuth access to Google accounts — Gmail, Drive, Calendar, and (when enabled) Workspace **Admin SDK** scopes. A vulnerability could expose mail, files, or directory data. Of particular interest:
+
+- **Token handling** — tokens live under `tokens/<alias>/token.json` (mode `0600`) and must never be logged or transmitted.
+- **Header / MIME construction** — Gmail tools build raw RFC 5322 messages; injection (e.g. CRLF in headers) is in scope.
+- **Scope escalation** — anything that grants an account scopes it didn't consent to.
+
+## Out of scope
+
+- Vulnerabilities requiring an already-compromised local machine or a maliciously modified `.env`.
+- Issues in Google's own APIs (report those to Google).
+
+## Good hygiene for everyone
+
+Never paste OAuth tokens, client secrets, authorization codes, or `.env` contents into issues, PRs, or logs.


### PR DESCRIPTION
Adds the missing community health files (CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, issue/PR templates) and updates CI to run on `main`/`staging`/`dev` ahead of branch protection.

Bootstrap PR — goes to `main` so the files land on the default branch (community profile) before `dev`/`staging` are created from it and all three are protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)