### PR TITLE
ci: least-privilege permissions on test workflow (CodeQL)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, staging, dev]
 
+# Least privilege: CI only checks out code + runs npm. (CodeQL: actions/missing-workflow-permissions)
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` to `.github/workflows/test.yml`.

Resolves CodeQL alert **actions/missing-workflow-permissions** (#1) — the CI workflow had no `permissions` block, so it inherited broad repo-default `GITHUB_TOKEN` scopes. The `ci` job only checks out code and runs npm (lint/typecheck/build/test), so read-only `contents` is sufficient. `release.yml` already sets its own (broader, needed) permissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)