### PR TITLE
ci: publish to npm via semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,11 @@ on:
   push:
     branches: [main, staging, dev]
 
-# Tags + GitHub Releases only — no commit-back, so nothing fights branch
-# protection. GITHUB_TOKEN is sufficient (it pushes a tag, not a branch commit).
 permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -28,6 +27,7 @@ jobs:
         with:
           node-version: 24
           cache: npm
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -38,4 +38,6 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
         run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,6 +7,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
     [
       "@semantic-release/github",
       {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,28 @@
   "description": "MCP server for Gmail, Google Drive, Calendar, Sheets, Docs, and Contacts with multi-account support",
   "type": "module",
   "license": "MIT",
+  "bin": {
+    "mcp-google-multi": "dist/index.js"
+  },
+  "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bakissation/mcp-google-multi.git"
+  },
+  "bugs": {
+    "url": "https://github.com/bakissation/mcp-google-multi/issues"
+  },
+  "homepage": "https://github.com/bakissation/mcp-google-multi#readme",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "keywords": [
     "mcp",
     "model-context-protocol",
@@ -19,6 +41,7 @@
   ],
   "scripts": {
     "build": "tsc && chmod +x dist/index.js",
+    "prepublishOnly": "npm run build",
     "watch": "tsc --watch",
     "auth": "node dist/index.js auth --account",
     "lint": "eslint .",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import './accounts.js';
 
 import { readFileSync } from 'node:fs';


### PR DESCRIPTION
Wires npm publishing into the existing release pipeline. Per-channel dist-tags: `main`→`latest`, `staging`→`beta`, `dev`→`alpha`. Package name `mcp-google-multi` (available, unscoped). No commit-back — fits the protected-branch model; `GITHUB_TOKEN` tags/releases, `NPM_TOKEN` publishes, provenance via `id-token`.

**⚠ Do not merge until the `NPM_TOKEN` secret is set.** `@semantic-release/npm` runs `verifyConditions` on every release-workflow invocation and fails the run if the token is missing — even for no-release pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)