### PR TITLE
ci: fix npm auth (drop setup-node registry-url)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Removes `registry-url` from the `setup-node` step. It made setup-node write an `.npmrc` keyed to `NODE_AUTH_TOKEN` (which we don't set), colliding with `@semantic-release/npm`'s own `NPM_TOKEN` auth → false "Invalid npm token" in `verifyConditions`. semantic-release now owns auth via `NPM_TOKEN` alone.