### PR TITLE
ci: npm publish via OIDC trusted publishing (token-free)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
         run: npx semantic-release


### PR DESCRIPTION
Switches the release workflow to **npm trusted publishing (OIDC)** — removes `NPM_TOKEN` and `NPM_CONFIG_PROVENANCE` from the Release step (keeps `id-token: write`). `@semantic-release/npm` auto-detects OIDC; provenance is automatic. No long-lived token, no expiry, no 2FA.

**⚠ Do not merge until the Trusted Publisher is configured on the npm package** (Settings → Trusted Publisher → GitHub Actions → bakissation/mcp-google-multi / release.yml). Merging before that would leave releases with no npm auth.

After merge: delete the `NPM_TOKEN` secret and revoke the granular token.