### PR TITLE
chore(deps): npm audit fix (brace-expansion ReDoS, dev-only)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-google-multi",
-  "version": "4.2.0",
+  "version": "0.0.0-semantically-released",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-google-multi",
-      "version": "4.2.0",
+      "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -16,6 +16,9 @@
         "open": "^11.0.0",
         "server-destroy": "^1.0.1",
         "zod": "^4.3.6"
+      },
+      "bin": {
+        "mcp-google-multi": "dist/index.js"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -27,6 +30,9 @@
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.1",
         "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@actions/core": {
@@ -1903,9 +1909,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Clears the eslint→minimatch→brace-expansion path to patched `5.0.6` ([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)). Lockfile-only, dev-only — the **production tree was already 0 vulns** (package consumers unaffected). Remaining advisory is npm's *bundled* brace-expansion (not fixable here; clears when `@semantic-release/npm` bumps npm). `chore:` — no release.