### PR TITLE
docs: mark project maintainer-led (roadmap on Milestones)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing to mcp-google-multi
 
-Thanks for your interest in contributing! This is an MCP server exposing Gmail, Drive, Calendar, Sheets, Docs, Contacts, Search Console, Tasks, Meet, Forms, Chat, Admin SDK, and Alert Center tools with multi-account OAuth.
+Thanks for your interest! This is an MCP server exposing Gmail, Drive, Calendar, Sheets, Docs, Contacts, Search Console, Tasks, Meet, Forms, Chat, and Admin SDK tools with multi-account OAuth.
+
+> **This project is maintainer-led.** The roadmap is published as **[GitHub Milestones](https://github.com/bakissation/mcp-google-multi/milestones)** — there is no code-ready issue backlog, and **unsolicited feature PRs aren't being accepted** right now. **Bug reports and security reports are very welcome** (open an issue for bugs; see [SECURITY.md](./SECURITY.md) for vulnerabilities). If you'd like to contribute a fix, please **open an issue first** so we can confirm it fits the roadmap. The branching/PR mechanics below apply to changes that have been agreed.
 
 ## Branching model
 


### PR DESCRIPTION
Adds a maintainer-led banner to CONTRIBUTING: roadmap is now published as [GitHub Milestones](https://github.com/bakissation/mcp-google-multi/milestones), no code-ready issue backlog, unsolicited feature PRs paused, bugs/security still welcome (open an issue first). Mirrors the v5 re-scope to local-only + user-OAuth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)