### PR TITLE
feat: secret redactor + minimal stderr logger (cc-logging)

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -1,0 +1,30 @@
+// Minimal stderr logger. stdout is the MCP channel — anything written there
+// corrupts the protocol — so all diagnostics go to stderr. Object args are
+// redacted first. `debug` is off unless MCP_LOG=debug (or DEBUG) is set.
+// Structured/observability logging is deferred to v6 (see FSD cc-logging).
+import { redact } from './redactor.js';
+
+const DEBUG_ENABLED = /^(1|true|debug)$/i.test(
+  process.env.MCP_LOG ?? process.env.DEBUG ?? '',
+);
+
+type Level = 'DEBUG' | 'WARN' | 'ERROR';
+
+function emit(level: Level, msg: string, meta?: unknown): void {
+  let line = `mcp-google-multi ${level}: ${msg}`;
+  if (meta !== undefined) line += ' ' + JSON.stringify(redact(meta));
+  process.stderr.write(line + '\n');
+}
+
+export const log = {
+  /** Verbose; only emitted when MCP_LOG=debug (or DEBUG) is set. */
+  debug(msg: string, meta?: unknown): void {
+    if (DEBUG_ENABLED) emit('DEBUG', msg, meta);
+  },
+  warn(msg: string, meta?: unknown): void {
+    emit('WARN', msg, meta);
+  },
+  error(msg: string, meta?: unknown): void {
+    emit('ERROR', msg, meta);
+  },
+};

--- a/src/redactor.ts
+++ b/src/redactor.ts
@@ -1,0 +1,69 @@
+// Secret redactor — a security primitive, not logging polish. Any object that
+// might be logged or embedded in an error message is passed through here first
+// so OAuth tokens and secrets never leak. See FSD cc-logging / cc-security.
+
+const REDACTED = '[REDACTED]';
+
+// Normalized (lowercased, non-alphanumerics stripped) key names to redact.
+// Deliberately NOT bare "token" — that would clobber non-secret Google fields
+// like pageToken / nextPageToken / token_type.
+const SENSITIVE_KEYS = new Set([
+  'accesstoken',
+  'refreshtoken',
+  'idtoken',
+  'authtoken',
+  'authorization',
+  'clientsecret',
+  'privatekey',
+  'apikey',
+  'password',
+  'encblob',
+]);
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEYS.has(key.toLowerCase().replace(/[^a-z0-9]/g, ''));
+}
+
+/**
+ * Deep-copy `value` with sensitive fields replaced by `[REDACTED]`.
+ * Never mutates the input. Safe on circular/shared references, arrays,
+ * `Error`, `Date`, and `Buffer`.
+ */
+export function redact<T>(value: T): T {
+  return redactInner(value, new WeakMap()) as T;
+}
+
+function redactInner(value: unknown, seen: WeakMap<object, unknown>): unknown {
+  if (value === null || typeof value !== 'object') return value;
+
+  if (Buffer.isBuffer(value)) return '[Buffer]';
+  if (value instanceof Date) return value;
+
+  const existing = seen.get(value);
+  if (existing !== undefined) return existing;
+
+  if (value instanceof Error) {
+    const out: Record<string, unknown> = { name: value.name, message: value.message };
+    seen.set(value, out);
+    for (const key of Object.keys(value)) {
+      out[key] = isSensitiveKey(key)
+        ? REDACTED
+        : redactInner((value as unknown as Record<string, unknown>)[key], seen);
+    }
+    return out;
+  }
+
+  if (Array.isArray(value)) {
+    const out: unknown[] = [];
+    seen.set(value, out);
+    for (const item of value) out.push(redactInner(item, seen));
+    return out;
+  }
+
+  const out: Record<string, unknown> = {};
+  seen.set(value, out);
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = isSensitiveKey(key) ? REDACTED : redactInner(v, seen);
+  }
+  return out;
+}

--- a/tests/log.test.ts
+++ b/tests/log.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('log', () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  let outSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    outSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('writes warn/error to stderr, never stdout', async () => {
+    const { log } = await import('../src/log.js');
+    log.warn('hi');
+    log.error('bad');
+    expect(outSpy).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledTimes(2);
+    expect(errSpy.mock.calls[0][0]).toContain('mcp-google-multi WARN: hi');
+    expect(errSpy.mock.calls[1][0]).toContain('mcp-google-multi ERROR: bad');
+  });
+
+  it('redacts object metadata before writing', async () => {
+    const { log } = await import('../src/log.js');
+    log.error('oops', { access_token: 'SECRET', keep: 1 });
+    const line = String(errSpy.mock.calls[0][0]);
+    expect(line).not.toContain('SECRET');
+    expect(line).toContain('[REDACTED]');
+    expect(line).toContain('"keep":1');
+  });
+
+  it('suppresses debug by default', async () => {
+    vi.stubEnv('MCP_LOG', '');
+    vi.stubEnv('DEBUG', '');
+    vi.resetModules();
+    const { log } = await import('../src/log.js');
+    log.debug('quiet');
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits debug when MCP_LOG=debug', async () => {
+    vi.stubEnv('MCP_LOG', 'debug');
+    vi.resetModules();
+    const { log } = await import('../src/log.js');
+    log.debug('loud');
+    expect(errSpy).toHaveBeenCalledOnce();
+    expect(String(errSpy.mock.calls[0][0])).toContain('DEBUG: loud');
+  });
+});

--- a/tests/redactor.test.ts
+++ b/tests/redactor.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { redact } from '../src/redactor.js';
+
+describe('redact', () => {
+  it('redacts top-level secret keys (snake_case)', () => {
+    const out = redact({
+      access_token: 'a', refresh_token: 'b', id_token: 'c', client_secret: 'd',
+      private_key: 'e', authorization: 'Bearer x', auth_token: 't', api_key: 'k',
+      password: 'p', enc_blob: 'z',
+    });
+    for (const v of Object.values(out)) expect(v).toBe('[REDACTED]');
+  });
+
+  it('redacts camelCase and capitalized variants', () => {
+    const out = redact({
+      accessToken: 'a', refreshToken: 'b', idToken: 'c', authToken: 'd',
+      clientSecret: 'e', privateKey: 'f', apiKey: 'g', Authorization: 'h',
+    });
+    for (const v of Object.values(out)) expect(v).toBe('[REDACTED]');
+  });
+
+  it('redacts nested objects and arrays', () => {
+    const out = redact({ a: { b: { access_token: 'x' } }, arr: [{ refresh_token: 'y' }] });
+    expect(out.a.b.access_token).toBe('[REDACTED]');
+    expect(out.arr[0].refresh_token).toBe('[REDACTED]');
+  });
+
+  it('does NOT over-redact non-secret Google fields', () => {
+    const input = { pageToken: '1', nextPageToken: '2', token_type: 'Bearer', scope: 's', email: 'a@b.com', expiry_date: 123 };
+    expect(redact(input)).toEqual(input);
+  });
+
+  it('handles circular references', () => {
+    const o: Record<string, unknown> = { access_token: 'x' };
+    o.self = o;
+    const out = redact(o) as Record<string, unknown>;
+    expect(out.access_token).toBe('[REDACTED]');
+    expect(out.self).toBe(out);
+  });
+
+  it('collapses shared references to one redacted copy', () => {
+    const shared = { refresh_token: 'x' };
+    const out = redact({ a: shared, b: shared });
+    expect(out.a).toBe(out.b);
+    expect(out.a.refresh_token).toBe('[REDACTED]');
+  });
+
+  it('does not mutate the input', () => {
+    const input = { access_token: 'secret', keep: 1 };
+    redact(input);
+    expect(input.access_token).toBe('secret');
+  });
+
+  it('passes through primitives', () => {
+    expect(redact('hello')).toBe('hello');
+    expect(redact(42)).toBe(42);
+    expect(redact(null)).toBe(null);
+    expect(redact(undefined)).toBe(undefined);
+  });
+
+  it('redacts secret keys inside Error objects but keeps name + message', () => {
+    const e = new Error('boom') as Error & { access_token?: string; config?: unknown };
+    e.access_token = 'x';
+    e.config = { headers: { Authorization: 'Bearer y' } };
+    const out = redact(e) as Record<string, unknown>;
+    expect(out.name).toBe('Error');
+    expect(out.message).toBe('boom');
+    expect(out.access_token).toBe('[REDACTED]');
+    expect((out.config as { headers: { Authorization: string } }).headers.Authorization).toBe('[REDACTED]');
+  });
+
+  it('does not leak Buffer bytes', () => {
+    const out = redact({ enc_blob: Buffer.from('x'), other: Buffer.from('y') });
+    expect(out.enc_blob).toBe('[REDACTED]');
+    expect(out.other).toBe('[Buffer]');
+  });
+
+  it('keeps Date values intact', () => {
+    const d = new Date('2020-01-01T00:00:00Z');
+    expect(redact({ when: d }).when).toBe(d);
+  });
+});


### PR DESCRIPTION
Phase 0, Slice 1. Adds the secret redactor (security primitive — scrubs tokens from logs/errors) and a minimal off-by-default stderr logger. Structured/observability logging deferred to v6 per the right-sized cc-logging spec. 15 unit tests; typecheck/lint/test/build green.