### PR TITLE
feat: encrypted token storage (AES-256-GCM) + MASTER_KEY + migrate-tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ GOOGLE_CLIENT_SECRET=your_client_secret_here
 # Example: work:you@company.com,personal:you@gmail.com
 GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
 
+# Encryption key for stored OAuth tokens (required). Generate with:
+#   openssl rand -base64 32
+MASTER_KEY=your_base64_32_byte_key_here
+
 # ─── Optional (v4.0.0) ──────────────────────────────────────────────────
 # Opt in to additional scope bundles. Each bundle enables a tool group and
 # its OAuth scopes. Re-auth all accounts after changing this.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "prepublishOnly": "npm run build",
     "watch": "tsc --watch",
     "auth": "node dist/index.js auth --account",
+    "migrate-tokens": "node dist/index.js migrate-tokens",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -5,11 +5,14 @@ import path from 'node:path';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
-const tokenDir = path.resolve(__dirname, '..', 'tokens');
+const tokenDir = process.env.TOKEN_STORE_PATH
+  ? path.resolve(process.env.TOKEN_STORE_PATH)
+  : path.resolve(__dirname, '..', 'tokens');
 
 export interface AccountConfig {
   email: string;
   tokenPath: string;
+  encPath: string;
 }
 
 /**
@@ -61,6 +64,7 @@ function parseAccounts(): { aliases: [string, ...string[]]; configs: Record<stri
     configs[alias] = {
       email,
       tokenPath: path.join(tokenDir, alias, 'token.json'),
+      encPath: path.join(tokenDir, `${alias}.enc`),
     };
   }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,11 +2,10 @@ import { google } from 'googleapis';
 import http from 'node:http';
 import { URL } from 'node:url';
 import { randomBytes } from 'node:crypto';
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import open from 'open';
 import destroyer from 'server-destroy';
 import { ACCOUNTS, ACCOUNT_CONFIG } from './accounts.js';
+import { writeToken } from './token-store.js';
 
 // ─── Scope tiers ────────────────────────────────────────────────────────
 //
@@ -114,6 +113,13 @@ export async function runAuthFlow(args: string[]): Promise<void> {
   const config = ACCOUNT_CONFIG[alias];
   const scopes = resolveScopesForAccount(alias);
 
+  if (!process.env.MASTER_KEY) {
+    console.error(
+      'MASTER_KEY is not set. Generate one (openssl rand -base64 32) and add it to .env before authenticating.',
+    );
+    process.exit(1);
+  }
+
   const oauth2Client = new google.auth.OAuth2(
     process.env.GOOGLE_CLIENT_ID,
     process.env.GOOGLE_CLIENT_SECRET,
@@ -174,13 +180,7 @@ export async function runAuthFlow(args: string[]): Promise<void> {
 
             const { tokens } = await oauth2Client.getToken(code);
 
-            await fs.mkdir(path.dirname(config.tokenPath), { recursive: true });
-            // 0o600: tokens grant full account access; keep them user-only.
-            await fs.writeFile(
-              config.tokenPath,
-              JSON.stringify(tokens, null, 2),
-              { mode: 0o600 },
-            );
+            writeToken(alias, tokens);
 
             res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end(
@@ -188,7 +188,7 @@ export async function runAuthFlow(args: string[]): Promise<void> {
             );
             (server as any).destroy();
 
-            console.log(`Token saved to ${config.tokenPath}`);
+            console.log(`Token saved (encrypted) for ${alias}.`);
             resolve();
           }
         } catch (e) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,7 @@
 import { google } from 'googleapis';
-import fs from 'node:fs/promises';
 import { ACCOUNT_CONFIG } from './accounts.js';
 import type { Account } from './accounts.js';
-import type { TokenData } from './types.js';
+import { readToken, writeToken } from './token-store.js';
 
 export async function getClient(account: Account) {
   const config = ACCOUNT_CONFIG[account];
@@ -20,30 +19,19 @@ export async function getClient(account: Account) {
     'http://localhost:4242/oauth2callback',
   );
 
-  let tokenData: TokenData;
-  try {
-    const raw = await fs.readFile(config.tokenPath, 'utf-8');
-    tokenData = JSON.parse(raw);
-  } catch {
+  const tokenData = readToken(account);
+  if (!tokenData) {
     throw new Error(
-      `No token file found for account "${account}" at ${config.tokenPath}. ` +
-        `Run: node dist/index.js auth --account ${account}`,
+      `No token found for account "${account}" (${config.email}). ` +
+        `Run: npx mcp-google-multi auth --account ${account}`,
     );
   }
 
   oauth2Client.setCredentials(tokenData);
 
-  // 0o600: tokens grant full account access; keep them user-only.
-  oauth2Client.on('tokens', async (tokens) => {
-    try {
-      const existing = JSON.parse(
-        await fs.readFile(config.tokenPath, 'utf-8'),
-      );
-      const merged = { ...existing, ...tokens };
-      await fs.writeFile(config.tokenPath, JSON.stringify(merged, null, 2), { mode: 0o600 });
-    } catch {
-      await fs.writeFile(config.tokenPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
-    }
+  oauth2Client.on('tokens', (tokens) => {
+    const existing = readToken(account) ?? {};
+    writeToken(account, { ...existing, ...tokens });
   });
 
   return oauth2Client;

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,12 @@ async function main() {
     return;
   }
 
+  if (process.argv.includes('migrate-tokens')) {
+    const { runMigrateTokens } = await import('./migrate-tokens.js');
+    runMigrateTokens();
+    return;
+  }
+
   // MCP server mode — no console.log (stdio is the MCP channel)
   const server = new McpServer({
     name: 'mcp-google-multi',

--- a/src/migrate-tokens.ts
+++ b/src/migrate-tokens.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import { ACCOUNTS, ACCOUNT_CONFIG } from './accounts.js';
+import { writeToken, hasToken } from './token-store.js';
+
+export function runMigrateTokens(): void {
+  let migrated = 0;
+  let skipped = 0;
+  for (const alias of ACCOUNTS) {
+    const plain = ACCOUNT_CONFIG[alias].tokenPath;
+    if (!fs.existsSync(plain)) continue;
+    if (hasToken(alias)) {
+      console.log(`• ${alias}: encrypted token already exists, skipping`);
+      skipped++;
+      continue;
+    }
+    writeToken(alias, JSON.parse(fs.readFileSync(plain, 'utf8')));
+    console.log(`✓ ${alias}: migrated ${plain} → encrypted store`);
+    migrated++;
+  }
+  console.log(
+    `Done. ${migrated} migrated, ${skipped} skipped. ` +
+      'Delete the plaintext tokens/<alias>/token.json once verified.',
+  );
+}

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -1,0 +1,82 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { ACCOUNT_CONFIG } from './accounts.js';
+import type { TokenData } from './types.js';
+
+const ENC_VERSION = 1;
+const ALGO = 'aes-256-gcm';
+
+interface EncFile {
+  v: number;
+  iv: string;
+  tag: string;
+  data: string;
+}
+
+export function deriveKey(masterKey: string): Buffer {
+  if (!masterKey) {
+    throw new Error(
+      'MASTER_KEY is required to encrypt/decrypt tokens. Generate one with: openssl rand -base64 32',
+    );
+  }
+  const raw = Buffer.from(masterKey, 'base64');
+  if (raw.length === 32) return raw;
+  return createHash('sha256').update(masterKey, 'utf8').digest();
+}
+
+export function encryptToken(data: object, masterKey: string): string {
+  const key = deriveKey(masterKey);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(ALGO, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(Buffer.from(JSON.stringify(data), 'utf8')),
+    cipher.final(),
+  ]);
+  const file: EncFile = {
+    v: ENC_VERSION,
+    iv: iv.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64'),
+    data: ciphertext.toString('base64'),
+  };
+  return JSON.stringify(file);
+}
+
+export function decryptToken(fileContents: string, masterKey: string): TokenData {
+  const key = deriveKey(masterKey);
+  const file = JSON.parse(fileContents) as EncFile;
+  if (file.v !== ENC_VERSION) {
+    throw new Error(`Unsupported token file version: ${file.v}`);
+  }
+  const decipher = createDecipheriv(ALGO, key, Buffer.from(file.iv, 'base64'));
+  decipher.setAuthTag(Buffer.from(file.tag, 'base64'));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(file.data, 'base64')),
+    decipher.final(),
+  ]);
+  return JSON.parse(plaintext.toString('utf8')) as TokenData;
+}
+
+function masterKey(): string {
+  return process.env.MASTER_KEY ?? '';
+}
+
+export function readToken(alias: string): TokenData | null {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(ACCOUNT_CONFIG[alias].encPath, 'utf8');
+  } catch {
+    return null;
+  }
+  return decryptToken(contents, masterKey());
+}
+
+export function writeToken(alias: string, data: object): void {
+  const p = ACCOUNT_CONFIG[alias].encPath;
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, encryptToken(data, masterKey()), { mode: 0o600 });
+}
+
+export function hasToken(alias: string): boolean {
+  return fs.existsSync(ACCOUNT_CONFIG[alias].encPath);
+}

--- a/tests/token-store.test.ts
+++ b/tests/token-store.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { deriveKey, encryptToken, decryptToken } from '../src/token-store.js';
+
+const KEY = 'test-master-key';
+const sample = { refresh_token: 'r', access_token: 'a', scope: 's', expiry_date: 123 };
+
+describe('token-store crypto', () => {
+  it('round-trips a token object', () => {
+    expect(decryptToken(encryptToken(sample, KEY), KEY)).toEqual(sample);
+  });
+
+  it('never leaks plaintext into the encrypted file', () => {
+    const enc = encryptToken(sample, KEY);
+    expect(enc).not.toContain('refresh_token');
+    expect(enc).not.toContain('"r"');
+    const o = JSON.parse(enc);
+    expect(o).toMatchObject({ v: 1 });
+    expect(o.iv && o.tag && o.data).toBeTruthy();
+  });
+
+  it('uses a fresh IV per call (ciphertext differs each time)', () => {
+    expect(encryptToken(sample, KEY)).not.toBe(encryptToken(sample, KEY));
+  });
+
+  it('fails to decrypt with the wrong key', () => {
+    expect(() => decryptToken(encryptToken(sample, KEY), 'wrong-key')).toThrow();
+  });
+
+  it('fails on tampered ciphertext (GCM auth)', () => {
+    const o = JSON.parse(encryptToken(sample, KEY));
+    const buf = Buffer.from(o.data, 'base64');
+    buf[0] ^= 0xff;
+    o.data = buf.toString('base64');
+    expect(() => decryptToken(JSON.stringify(o), KEY)).toThrow();
+  });
+
+  it('rejects an unsupported file version', () => {
+    const o = JSON.parse(encryptToken(sample, KEY));
+    o.v = 99;
+    expect(() => decryptToken(JSON.stringify(o), KEY)).toThrow(/version/i);
+  });
+
+  it('throws a clear error when MASTER_KEY is empty', () => {
+    expect(() => deriveKey('')).toThrow(/MASTER_KEY/);
+  });
+
+  it('accepts a base64 32-byte key directly', () => {
+    const k = Buffer.alloc(32, 7).toString('base64');
+    expect(deriveKey(k)).toHaveLength(32);
+    expect(decryptToken(encryptToken(sample, k), k)).toEqual(sample);
+  });
+
+  it('derives a 32-byte key from an arbitrary passphrase', () => {
+    expect(deriveKey('short')).toHaveLength(32);
+  });
+});


### PR DESCRIPTION
Phase 0 keystone (lean spec). Replaces plaintext `token.json` with per-account **encrypted files** (AES-256-GCM, key from `MASTER_KEY`) — secure-by-default, no native deps (`node:crypto`), frictionless install.

- `token-store.ts`: deriveKey / encryptToken / decryptToken / readToken / writeToken / hasToken
- rewired `client.ts` + `auth.ts`; `migrate-tokens` CLI for existing plaintext tokens; `TOKEN_STORE_PATH` override; `MASTER_KEY` in `.env.example`
- 9 unit tests (round-trip, wrong-key, GCM tamper, version, key derivation); typecheck/lint/test/build green

Breaking for v4 users (requires `MASTER_KEY`; run `migrate-tokens` or re-auth) — part of the v5 train.