### PR TITLE
feat: error taxonomy + param coercion across all tool methods

### DIFF
--- a/src/tools/_coerce.ts
+++ b/src/tools/_coerce.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+function parseJsonLoose(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}
+
+export function coerceArray<T extends z.ZodTypeAny>(element: T) {
+  return z.preprocess((val) => {
+    if (typeof val !== 'string') return val;
+    const t = val.trim();
+    if (t === '') return [];
+    if (t.startsWith('[')) return parseJsonLoose(t);
+    return t.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+  }, z.array(element));
+}
+
+export function coerceJson<T extends z.ZodTypeAny>(schema: T) {
+  return z.preprocess((val) => (typeof val === 'string' ? parseJsonLoose(val) : val), schema);
+}
+
+export const coerceBoolean = z.preprocess((val) => {
+  if (typeof val === 'boolean') return val;
+  if (typeof val === 'string') {
+    const t = val.trim().toLowerCase();
+    if (['true', '1', 'yes', 'y'].includes(t)) return true;
+    if (['false', '0', 'no', 'n'].includes(t)) return false;
+  }
+  return val;
+}, z.boolean());

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -1,44 +1,91 @@
 import type { Account } from '../accounts.js';
 
-/** Maps googleapis errors to MCP tool responses. 401 → re-auth instruction; 403 + hint → structured hint payload; 429 → retry-after; else → {error, code}. */
+export interface ErrorEnvelope {
+  error: string;
+  message: string;
+  hint?: string;
+  retriable: boolean;
+  account: string;
+}
+
+function statusOf(error: any): number | undefined {
+  const c = error?.code ?? error?.status ?? error?.response?.status;
+  const n = typeof c === 'string' ? Number(c) : c;
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function reasonOf(error: any): string | undefined {
+  return (
+    error?.errors?.[0]?.reason ??
+    error?.response?.data?.error?.errors?.[0]?.reason ??
+    error?.response?.data?.error?.status
+  );
+}
+
+function messageOf(error: any): string {
+  return error?.response?.data?.error?.message ?? error?.message ?? String(error);
+}
+
+export function mapGoogleError(
+  error: any,
+  account: Account,
+  forbiddenHint?: string,
+): ErrorEnvelope {
+  const status = statusOf(error);
+  const reason = reasonOf(error);
+  const message = messageOf(error);
+
+  if (status === 401) {
+    return {
+      error: 'auth_required',
+      message: `Authentication failed for account "${account}".`,
+      hint: `Run: npx mcp-google-multi auth --account ${account}`,
+      retriable: false,
+      account,
+    };
+  }
+  if (status === 403) {
+    const scopeIssue =
+      reason === 'insufficientPermissions' ||
+      reason === 'ACCESS_TOKEN_SCOPE_INSUFFICIENT' ||
+      /insufficient.*scope/i.test(message);
+    if (scopeIssue) {
+      return {
+        error: 'insufficient_scope',
+        message,
+        hint: forbiddenHint ?? `Re-auth "${account}" with the scope this operation needs.`,
+        retriable: false,
+        account,
+      };
+    }
+    return { error: 'forbidden', message, hint: forbiddenHint, retriable: false, account };
+  }
+  if (status === 400 && /invalid[_ ]scope/i.test(message)) {
+    return { error: 'invalid_scope', message, retriable: false, account };
+  }
+  if (status === 404) {
+    return { error: 'not_found', message, retriable: false, account };
+  }
+  if (status === 429) {
+    const retryAfter = error?.response?.headers?.['retry-after'];
+    return {
+      error: 'rate_limited',
+      message,
+      hint: retryAfter ? `Retry after ${retryAfter}s.` : 'Back off and retry.',
+      retriable: true,
+      account,
+    };
+  }
+  if (status !== undefined && status >= 500) {
+    return { error: 'upstream_error', message, retriable: true, account };
+  }
+  return { error: 'upstream_error', message, retriable: false, account };
+}
+
 export function handleGoogleApiError(error: any, account: Account, forbiddenHint?: string) {
-  if (error.code === 401) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: `Authentication error for account "${account}". Run: node dist/index.js auth --account ${account}`,
-      }],
-      isError: true as const,
-    };
-  }
-  if (error.code === 403 && forbiddenHint) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({
-          error: 'forbidden',
-          hint: forbiddenHint,
-          original: error.message ?? String(error),
-        }),
-      }],
-      isError: true as const,
-    };
-  }
-  if (error.code === 429) {
-    const retryAfter = error.response?.headers?.['retry-after'] ?? 'unknown';
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({ error: 'rate_limited', retryAfter }),
-      }],
-      isError: true as const,
-    };
-  }
+  const envelope = mapGoogleError(error, account, forbiddenHint);
   return {
-    content: [{
-      type: 'text' as const,
-      text: JSON.stringify({ error: error.message ?? String(error), code: error.code }),
-    }],
+    content: [{ type: 'text' as const, text: JSON.stringify(envelope) }],
     isError: true as const,
   };
 }

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -87,7 +88,7 @@ export function registerAdminTools(server: McpServer): void {
         maxResults: z.number().min(1).max(500).optional(),
         pageToken: z.string().optional(),
         orderBy: z.enum(['email', 'familyName', 'givenName']).optional(),
-        showDeleted: z.boolean().optional(),
+        showDeleted: coerceBoolean.optional(),
         projection: z.enum(['basic', 'custom', 'full']).optional(),
       },
     },
@@ -150,9 +151,9 @@ export function registerAdminTools(server: McpServer): void {
         userKey: z.string().describe('User email or ID'),
         givenName: z.string().optional(),
         familyName: z.string().optional(),
-        suspended: z.boolean().optional(),
+        suspended: coerceBoolean.optional(),
         password: z.string().optional(),
-        changePasswordAtNextLogin: z.boolean().optional(),
+        changePasswordAtNextLogin: coerceBoolean.optional(),
         orgUnitPath: z.string().optional(),
       },
     },
@@ -242,7 +243,7 @@ export function registerAdminTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
         groupKey: z.string().describe('Group email or ID'),
         roles: z.string().optional().describe('Comma-separated roles to include (OWNER, MANAGER, MEMBER)'),
-        includeDerivedMembership: z.boolean().optional(),
+        includeDerivedMembership: coerceBoolean.optional(),
         maxResults: z.number().min(1).max(200).optional(),
         pageToken: z.string().optional(),
       },

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -134,7 +135,7 @@ export function registerCalendarTools(server: McpServer): void {
           .describe('Comma-separated email addresses of attendees'),
         calendarId: z.string().default('primary').optional()
           .describe('Calendar ID (default: primary)'),
-        allDay: z.boolean().default(false).optional()
+        allDay: coerceBoolean.default(false).optional()
           .describe('If true, start/end are dates (YYYY-MM-DD) not datetimes'),
       },
     },
@@ -280,7 +281,7 @@ export function registerCalendarTools(server: McpServer): void {
         calendarId: z.string().default('primary').optional()
           .describe('Calendar ID (default: primary)'),
         text: z.string().describe('Natural language event, e.g. "Lunch with Farouk Thursday 1pm at Le Boulanger"'),
-        sendNotifications: z.boolean().optional().describe('Send notifications to attendees (default: false)'),
+        sendNotifications: coerceBoolean.optional().describe('Send notifications to attendees (default: false)'),
       },
     },
     async ({ account, calendarId, text, sendNotifications }) => {
@@ -310,7 +311,7 @@ export function registerCalendarTools(server: McpServer): void {
         calendarId: z.string().describe('Source calendar ID'),
         eventId: z.string().describe('Event ID to move'),
         destinationCalendarId: z.string().describe('Destination calendar ID'),
-        sendNotifications: z.boolean().optional().describe('Send notifications (default: false)'),
+        sendNotifications: coerceBoolean.optional().describe('Send notifications (default: false)'),
       },
     },
     async ({ account, calendarId, eventId, destinationCalendarId, sendNotifications }) => {
@@ -374,7 +375,7 @@ export function registerCalendarTools(server: McpServer): void {
       description: 'Check free/busy times for one or more calendars within a time window. Returns only busy blocks, not event details.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
-        calendarIds: z.array(z.string()).describe('Calendar IDs to check, e.g. ["primary", "user@example.com"]'),
+        calendarIds: coerceArray(z.string()).describe('Calendar IDs to check, e.g. ["primary", "user@example.com"]'),
         timeMin: z.string().describe('ISO 8601 start of window'),
         timeMax: z.string().describe('ISO 8601 end of window'),
         timeZone: z.string().optional().describe('Timezone (default: UTC)'),

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -69,7 +70,7 @@ export function registerChatTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         parent: z.string().describe('Space resource name, format: spaces/{space}'),
         text: z.string().optional().describe('Plain message text'),
-        cardsV2: z.array(z.record(z.string(), z.any())).optional().describe('Optional Card v2 payloads'),
+        cardsV2: coerceJson(z.array(z.record(z.string(), z.any()))).optional().describe('Optional Card v2 payloads'),
         threadKey: z.string().optional().describe('Thread key to group messages'),
         messageReplyOption: z.enum(['MESSAGE_REPLY_OPTION_UNSPECIFIED', 'REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD', 'REPLY_MESSAGE_OR_FAIL']).optional(),
       },

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceBoolean, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -65,7 +66,7 @@ export function registerDocsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         documentId: z.string().describe('Google Docs document ID'),
-        includeTabsContent: z.boolean().optional()
+        includeTabsContent: coerceBoolean.optional()
           .describe('Include full content for every tab (default: false — first tab only)'),
         suggestionsViewMode: z.enum([
           'DEFAULT_FOR_CURRENT_ACCESS',
@@ -176,7 +177,7 @@ export function registerDocsTools(server: McpServer): void {
         documentId: z.string().describe('Google Docs document ID'),
         findText: z.string().describe('Text to search for'),
         replaceText: z.string().describe('Replacement text'),
-        matchCase: z.boolean().default(true).optional()
+        matchCase: coerceBoolean.default(true).optional()
           .describe('Case-sensitive match (default: true)'),
       },
     },
@@ -254,9 +255,9 @@ export function registerDocsTools(server: McpServer): void {
         documentId: z.string().describe('Google Docs document ID'),
         startIndex: z.number().min(1).describe('Start index (inclusive, 1-based)'),
         endIndex: z.number().min(2).describe('End index (exclusive)'),
-        bold: z.boolean().optional().describe('Set bold'),
-        italic: z.boolean().optional().describe('Set italic'),
-        underline: z.boolean().optional().describe('Set underline'),
+        bold: coerceBoolean.optional().describe('Set bold'),
+        italic: coerceBoolean.optional().describe('Set italic'),
+        underline: coerceBoolean.optional().describe('Set underline'),
         fontSize: z.number().min(1).optional().describe('Font size in points'),
         fontFamily: z.string().optional().describe('Font family name (e.g. "Arial", "Times New Roman")'),
       },
@@ -489,9 +490,9 @@ export function registerDocsTools(server: McpServer): void {
         indentEnd: z.number().optional().describe('End indent in points'),
         indentFirstLine: z.number().optional().describe('First-line indent in points'),
         direction: z.enum(['LEFT_TO_RIGHT', 'RIGHT_TO_LEFT']).optional(),
-        keepLinesTogether: z.boolean().optional(),
-        keepWithNext: z.boolean().optional(),
-        avoidWidowAndOrphan: z.boolean().optional(),
+        keepLinesTogether: coerceBoolean.optional(),
+        keepWithNext: coerceBoolean.optional(),
+        avoidWidowAndOrphan: coerceBoolean.optional(),
       },
     },
     async ({ account, documentId, startIndex, endIndex, ...style }) => {
@@ -539,9 +540,9 @@ export function registerDocsTools(server: McpServer): void {
         marginHeader: z.number().optional(),
         marginFooter: z.number().optional(),
         pageNumberStart: z.number().optional(),
-        useFirstPageHeaderFooter: z.boolean().optional(),
-        useEvenPageHeaderFooter: z.boolean().optional(),
-        useCustomHeaderFooterMargins: z.boolean().optional(),
+        useFirstPageHeaderFooter: coerceBoolean.optional(),
+        useEvenPageHeaderFooter: coerceBoolean.optional(),
+        useCustomHeaderFooterMargins: coerceBoolean.optional(),
       },
     },
     async ({ account, documentId, ...style }) => {
@@ -892,8 +893,8 @@ export function registerDocsTools(server: McpServer): void {
         tableStartIndex: z.number().min(1).describe('Start index of the table in the document'),
         rowIndex: z.number().min(0).describe('Target row (0-based)'),
         columnIndex: z.number().min(0).describe('Target column (0-based)'),
-        insertBelow: z.boolean().optional().describe('insertRow only: insert below the target row (default: false)'),
-        insertRight: z.boolean().optional().describe('insertColumn only: insert right of the target column (default: false)'),
+        insertBelow: coerceBoolean.optional().describe('insertRow only: insert below the target row (default: false)'),
+        insertRight: coerceBoolean.optional().describe('insertColumn only: insert right of the target column (default: false)'),
         rowSpan: z.number().min(1).optional().describe('mergeCells only: how many rows the merged cell spans (default 1)'),
         columnSpan: z.number().min(1).optional().describe('mergeCells/unmergeCells: column span (default 1)'),
       },
@@ -1073,7 +1074,7 @@ export function registerDocsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         documentId: z.string().describe('Google Docs document ID'),
-        requests: z.array(z.record(z.string(), z.any())).describe('Array of Request objects, each with one request-type key'),
+        requests: coerceJson(z.array(z.record(z.string(), z.any()))).describe('Array of Request objects, each with one request-type key'),
         writeControl: z.object({
           requiredRevisionId: z.string().optional(),
           targetRevisionId: z.string().optional(),

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -607,9 +608,9 @@ export function registerDriveTools(server: McpServer): void {
         role: z.enum(['reader', 'commenter', 'writer', 'fileOrganizer', 'organizer', 'owner']).describe('Permission role'),
         emailAddress: z.string().optional().describe('Required when type is "user" or "group"'),
         domain: z.string().optional().describe('Required when type is "domain"'),
-        sendNotification: z.boolean().optional().describe('Send notification email (default: true)'),
+        sendNotification: coerceBoolean.optional().describe('Send notification email (default: true)'),
         emailMessage: z.string().optional().describe('Custom message in notification email'),
-        transferOwnership: z.boolean().optional().describe('Transfer ownership to the recipient. Requires role="owner". Recipient must accept ownership.'),
+        transferOwnership: coerceBoolean.optional().describe('Transfer ownership to the recipient. Requires role="owner". Recipient must accept ownership.'),
         expirationTime: z.string().optional().describe('RFC 3339 timestamp when access expires. Only valid for role="reader" or "commenter".'),
       },
     },
@@ -677,9 +678,9 @@ export function registerDriveTools(server: McpServer): void {
           .describe('New role'),
         expirationTime: z.string().optional()
           .describe('New RFC 3339 expiration timestamp. Only valid for role "reader" or "commenter".'),
-        removeExpiration: z.boolean().optional()
+        removeExpiration: coerceBoolean.optional()
           .describe('Clear the existing expirationTime'),
-        transferOwnership: z.boolean().optional()
+        transferOwnership: coerceBoolean.optional()
           .describe('Promote to owner. Requires role="owner".'),
       },
     },
@@ -779,7 +780,7 @@ export function registerDriveTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
-        includeDeleted: z.boolean().optional().describe('Include deleted comments (default: false)'),
+        includeDeleted: coerceBoolean.optional().describe('Include deleted comments (default: false)'),
         pageSize: z.number().min(1).max(100).optional().describe('Max comments per page (default: 20)'),
         pageToken: z.string().optional().describe('Token from a previous page'),
         startModifiedTime: z.string().optional().describe('Only return comments modified after this RFC 3339 timestamp'),
@@ -814,7 +815,7 @@ export function registerDriveTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
         commentId: z.string().describe('Comment ID'),
-        includeDeleted: z.boolean().optional(),
+        includeDeleted: coerceBoolean.optional(),
       },
     },
     async ({ account, fileId, commentId, includeDeleted }) => {
@@ -935,7 +936,7 @@ export function registerDriveTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
         commentId: z.string().describe('Parent comment ID'),
-        includeDeleted: z.boolean().optional(),
+        includeDeleted: coerceBoolean.optional(),
         pageSize: z.number().min(1).max(100).optional(),
         pageToken: z.string().optional(),
       },
@@ -1058,10 +1059,10 @@ export function registerDriveTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
         revisionId: z.string().describe('Revision ID'),
-        keepForever: z.boolean().optional().describe('Pin this revision indefinitely'),
-        published: z.boolean().optional().describe('Toggle published state (Docs only)'),
-        publishAuto: z.boolean().optional().describe('Auto-publish subsequent revisions'),
-        publishedOutsideDomain: z.boolean().optional().describe('Allow publish outside domain'),
+        keepForever: coerceBoolean.optional().describe('Pin this revision indefinitely'),
+        published: coerceBoolean.optional().describe('Toggle published state (Docs only)'),
+        publishAuto: coerceBoolean.optional().describe('Auto-publish subsequent revisions'),
+        publishedOutsideDomain: coerceBoolean.optional().describe('Allow publish outside domain'),
       },
     },
     async ({ account, fileId, revisionId, keepForever, published, publishAuto, publishedOutsideDomain }) => {
@@ -1153,10 +1154,10 @@ export function registerDriveTools(server: McpServer): void {
         fileId: z.string().describe('Google Drive file ID'),
         proposalId: z.string().describe('Access proposal ID'),
         action: z.enum(['ACCEPT', 'DENY']).describe('Whether to accept or deny the proposal'),
-        role: z.array(z.enum(['reader', 'commenter', 'writer', 'fileOrganizer'])).optional()
+        role: coerceArray(z.enum(['reader', 'commenter', 'writer', 'fileOrganizer'])).optional()
           .describe('Required when action is ACCEPT'),
         view: z.string().optional().describe('Optional view, e.g. "published"'),
-        sendNotification: z.boolean().optional()
+        sendNotification: coerceBoolean.optional()
           .describe('Email the requester about the resolution'),
       },
     },

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -381,8 +382,8 @@ export function registerGmailTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         messageId: z.string().describe('Gmail message ID'),
-        addLabelIds: z.array(z.string()).optional().describe('Label IDs to add'),
-        removeLabelIds: z.array(z.string()).optional().describe('Label IDs to remove'),
+        addLabelIds: coerceArray(z.string()).optional().describe('Label IDs to add'),
+        removeLabelIds: coerceArray(z.string()).optional().describe('Label IDs to remove'),
       },
     },
     async ({ account, messageId, addLabelIds, removeLabelIds }) => {
@@ -458,9 +459,9 @@ export function registerGmailTools(server: McpServer): void {
       description: 'Add/remove labels across up to 1000 Gmail messages at once. Useful for bulk archiving, marking as read, etc.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
-        messageIds: z.array(z.string()).describe('Message IDs (up to 1000)'),
-        addLabelIds: z.array(z.string()).optional().describe('Label IDs to add'),
-        removeLabelIds: z.array(z.string()).optional().describe('Label IDs to remove'),
+        messageIds: coerceArray(z.string()).describe('Message IDs (up to 1000)'),
+        addLabelIds: coerceArray(z.string()).optional().describe('Label IDs to add'),
+        removeLabelIds: coerceArray(z.string()).optional().describe('Label IDs to remove'),
       },
     },
     async ({ account, messageIds, addLabelIds, removeLabelIds }) => {
@@ -490,7 +491,7 @@ export function registerGmailTools(server: McpServer): void {
       description: 'Permanently delete multiple Gmail messages. Irreversible.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
-        messageIds: z.array(z.string()).describe('Message IDs (up to 1000)'),
+        messageIds: coerceArray(z.string()).describe('Message IDs (up to 1000)'),
       },
     },
     async ({ account, messageIds }) => {
@@ -702,7 +703,7 @@ export function registerGmailTools(server: McpServer): void {
         startHistoryId: z.string().describe('History ID from a previous gmail_get_profile or gmail_read response'),
         maxResults: z.number().min(1).max(500).default(100).optional()
           .describe('Max results to return (default: 100)'),
-        historyTypes: z.array(z.enum(['messageAdded', 'messageDeleted', 'labelAdded', 'labelRemoved'])).optional()
+        historyTypes: coerceArray(z.enum(['messageAdded', 'messageDeleted', 'labelAdded', 'labelRemoved'])).optional()
           .describe('Filter by history event types'),
       },
     },
@@ -753,13 +754,13 @@ export function registerGmailTools(server: McpServer): void {
       description: 'Enable or disable Gmail vacation responder with a custom message',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
-        enableAutoReply: z.boolean().describe('Whether to enable the vacation responder'),
+        enableAutoReply: coerceBoolean.describe('Whether to enable the vacation responder'),
         responseSubject: z.string().optional().describe('Subject line for auto-reply'),
         responseBodyPlainText: z.string().optional().describe('Plain text body for auto-reply'),
         startTime: z.string().optional().describe('Start time as Unix timestamp in ms'),
         endTime: z.string().optional().describe('End time as Unix timestamp in ms'),
-        restrictToContacts: z.boolean().optional().describe('Only reply to contacts (default: false)'),
-        restrictToDomain: z.boolean().optional().describe('Only reply to same domain (default: false)'),
+        restrictToContacts: coerceBoolean.optional().describe('Only reply to contacts (default: false)'),
+        restrictToDomain: coerceBoolean.optional().describe('Only reply to same domain (default: false)'),
       },
     },
     async ({ account, enableAutoReply, responseSubject, responseBodyPlainText, startTime, endTime, restrictToContacts, restrictToDomain }) => {

--- a/src/tools/searchconsole.ts
+++ b/src/tools/searchconsole.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceArray, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -210,18 +211,18 @@ export function registerSearchConsoleTools(server: McpServer): void {
         siteUrl: z.string().describe('Site URL (e.g. "https://example.com/" or "sc-domain:example.com")'),
         startDate: z.string().describe('Start date (YYYY-MM-DD). Data is available starting ~3 days ago.'),
         endDate: z.string().describe('End date (YYYY-MM-DD)'),
-        dimensions: z.array(z.enum(['query', 'page', 'country', 'device', 'searchAppearance', 'date'])).optional()
+        dimensions: coerceArray(z.enum(['query', 'page', 'country', 'device', 'searchAppearance', 'date'])).optional()
           .describe('Dimensions to group by. Common: ["query", "page"], ["date"], ["query", "date"]'),
         type: z.enum(['web', 'image', 'video', 'news', 'discover', 'googleNews']).optional()
           .describe('Search type filter (default: web)'),
-        dimensionFilterGroups: z.array(z.object({
+        dimensionFilterGroups: coerceJson(z.array(z.object({
           groupType: z.enum(['and']).optional(),
           filters: z.array(z.object({
             dimension: z.enum(['query', 'page', 'country', 'device', 'searchAppearance']),
             operator: z.enum(['contains', 'equals', 'notContains', 'notEquals', 'includingRegex', 'excludingRegex']),
             expression: z.string(),
           })),
-        })).optional()
+        }))).optional()
           .describe('Filters to narrow results. Example: filter by page containing "/blog/" or query containing "keyword"'),
         rowLimit: z.number().min(1).max(25000).optional()
           .describe('Max rows to return (default: 1000, max: 25000)'),

--- a/src/tools/sheets.ts
+++ b/src/tools/sheets.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceArray, coerceBoolean, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -16,7 +17,7 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         title: z.string().describe('Spreadsheet title'),
-        sheetTitles: z.array(z.string()).optional()
+        sheetTitles: coerceArray(z.string()).optional()
           .describe('Optional tab/sheet names (default: one sheet named "Sheet1")'),
       },
     },
@@ -129,7 +130,7 @@ export function registerSheetsTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
         range: z.string().describe('A1 notation target range, e.g. "Sheet1!A1:C3"'),
-        values: z.array(z.array(z.any())).describe('2D array of values (rows x columns)'),
+        values: coerceJson(z.array(z.array(z.any()))).describe('2D array of values (rows x columns)'),
         valueInputOption: z.enum(['RAW', 'USER_ENTERED']).default('USER_ENTERED').optional()
           .describe('How to interpret values: RAW (literal) or USER_ENTERED (formulas/dates parsed). Default: USER_ENTERED'),
       },
@@ -166,7 +167,7 @@ export function registerSheetsTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
         range: z.string().describe('A1 notation range to search for the table (e.g. "Sheet1")'),
-        values: z.array(z.array(z.any())).describe('2D array of rows to append'),
+        values: coerceJson(z.array(z.array(z.any()))).describe('2D array of rows to append'),
         valueInputOption: z.enum(['RAW', 'USER_ENTERED']).default('USER_ENTERED').optional()
           .describe('How to interpret values. Default: USER_ENTERED'),
       },
@@ -233,7 +234,7 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
-        ranges: z.array(z.string()).describe('Array of A1 notation ranges'),
+        ranges: coerceArray(z.string()).describe('Array of A1 notation ranges'),
         valueRenderOption: z.enum(['FORMATTED_VALUE', 'UNFORMATTED_VALUE', 'FORMULA'])
           .default('FORMATTED_VALUE').optional()
           .describe('How to render values. Default: FORMATTED_VALUE'),
@@ -268,10 +269,10 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
-        data: z.array(z.object({
+        data: coerceJson(z.array(z.object({
           range: z.string().describe('A1 notation range'),
-          values: z.array(z.array(z.any())).describe('2D array of values'),
-        })).describe('Array of { range, values } objects to write'),
+          values: coerceJson(z.array(z.array(z.any()))).describe('2D array of values'),
+        }))).describe('Array of { range, values } objects to write'),
         valueInputOption: z.enum(['RAW', 'USER_ENTERED']).default('USER_ENTERED').optional()
           .describe('How to interpret values. Default: USER_ENTERED'),
       },
@@ -427,7 +428,7 @@ export function registerSheetsTools(server: McpServer): void {
         sheetId: z.number().describe('Sheet ID'),
         title: z.string().optional().describe('New tab title'),
         index: z.number().optional().describe('New position among tabs'),
-        hidden: z.boolean().optional().describe('Hide the tab from the UI'),
+        hidden: coerceBoolean.optional().describe('Hide the tab from the UI'),
         tabColor: rgbColorSchema.optional().describe('Tab color (RGB 0..1)'),
         frozenRowCount: z.number().min(0).optional().describe('Number of frozen header rows'),
         frozenColumnCount: z.number().min(0).optional().describe('Number of frozen header columns'),
@@ -498,10 +499,10 @@ export function registerSheetsTools(server: McpServer): void {
         backgroundColor: rgbColorSchema.optional().describe('Cell background (RGB 0..1)'),
         textFormat: z.object({
           foregroundColor: rgbColorSchema.optional(),
-          bold: z.boolean().optional(),
-          italic: z.boolean().optional(),
-          underline: z.boolean().optional(),
-          strikethrough: z.boolean().optional(),
+          bold: coerceBoolean.optional(),
+          italic: coerceBoolean.optional(),
+          underline: coerceBoolean.optional(),
+          strikethrough: coerceBoolean.optional(),
           fontFamily: z.string().optional(),
           fontSize: z.number().min(1).optional(),
         }).optional(),
@@ -658,19 +659,19 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
-        ranges: z.array(gridRangeSchema).describe('Ranges the rule applies to'),
+        ranges: coerceJson(z.array(gridRangeSchema)).describe('Ranges the rule applies to'),
         index: z.number().min(0).optional().describe('Where in the rule order to insert (0 = highest priority)'),
         booleanRule: z.object({
           conditionType: z.string().describe(BOOLEAN_CONDITION_TYPE_DESC),
-          conditionValues: z.array(z.string()).optional().describe('Values for the condition (e.g. ["100"] for NUMBER_GREATER, or ["=A1>10"] for CUSTOM_FORMULA)'),
+          conditionValues: coerceArray(z.string()).optional().describe('Values for the condition (e.g. ["100"] for NUMBER_GREATER, or ["=A1>10"] for CUSTOM_FORMULA)'),
           format: z.object({
             backgroundColor: rgbColorSchema.optional(),
             textFormat: z.object({
               foregroundColor: rgbColorSchema.optional(),
-              bold: z.boolean().optional(),
-              italic: z.boolean().optional(),
-              strikethrough: z.boolean().optional(),
-              underline: z.boolean().optional(),
+              bold: coerceBoolean.optional(),
+              italic: coerceBoolean.optional(),
+              strikethrough: coerceBoolean.optional(),
+              underline: coerceBoolean.optional(),
             }).optional(),
           }).describe('Format to apply when condition is true. Conditional formatting only supports bold/italic/strikethrough/underline/foregroundColor/backgroundColor.'),
         }).optional(),
@@ -749,7 +750,7 @@ export function registerSheetsTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
         range: gridRangeSchema,
-        sortSpecs: z.array(sortSpecSchema).describe('One spec per sort column (in priority order)'),
+        sortSpecs: coerceJson(z.array(sortSpecSchema)).describe('One spec per sort column (in priority order)'),
       },
     },
     async ({ account, spreadsheetId, range, sortSpecs }) => {
@@ -779,13 +780,13 @@ export function registerSheetsTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
         range: gridRangeSchema,
-        sortSpecs: z.array(sortSpecSchema).optional(),
-        filterSpecs: z.array(z.object({
+        sortSpecs: coerceJson(z.array(sortSpecSchema)).optional(),
+        filterSpecs: coerceJson(z.array(z.object({
           columnIndex: z.number().min(0),
-          hiddenValues: z.array(z.string()).optional().describe('Values to hide in this column'),
+          hiddenValues: coerceArray(z.string()).optional().describe('Values to hide in this column'),
           conditionType: z.string().optional().describe(BOOLEAN_CONDITION_TYPE_DESC),
-          conditionValues: z.array(z.string()).optional(),
-        })).optional(),
+          conditionValues: coerceArray(z.string()).optional(),
+        }))).optional(),
       },
     },
     async ({ account, spreadsheetId, range, sortSpecs, filterSpecs }) => {
@@ -861,10 +862,10 @@ export function registerSheetsTools(server: McpServer): void {
         scope: z.enum(['allSheets', 'sheet', 'range']).describe('Search scope'),
         sheetId: z.number().optional().describe('Required when scope=sheet'),
         range: gridRangeSchema.optional().describe('Required when scope=range'),
-        matchCase: z.boolean().optional(),
-        matchEntireCell: z.boolean().optional(),
-        searchByRegex: z.boolean().optional(),
-        includeFormulas: z.boolean().optional(),
+        matchCase: coerceBoolean.optional(),
+        matchEntireCell: coerceBoolean.optional(),
+        searchByRegex: coerceBoolean.optional(),
+        includeFormulas: coerceBoolean.optional(),
       },
     },
     async ({ account, spreadsheetId, find, replacement, scope, sheetId, range, matchCase, matchEntireCell, searchByRegex, includeFormulas }) => {
@@ -957,7 +958,7 @@ export function registerSheetsTools(server: McpServer): void {
         dimension: z.enum(['ROWS', 'COLUMNS']),
         startIndex: z.number().min(0).describe('0-based, inclusive'),
         endIndex: z.number().min(1).describe('0-based, exclusive'),
-        inheritFromBefore: z.boolean().optional(),
+        inheritFromBefore: coerceBoolean.optional(),
       },
     },
     async ({ account, spreadsheetId, sheetId, dimension, startIndex, endIndex, inheritFromBefore }) => {
@@ -1031,10 +1032,10 @@ export function registerSheetsTools(server: McpServer): void {
         spreadsheetId: z.string().describe('Spreadsheet ID'),
         range: gridRangeSchema,
         conditionType: z.string().describe(BOOLEAN_CONDITION_TYPE_DESC),
-        conditionValues: z.array(z.string()).optional().describe('Values per condition type (list items for ONE_OF_LIST, range A1 for ONE_OF_RANGE, etc.)'),
+        conditionValues: coerceArray(z.string()).optional().describe('Values per condition type (list items for ONE_OF_LIST, range A1 for ONE_OF_RANGE, etc.)'),
         inputMessage: z.string().optional().describe('Tooltip shown when cell is selected'),
-        strict: z.boolean().optional().describe('Reject invalid input (default: false = warning only)'),
-        showCustomUi: z.boolean().optional().describe('Show dropdown UI for list-type validations'),
+        strict: coerceBoolean.optional().describe('Reject invalid input (default: false = warning only)'),
+        showCustomUi: coerceBoolean.optional().describe('Show dropdown UI for list-type validations'),
       },
     },
     async ({ account, spreadsheetId, range, conditionType, conditionValues, inputMessage, strict, showCustomUi }) => {
@@ -1135,7 +1136,7 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
-        ranges: z.array(z.string()).describe('Array of A1 notation ranges'),
+        ranges: coerceArray(z.string()).describe('Array of A1 notation ranges'),
       },
     },
     async ({ account, spreadsheetId, ranges }) => {
@@ -1164,10 +1165,10 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
-        requests: z.array(z.record(z.string(), z.any())).describe('Array of Request objects. Each object has exactly one key (the request type) like {repeatCell: {...}}, {addChart: {...}}, {updateBanding: {...}}, etc.'),
-        includeSpreadsheetInResponse: z.boolean().optional(),
-        responseRanges: z.array(z.string()).optional(),
-        responseIncludeGridData: z.boolean().optional(),
+        requests: coerceJson(z.array(z.record(z.string(), z.any()))).describe('Array of Request objects. Each object has exactly one key (the request type) like {repeatCell: {...}}, {addChart: {...}}, {updateBanding: {...}}, etc.'),
+        includeSpreadsheetInResponse: coerceBoolean.optional(),
+        responseRanges: coerceArray(z.string()).optional(),
+        responseIncludeGridData: coerceBoolean.optional(),
       },
     },
     async ({ account, spreadsheetId, requests, includeSpreadsheetInResponse, responseRanges, responseIncludeGridData }) => {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -147,10 +148,10 @@ export function registerTasksTools(server: McpServer): void {
         tasklistId: z.string().describe('Tasklist ID'),
         maxResults: z.number().min(1).max(100).optional(),
         pageToken: z.string().optional(),
-        showCompleted: z.boolean().optional().describe('Include completed tasks (default: true)'),
-        showDeleted: z.boolean().optional(),
-        showHidden: z.boolean().optional(),
-        showAssigned: z.boolean().optional(),
+        showCompleted: coerceBoolean.optional().describe('Include completed tasks (default: true)'),
+        showDeleted: coerceBoolean.optional(),
+        showHidden: coerceBoolean.optional(),
+        showAssigned: coerceBoolean.optional(),
         completedMax: z.string().optional().describe('RFC 3339 upper bound on completion date'),
         completedMin: z.string().optional(),
         dueMax: z.string().optional(),

--- a/tests/coerce.test.ts
+++ b/tests/coerce.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { coerceArray, coerceJson, coerceBoolean } from '../src/tools/_coerce.js';
+
+describe('coerceArray', () => {
+  const s = coerceArray(z.string());
+  it('passes arrays through', () => expect(s.parse(['a', 'b'])).toEqual(['a', 'b']));
+  it('splits comma strings', () => expect(s.parse('a, b ,c')).toEqual(['a', 'b', 'c']));
+  it('parses JSON arrays', () => expect(s.parse('["x","y"]')).toEqual(['x', 'y']));
+  it('treats empty string as empty array', () => expect(s.parse('')).toEqual([]));
+  it('validates element types', () => {
+    const e = coerceArray(z.enum(['r', 'w']));
+    expect(e.parse('r,w')).toEqual(['r', 'w']);
+    expect(e.safeParse('x').success).toBe(false);
+  });
+});
+
+describe('coerceJson', () => {
+  const o = coerceJson(z.record(z.string(), z.unknown()));
+  it('passes objects through', () => expect(o.parse({ a: 1 })).toEqual({ a: 1 }));
+  it('parses JSON object strings', () => expect(o.parse('{"a":1}')).toEqual({ a: 1 }));
+  it('fails on non-JSON strings', () => expect(o.safeParse('nope').success).toBe(false));
+  it('coerces 2D arrays from a JSON string', () => {
+    const grid = coerceJson(z.array(z.array(z.any())));
+    expect(grid.parse('[[1,2],[3,4]]')).toEqual([[1, 2], [3, 4]]);
+  });
+});
+
+describe('coerceBoolean', () => {
+  it('passes booleans through', () => {
+    expect(coerceBoolean.parse(true)).toBe(true);
+    expect(coerceBoolean.parse(false)).toBe(false);
+  });
+  it('coerces truthy strings', () => {
+    for (const v of ['true', '1', 'yes', 'Y']) expect(coerceBoolean.parse(v)).toBe(true);
+  });
+  it('coerces falsy strings', () => {
+    for (const v of ['false', '0', 'no', 'N']) expect(coerceBoolean.parse(v)).toBe(false);
+  });
+  it('rejects nonsense', () => expect(coerceBoolean.safeParse('maybe').success).toBe(false));
+});

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { mapGoogleError } from '../src/tools/_errors.js';
+
+const acc = 'ic';
+
+describe('mapGoogleError', () => {
+  it('401 → auth_required with a re-auth hint', () => {
+    const e = mapGoogleError({ code: 401, message: 'Invalid Credentials' }, acc);
+    expect(e.error).toBe('auth_required');
+    expect(e.retriable).toBe(false);
+    expect(e.hint).toContain('auth --account ic');
+  });
+
+  it('403 insufficientPermissions → insufficient_scope', () => {
+    const e = mapGoogleError(
+      { code: 403, errors: [{ reason: 'insufficientPermissions' }], message: 'Insufficient Permission' },
+      acc,
+    );
+    expect(e.error).toBe('insufficient_scope');
+  });
+
+  it('403 generic → forbidden, passes the hint through', () => {
+    const e = mapGoogleError({ code: 403, message: 'forbidden' }, acc, 'enable admin writes');
+    expect(e.error).toBe('forbidden');
+    expect(e.hint).toBe('enable admin writes');
+  });
+
+  it('404 → not_found', () => {
+    expect(mapGoogleError({ code: 404, message: 'x' }, acc).error).toBe('not_found');
+  });
+
+  it('429 → rate_limited, retriable, with Retry-After', () => {
+    const e = mapGoogleError(
+      { code: 429, message: 'quota', response: { headers: { 'retry-after': '30' } } },
+      acc,
+    );
+    expect(e.error).toBe('rate_limited');
+    expect(e.retriable).toBe(true);
+    expect(e.hint).toContain('30');
+  });
+
+  it('5xx → upstream_error, retriable', () => {
+    const e = mapGoogleError({ code: 503, message: 'unavailable' }, acc);
+    expect(e.error).toBe('upstream_error');
+    expect(e.retriable).toBe(true);
+  });
+
+  it('never leaks the Authorization header / token from the raw error', () => {
+    const e = mapGoogleError(
+      {
+        code: 403,
+        message: 'Forbidden',
+        config: { headers: { Authorization: 'Bearer SECRET' } },
+        response: { data: { access_token: 'SECRET' } },
+      },
+      acc,
+    );
+    const json = JSON.stringify(e);
+    expect(json).not.toContain('SECRET');
+    expect(json).not.toContain('Authorization');
+  });
+
+  it('reads the nested Google message + reason', () => {
+    const e = mapGoogleError(
+      { response: { status: 404, data: { error: { message: 'Not found here', errors: [{ reason: 'notFound' }] } } } },
+      acc,
+    );
+    expect(e.error).toBe('not_found');
+    expect(e.message).toBe('Not found here');
+  });
+});


### PR DESCRIPTION
Phase 0, slice 2.

**Error taxonomy** — `_errors.ts` now maps Google errors to a typed envelope `{error,message,hint?,retriable,account}` (`auth_required`/`insufficient_scope`/`forbidden`/`not_found`/`rate_limited`/`invalid_scope`/`upstream_error`). Re-auth hints only on real auth errors; **never embeds raw error objects** (no token leak). Universal via the existing per-service shims.

**Param coercion** — `_coerce.ts` (coerceArray/coerceJson/coerceBoolean) applied to **every** array, object/record, 2D-array and boolean param across all 9 service files — fixes the 'Expected array, received string' client bug for all methods.

21 new unit tests (13 coerce + 8 errors); typecheck/lint/test (88) green; all tools register cleanly with the coerced schemas.

⚠️ **Merge as a MERGE COMMIT (not squash):** this branch back-merges `main` to resync the alpha line — landing it as a merge commit pulls `main`'s 4.4.0 tag into `dev`, so this releases as **4.5.0-alpha.1**.