### PR TITLE
ci: auto back-merge main → staging/dev after stable releases

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,33 @@
+name: backmerge
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backmerge:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open + auto-merge main into staging and dev
+        env:
+          GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -uo pipefail
+          for target in staging dev; do
+            url=$(gh pr create --repo "$REPO" --base "$target" --head main \
+                  --title "chore: back-merge main into $target (resync after $TAG)" \
+                  --body "Automated post-release resync so the \`$target\` prerelease base tracks \`main\` ($TAG). No content change." || true)
+            if [ -n "${url:-}" ]; then
+              gh pr merge "$url" --repo "$REPO" --auto --merge
+              echo "queued auto-merge: $url"
+            else
+              echo "nothing to back-merge into $target"
+            fi
+          done


### PR DESCRIPTION
Automates the post-release resync we discussed: on a **stable** release (`release: published`, `prerelease == false`), opens and **auto-merges** PRs `main → staging` and `main → dev` so the alpha/beta preview bases re-anchor to the released version (no more 4.3.0-alpha.N drift).

**One-time setup required (only you can do this):**
1. Create a fine-grained PAT with **Contents: Read/Write** + **Pull requests: Read/Write** on this repo.
2. Add it as the repo secret **`BACKMERGE_TOKEN`** (`gh secret set BACKMERGE_TOKEN`). A PAT is needed because PRs opened by the default `GITHUB_TOKEN` don't trigger CI, so auto-merge would never satisfy the required `ci` check.

Repo **auto-merge is already enabled** (done in this change). Activates from the **next stable release after this reaches `main`**. Back-merge PRs are content-noops, so their CI passes and they auto-merge within ~1 min; the resulting dev/staging prerelease is skipped by the workflow (`prerelease` guard), so no loop.