### PR TITLE
feat: tool registry + cud metadata for all 175 tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { registerFormsTools } from './tools/forms.js';
 import { registerChatTools } from './tools/chat.js';
 import { registerAdminTools, registerAlertCenterTools } from './tools/admin.js';
 import { getOptionalBundles, getAdminAccounts } from './auth.js';
+import { ToolRegistry } from './registry.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'));
@@ -41,20 +42,21 @@ async function main() {
     name: 'mcp-google-multi',
     version: pkg.version,
   });
-  registerGmailTools(server);
-  registerDriveTools(server);
-  registerCalendarTools(server);
-  registerSheetsTools(server);
-  registerDocsTools(server);
-  registerContactsTools(server);
-  registerSearchConsoleTools(server);
-  registerTasksTools(server);
-  registerMeetTools(server);
+  const registry = new ToolRegistry(server);
+  registerGmailTools(registry);
+  registerDriveTools(registry);
+  registerCalendarTools(registry);
+  registerSheetsTools(registry);
+  registerDocsTools(registry);
+  registerContactsTools(registry);
+  registerSearchConsoleTools(registry);
+  registerTasksTools(registry);
+  registerMeetTools(registry);
   const optional = new Set(getOptionalBundles());
-  if (optional.has('forms')) registerFormsTools(server);
-  if (optional.has('chat')) registerChatTools(server);
-  if (optional.has('alertcenter')) registerAlertCenterTools(server);
-  if (getAdminAccounts().length > 0) registerAdminTools(server);
+  if (optional.has('forms')) registerFormsTools(registry);
+  if (optional.has('chat')) registerChatTools(registry);
+  if (optional.has('alertcenter')) registerAlertCenterTools(registry);
+  if (getAdminAccounts().length > 0) registerAdminTools(registry);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,39 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export type Cud = 'read' | 'create' | 'update' | 'delete';
+
+export interface ToolEntry {
+  name: string;
+  service: string;
+  cud: Cud;
+}
+
+const CUD_OVERRIDES: Record<string, Cud> = {
+  drive_untrash: 'update',
+};
+
+const DELETE_VERB = /(^|_)(delete|remove|trash|clear|empty)(_|$)/;
+const CREATE_VERB = /(^|_)(create|add|insert|send|upload|copy|import|append|submit|duplicate|share|quick)(_|$)/;
+const UPDATE_VERB = /(^|_)(update|patch|modify|set|move|write|format|merge|unmerge|sort|replace|resize|publish|resolve)(_|$)/;
+
+export function inferCud(name: string): Cud {
+  const override = CUD_OVERRIDES[name];
+  if (override) return override;
+  if (DELETE_VERB.test(name)) return 'delete';
+  if (CREATE_VERB.test(name)) return 'create';
+  if (UPDATE_VERB.test(name)) return 'update';
+  return 'read';
+}
+
+export class ToolRegistry {
+  readonly tools: ToolEntry[] = [];
+  readonly registerTool: McpServer['registerTool'];
+
+  constructor(server: McpServer) {
+    this.registerTool = ((name: string, ...rest: unknown[]) => {
+      const service = name.includes('_') ? name.slice(0, name.indexOf('_')) : name;
+      this.tools.push({ name, service, cud: inferCud(name) });
+      return (server.registerTool as (...args: unknown[]) => unknown)(name, ...rest);
+    }) as McpServer['registerTool'];
+  }
+}

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
@@ -17,7 +17,7 @@ const accountEnum = z.enum(ACCOUNTS);
  * Writes are gated behind GOOGLE_ALLOW_ADMIN_WRITES=true to prevent accidents on small orgs
  * (a stray users.update on a 3-person Workspace is a bad day).
  */
-export function registerAdminTools(server: McpServer): void {
+export function registerAdminTools(server: ToolRegistry): void {
   // ─── Reports / audit log ───────────────────────────────────────────────
 
   server.registerTool(
@@ -276,7 +276,7 @@ export function registerAdminTools(server: McpServer): void {
  * domain-wide delegation. Registered separately so a missing/ungrantable
  * apps.alerts scope never blocks the working Admin SDK admin tools.
  */
-export function registerAlertCenterTools(server: McpServer): void {
+export function registerAlertCenterTools(server: ToolRegistry): void {
   server.registerTool(
     'alertcenter_alerts_list',
     {

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
@@ -9,7 +9,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerCalendarTools(server: McpServer): void {
+export function registerCalendarTools(server: ToolRegistry): void {
   server.registerTool(
     'calendar_list_calendars',
     {

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
@@ -9,7 +9,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerChatTools(server: McpServer): void {
+export function registerChatTools(server: ToolRegistry): void {
   server.registerTool(
     'chat_spaces_list',
     {

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
@@ -37,7 +37,7 @@ function formatContact(person: any) {
   };
 }
 
-export function registerContactsTools(server: McpServer): void {
+export function registerContactsTools(server: ToolRegistry): void {
   server.registerTool(
     'contacts_search',
     {

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceBoolean, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
@@ -30,7 +30,7 @@ function extractPlainText(body: any): string {
   return text;
 }
 
-export function registerDocsTools(server: McpServer): void {
+export function registerDocsTools(server: ToolRegistry): void {
   server.registerTool(
     'docs_create',
     {

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
@@ -30,7 +30,7 @@ const COMMENT_LIST_FIELDS = `nextPageToken,comments(${COMMENT_BASE_FIELDS},repli
 const REPLY_FIELDS = `kind,htmlContent,${REPLY_SUBFIELDS}`;
 const REPLY_LIST_FIELDS = `nextPageToken,replies(${REPLY_FIELDS})`;
 
-export function registerDriveTools(server: McpServer): void {
+export function registerDriveTools(server: ToolRegistry): void {
   // ─── Read / search / list ──────────────────────────────────────────────
 
   server.registerTool(

--- a/src/tools/forms.ts
+++ b/src/tools/forms.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
@@ -8,7 +8,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerFormsTools(server: McpServer): void {
+export function registerFormsTools(server: ToolRegistry): void {
   server.registerTool(
     'forms_get',
     {

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
@@ -80,7 +80,7 @@ function parseMessage(msg: any): GmailMessageFull {
   };
 }
 
-export function registerGmailTools(server: McpServer): void {
+export function registerGmailTools(server: ToolRegistry): void {
   server.registerTool(
     'gmail_search',
     {

--- a/src/tools/meet.ts
+++ b/src/tools/meet.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
@@ -8,7 +8,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerMeetTools(server: McpServer): void {
+export function registerMeetTools(server: ToolRegistry): void {
   // ─── Conference records (past meetings) ────────────────────────────────
 
   server.registerTool(

--- a/src/tools/searchconsole.ts
+++ b/src/tools/searchconsole.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
@@ -9,7 +9,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerSearchConsoleTools(server: McpServer): void {
+export function registerSearchConsoleTools(server: ToolRegistry): void {
   // ─── Sites ───────────────────────────────────────────────
 
   server.registerTool(

--- a/src/tools/sheets.ts
+++ b/src/tools/sheets.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
@@ -9,7 +9,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerSheetsTools(server: McpServer): void {
+export function registerSheetsTools(server: ToolRegistry): void {
   server.registerTool(
     'sheets_create',
     {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
@@ -9,7 +9,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerTasksTools(server: McpServer): void {
+export function registerTasksTools(server: ToolRegistry): void {
   // ─── Tasklists ─────────────────────────────────────────────────────────
 
   server.registerTool(

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { inferCud, ToolRegistry } from '../src/registry.js';
+
+describe('inferCud', () => {
+  const cases: [string, string][] = [
+    ['gmail_list_labels', 'read'],
+    ['gmail_get_profile', 'read'],
+    ['gmail_read_thread', 'read'],
+    ['drive_search', 'read'],
+    ['sheets_batch_read', 'read'],
+    ['searchconsole_url_inspect', 'read'],
+    ['searchconsole_searchanalytics_query', 'read'],
+    ['contacts_group_members', 'read'],
+    ['drive_get_about', 'read'],
+    ['gmail_send', 'create'],
+    ['gmail_create_draft', 'create'],
+    ['drive_upload', 'create'],
+    ['drive_copy', 'create'],
+    ['drive_share', 'create'],
+    ['calendar_quick_add', 'create'],
+    ['sheets_append_rows', 'create'],
+    ['searchconsole_sites_add', 'create'],
+    ['docs_insert_text', 'create'],
+    ['gmail_modify_labels', 'update'],
+    ['gmail_batch_modify', 'update'],
+    ['drive_move', 'update'],
+    ['drive_update', 'update'],
+    ['drive_permission_update', 'update'],
+    ['sheets_write_range', 'update'],
+    ['sheets_batch_write', 'update'],
+    ['gmail_set_vacation', 'update'],
+    ['drive_access_proposal_resolve', 'update'],
+    ['drive_untrash', 'update'],
+    ['gmail_delete', 'delete'],
+    ['gmail_batch_delete', 'delete'],
+    ['drive_trash', 'delete'],
+    ['drive_remove_permission', 'delete'],
+    ['drive_empty_trash', 'delete'],
+    ['sheets_clear_range', 'delete'],
+    ['tasks_clear', 'delete'],
+    ['docs_delete_named_range', 'delete'],
+  ];
+  it.each(cases)('%s → %s', (name, expected) => {
+    expect(inferCud(name)).toBe(expected);
+  });
+
+  it('does not confuse "shared" with the "share" verb', () => {
+    expect(inferCud('drive_shared_drives_list')).toBe('read');
+    expect(inferCud('drive_share')).toBe('create');
+  });
+});
+
+describe('ToolRegistry', () => {
+  it('records name/service/cud and forwards to the server', () => {
+    const calls: unknown[][] = [];
+    const fakeServer = {
+      registerTool: (...a: unknown[]) => { calls.push(a); return 'ok'; },
+    } as never;
+    const reg = new ToolRegistry(fakeServer);
+    const ret = reg.registerTool('gmail_send', { description: 'x' }, () => {});
+    expect(ret).toBe('ok');
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe('gmail_send');
+    expect(reg.tools).toEqual([{ name: 'gmail_send', service: 'gmail', cud: 'create' }]);
+  });
+});


### PR DESCRIPTION
Phase 0, slice 3 (the registry). Routes every tool through a `ToolRegistry` that records `{name, service, cud}` and forwards to the MCP server — **v4 parity, no behavior change** (all 175 tools still register eager). `inferCud` derives read/create/update/delete from the tool verb (one override: `drive_untrash`).

- Smoke: all **175 tools** register via the registry — cud split read 68 / create 38 / update 39 / delete 30.
- 126 tests (registry + inferCud added); typecheck/lint/build green.
- This is the metadata layer write-control (next slice) and discover/deferral (Phase 1) build on.

Merge as a **merge commit** (repo standard); single clean `feat:` commit.