### PR TITLE
feat: write-control — deny-by-default CUD gating (profiles + globs + config check)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,14 @@ GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
 #   openssl rand -base64 32
 MASTER_KEY=your_base64_32_byte_key_here
 
+# ─── Write-control (CUD gating; reads are never gated) ──────────────────
+# Deny-by-default: all create/update/delete tools are OFF until you opt in.
+# GOOGLE_PROFILE=read-only        # read-only (default) | safe-writes (create+update) | full-writes
+# GOOGLE_READ_ONLY=true           # hard filter: disables ALL writes regardless of profile
+# GOOGLE_WRITE_ALLOW=calendar:*, sheets:update*   # globs (service:cud or service:op) that open holes
+# GOOGLE_WRITE_DENY=*:delete*     # globs; deny wins over allow + profile
+# Inspect the resolved policy: npx mcp-google-multi config check
+
 # ─── Optional (v4.0.0) ──────────────────────────────────────────────────
 # Opt in to additional scope bundles. Each bundle enables a tool group and
 # its OAuth scopes. Re-auth all accounts after changing this.

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,29 +20,13 @@ import { registerChatTools } from './tools/chat.js';
 import { registerAdminTools, registerAlertCenterTools } from './tools/admin.js';
 import { getOptionalBundles, getAdminAccounts } from './auth.js';
 import { ToolRegistry } from './registry.js';
+import { resolvePolicy, isAllowed, describePolicy, type Policy } from './write-control.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'));
 
-async function main() {
-  if (process.argv.includes('auth')) {
-    const { runAuthFlow } = await import('./auth.js');
-    await runAuthFlow(process.argv);
-    return;
-  }
-
-  if (process.argv.includes('migrate-tokens')) {
-    const { runMigrateTokens } = await import('./migrate-tokens.js');
-    runMigrateTokens();
-    return;
-  }
-
-  // MCP server mode — no console.log (stdio is the MCP channel)
-  const server = new McpServer({
-    name: 'mcp-google-multi',
-    version: pkg.version,
-  });
-  const registry = new ToolRegistry(server);
+function buildRegistry(server: McpServer, policy: Policy): ToolRegistry {
+  const registry = new ToolRegistry(server, policy);
   registerGmailTools(registry);
   registerDriveTools(registry);
   registerCalendarTools(registry);
@@ -57,6 +41,42 @@ async function main() {
   if (optional.has('chat')) registerChatTools(registry);
   if (optional.has('alertcenter')) registerAlertCenterTools(registry);
   if (getAdminAccounts().length > 0) registerAdminTools(registry);
+  return registry;
+}
+
+async function main() {
+  if (process.argv.includes('auth')) {
+    const { runAuthFlow } = await import('./auth.js');
+    await runAuthFlow(process.argv);
+    return;
+  }
+
+  if (process.argv.includes('migrate-tokens')) {
+    const { runMigrateTokens } = await import('./migrate-tokens.js');
+    runMigrateTokens();
+    return;
+  }
+
+  if (process.argv.includes('config') && process.argv.includes('check')) {
+    const policy = resolvePolicy();
+    const registry = buildRegistry(
+      new McpServer({ name: 'mcp-google-multi', version: pkg.version }),
+      policy,
+    );
+    const cud = registry.tools.filter((t) => t.cud !== 'read');
+    const disabled = cud.filter((t) => !isAllowed(t, policy));
+    console.log(`Write-control: ${describePolicy(policy)}`);
+    console.log(`CUD tools enabled: ${cud.length - disabled.length}/${cud.length}`);
+    console.log(`Disabled: ${disabled.map((t) => t.name).join(', ') || '(none)'}`);
+    return;
+  }
+
+  const policy = resolvePolicy();
+  const server = new McpServer({
+    name: 'mcp-google-multi',
+    version: pkg.version,
+  });
+  buildRegistry(server, policy);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { type Policy, isAllowed, writeDisabledResult } from './write-control.js';
 
 export type Cud = 'read' | 'create' | 'update' | 'delete';
 
@@ -29,11 +30,19 @@ export class ToolRegistry {
   readonly tools: ToolEntry[] = [];
   readonly registerTool: McpServer['registerTool'];
 
-  constructor(server: McpServer) {
-    this.registerTool = ((name: string, ...rest: unknown[]) => {
+  constructor(server: McpServer, policy: Policy) {
+    this.registerTool = ((name: string, config: unknown, handler: (...a: unknown[]) => unknown) => {
       const service = name.includes('_') ? name.slice(0, name.indexOf('_')) : name;
-      this.tools.push({ name, service, cud: inferCud(name) });
-      return (server.registerTool as (...args: unknown[]) => unknown)(name, ...rest);
+      const cud = inferCud(name);
+      this.tools.push({ name, service, cud });
+      const guarded =
+        cud === 'read'
+          ? handler
+          : (...args: unknown[]) =>
+              isAllowed({ name, service, cud }, policy)
+                ? handler(...args)
+                : writeDisabledResult({ name, service, cud }, policy);
+      return (server.registerTool as (...a: unknown[]) => unknown)(name, config, guarded);
     }) as McpServer['registerTool'];
   }
 }

--- a/src/write-control.ts
+++ b/src/write-control.ts
@@ -1,0 +1,82 @@
+import type { Cud } from './registry.js';
+
+export type Profile = 'read-only' | 'safe-writes' | 'full-writes';
+
+export interface Policy {
+  profile: Profile;
+  readOnly: boolean;
+  allow: string[];
+  deny: string[];
+}
+
+interface ToolRef {
+  name: string;
+  service: string;
+  cud: Cud;
+}
+
+const PROFILES: Profile[] = ['read-only', 'safe-writes', 'full-writes'];
+
+function parseGlobs(value: string | undefined): string[] {
+  return (value ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+export function resolvePolicy(env: NodeJS.ProcessEnv = process.env): Policy {
+  const raw = (env.GOOGLE_PROFILE ?? 'read-only').trim() as Profile;
+  return {
+    profile: PROFILES.includes(raw) ? raw : 'read-only',
+    readOnly: /^(1|true|yes)$/i.test(env.GOOGLE_READ_ONLY ?? ''),
+    allow: parseGlobs(env.GOOGLE_WRITE_ALLOW),
+    deny: parseGlobs(env.GOOGLE_WRITE_DENY),
+  };
+}
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob.trim().replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function candidates(tool: ToolRef): string[] {
+  const op = tool.name.includes('_') ? tool.name.slice(tool.name.indexOf('_') + 1) : tool.name;
+  return [`${tool.service}:${tool.cud}`, `${tool.service}:${op}`];
+}
+
+function matchesAny(tool: ToolRef, globs: string[]): boolean {
+  if (globs.length === 0) return false;
+  const cands = candidates(tool);
+  return globs.some((g) => {
+    const re = globToRegExp(g);
+    return cands.some((c) => re.test(c));
+  });
+}
+
+function profileAllows(profile: Profile, cud: Cud): boolean {
+  if (profile === 'full-writes') return true;
+  if (profile === 'safe-writes') return cud === 'create' || cud === 'update';
+  return false;
+}
+
+export function isAllowed(tool: ToolRef, policy: Policy): boolean {
+  if (tool.cud === 'read') return true;
+  if (policy.readOnly) return false;
+  if (matchesAny(tool, policy.deny)) return false;
+  if (matchesAny(tool, policy.allow)) return true;
+  return profileAllows(policy.profile, tool.cud);
+}
+
+export function writeDisabledResult(tool: ToolRef, policy: Policy) {
+  const envelope = {
+    error: 'write_disabled',
+    message: `"${tool.name}" (${tool.cud}) is disabled by the current write-control policy (profile: ${policy.profile}${policy.readOnly ? ', GOOGLE_READ_ONLY=true' : ''}).`,
+    hint: `Enable via GOOGLE_PROFILE=safe-writes|full-writes, or GOOGLE_WRITE_ALLOW="${tool.service}:*".`,
+    retriable: false,
+  };
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(envelope) }],
+    isError: true as const,
+  };
+}
+
+export function describePolicy(policy: Policy): string {
+  return `profile=${policy.profile} readOnly=${policy.readOnly} allow=[${policy.allow.join(', ')}] deny=[${policy.deny.join(', ')}]`;
+}

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -56,7 +56,7 @@ describe('ToolRegistry', () => {
     const fakeServer = {
       registerTool: (...a: unknown[]) => { calls.push(a); return 'ok'; },
     } as never;
-    const reg = new ToolRegistry(fakeServer);
+    const reg = new ToolRegistry(fakeServer, { profile: 'full-writes', readOnly: false, allow: [], deny: [] });
     const ret = reg.registerTool('gmail_send', { description: 'x' }, () => {});
     expect(ret).toBe('ok');
     expect(calls).toHaveLength(1);

--- a/tests/write-control.test.ts
+++ b/tests/write-control.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePolicy, isAllowed, describePolicy, type Policy } from '../src/write-control.js';
+
+const tool = (name: string, cud: 'read' | 'create' | 'update' | 'delete') => ({
+  name,
+  service: name.slice(0, name.indexOf('_')),
+  cud,
+});
+
+describe('resolvePolicy', () => {
+  it('defaults to read-only, no globs', () => {
+    expect(resolvePolicy({})).toEqual({ profile: 'read-only', readOnly: false, allow: [], deny: [] });
+  });
+  it('parses profile, readOnly, and glob lists', () => {
+    const p = resolvePolicy({
+      GOOGLE_PROFILE: 'safe-writes',
+      GOOGLE_READ_ONLY: 'true',
+      GOOGLE_WRITE_ALLOW: 'calendar:*, sheets:update*',
+      GOOGLE_WRITE_DENY: '*:delete*',
+    });
+    expect(p).toEqual({
+      profile: 'safe-writes',
+      readOnly: true,
+      allow: ['calendar:*', 'sheets:update*'],
+      deny: ['*:delete*'],
+    });
+  });
+  it('falls back to read-only on an invalid profile', () => {
+    expect(resolvePolicy({ GOOGLE_PROFILE: 'bogus' }).profile).toBe('read-only');
+  });
+});
+
+describe('isAllowed', () => {
+  const ro: Policy = { profile: 'read-only', readOnly: false, allow: [], deny: [] };
+  const safe: Policy = { profile: 'safe-writes', readOnly: false, allow: [], deny: [] };
+  const full: Policy = { profile: 'full-writes', readOnly: false, allow: [], deny: [] };
+
+  it('reads always pass, even read-only', () => {
+    expect(isAllowed(tool('gmail_search', 'read'), ro)).toBe(true);
+  });
+  it('read-only denies all CUD', () => {
+    expect(isAllowed(tool('gmail_send', 'create'), ro)).toBe(false);
+    expect(isAllowed(tool('drive_delete', 'delete'), ro)).toBe(false);
+  });
+  it('safe-writes allows create+update, denies delete', () => {
+    expect(isAllowed(tool('gmail_send', 'create'), safe)).toBe(true);
+    expect(isAllowed(tool('drive_update', 'update'), safe)).toBe(true);
+    expect(isAllowed(tool('drive_delete', 'delete'), safe)).toBe(false);
+  });
+  it('full-writes allows everything', () => {
+    expect(isAllowed(tool('drive_delete', 'delete'), full)).toBe(true);
+  });
+  it('GOOGLE_READ_ONLY beats any profile', () => {
+    expect(isAllowed(tool('gmail_send', 'create'), { ...full, readOnly: true })).toBe(false);
+  });
+  it('deny glob wins over allow + profile', () => {
+    const p: Policy = { profile: 'full-writes', readOnly: false, allow: ['drive:*'], deny: ['*:delete*'] };
+    expect(isAllowed(tool('drive_delete', 'delete'), p)).toBe(false);
+    expect(isAllowed(tool('drive_update', 'update'), p)).toBe(true);
+  });
+  it('allow glob opens a hole in a restrictive profile', () => {
+    const p: Policy = { profile: 'read-only', readOnly: false, allow: ['calendar:*'], deny: [] };
+    expect(isAllowed(tool('calendar_create_event', 'create'), p)).toBe(true);
+    expect(isAllowed(tool('gmail_send', 'create'), p)).toBe(false);
+  });
+  it('allow matches by operation name (gmail:send)', () => {
+    const p: Policy = { profile: 'read-only', readOnly: false, allow: ['gmail:send'], deny: [] };
+    expect(isAllowed(tool('gmail_send', 'create'), p)).toBe(true);
+  });
+  it('precedence holds: readonly > deny > allow > profile', () => {
+    expect(isAllowed(tool('gmail_send', 'create'), { profile: 'full-writes', readOnly: true, allow: ['*:*'], deny: [] })).toBe(false);
+  });
+});
+
+describe('describePolicy', () => {
+  it('renders a one-line summary', () => {
+    expect(
+      describePolicy({ profile: 'safe-writes', readOnly: false, allow: ['a:*'], deny: ['*:delete*'] }),
+    ).toBe('profile=safe-writes readOnly=false allow=[a:*] deny=[*:delete*]');
+  });
+});


### PR DESCRIPTION
Phase 0, slice 4 — **completes Phase 0**.

Reads never gated; **create/update/delete deny-by-default**, enforced at dispatch in the registry using each tool's `cud`.
- `GOOGLE_PROFILE` = read-only (default) / safe-writes (create+update) / full-writes
- `GOOGLE_READ_ONLY` hard filter; `GOOGLE_WRITE_ALLOW`/`DENY` globs (`service:cud` or `service:op`; deny wins)
- denied calls return a `write_disabled` error envelope
- `config check` CLI prints the resolved policy + enabled/disabled CUD tools

Verified via `config check`: read-only **0/105**, safe-writes **75/105**, full-writes **105/105**, `allow calendar:*` → **6**, `GOOGLE_READ_ONLY` → **0**. 139 tests; typecheck/lint/build green.

⚠️ Breaking (intended, v5): writes are off until you set `GOOGLE_PROFILE`. Merge as a **merge commit**.