### PR TITLE
feat!: v5 launch prep — npm-first README + COVERAGE + OS-config token dir

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,38 +1,31 @@
 GOOGLE_CLIENT_ID=your_client_id_here
 GOOGLE_CLIENT_SECRET=your_client_secret_here
 
-# Comma-separated list of alias:email pairs
-# Example: work:you@company.com,personal:you@gmail.com
+# Comma-separated alias:email pairs — e.g. work:you@company.com,personal:you@gmail.com
 GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
 
-# Encryption key for stored OAuth tokens (required). Generate with:
+# Encryption key for the local token store (REQUIRED). Generate with:
 #   openssl rand -base64 32
 MASTER_KEY=your_base64_32_byte_key_here
 
 # ─── Write-control (CUD gating; reads are never gated) ──────────────────
-# Deny-by-default: all create/update/delete tools are OFF until you opt in.
-# GOOGLE_PROFILE=read-only        # read-only (default) | safe-writes (create+update) | full-writes
-# GOOGLE_READ_ONLY=true           # hard filter: disables ALL writes regardless of profile
-# GOOGLE_WRITE_ALLOW=calendar:*, sheets:update*   # globs (service:cud or service:op) that open holes
-# GOOGLE_WRITE_DENY=*:delete*     # globs; deny wins over allow + profile
-# Inspect the resolved policy: npx mcp-google-multi config check
+# Deny-by-default: every create/update/delete tool is OFF until you opt in.
+GOOGLE_PROFILE=read-only              # read-only (default) | safe-writes (create+update) | full-writes
+# GOOGLE_READ_ONLY=true               # hard kill-switch for ALL writes (overrides the profile)
+# GOOGLE_WRITE_ALLOW=calendar:*, sheets:update*   # glob holes (service:cud or service:op)
+# GOOGLE_WRITE_DENY=*:delete*         # globs; deny wins over allow + profile
+# Inspect the resolved policy:  mcp-google-multi config check
 
-# ─── Optional (v4.0.0) ──────────────────────────────────────────────────
-# Opt in to additional scope bundles. Each bundle enables a tool group and
-# its OAuth scopes. Re-auth all accounts after changing this.
-# Supported: forms, chat, alertcenter
-# NOTE: the `alertcenter` bundle (apps.alerts) is NOT grantable via this
-# server's user-consent OAuth flow — it needs a service account with
-# domain-wide delegation, which is not yet supported. Enabling it declares
-# the scope and registers the 2 alert tools, but the API rejects user tokens.
+# ─── Optional tool bundles ──────────────────────────────────────────────
+# Enable extra services + their OAuth scopes; re-auth accounts after changing.
 # GOOGLE_OPTIONAL_SCOPES=forms,chat
 
-# Comma-separated list of account aliases that should be granted Workspace
-# admin scopes (Reports + Directory). Accounts NOT listed here will never
-# request admin scopes — safe for personal Gmail. (Alert Center is no longer
-# part of this bundle; it is the separate `alertcenter` optional bundle above.)
+# ─── Workspace Admin (per-account) ──────────────────────────────────────
+# Aliases granted Admin SDK scopes (the account's own super-admin OAuth).
+# Personal @gmail accounts will 403 — never list them. Admin writes are gated
+# by write-control like any other CUD tool.
 # GOOGLE_ADMIN_ACCOUNTS=work
 
-# Required to unlock destructive admin write operations (admin_users_update).
-# Default refuses to prevent accidents on small orgs.
-# GOOGLE_ALLOW_ADMIN_WRITES=true
+# ─── Token store location (optional) ────────────────────────────────────
+# Default: ~/.config/mcp-google-multi/tokens
+# TOKEN_STORE_PATH=/custom/path/tokens

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,37 +1,37 @@
 # Working on mcp-google-multi
 
-Conventions for AI assistants modifying this codebase.
+Conventions for AI assistants modifying this codebase. v5 is **local, stdio, user-OAuth only**.
 
 ## Project shape
 
-- Each Google service lives in `src/tools/<service>.ts` and exports `register<Service>Tools(server: McpServer): void`.
-- `src/index.ts` is the entry point. It wires service registrations into the MCP server, conditional on env-driven scope bundles (Forms/Chat/Alert Center opt-in, Admin opt-in per-account).
-- `src/auth.ts` owns OAuth flow + scope tier resolution. `BASE_SCOPES` are always granted; `OPTIONAL_SCOPE_BUNDLES` are env-gated; `ADMIN_SCOPES` are per-account-gated. `resolveScopesForAccount(alias)` is the authoritative composer.
-- `src/client.ts` is a thin OAuth2Client factory used by every tool handler.
-- `src/accounts.ts` parses the `GOOGLE_ACCOUNTS` env var.
+- `src/index.ts` — entry. `buildRegistry()` registers every service into a `ToolRegistry`; `main()` runs the stdio MCP server, or the `auth` / `migrate-tokens` / `config check` CLI commands.
+- `src/registry.ts` — `ToolRegistry` wraps the MCP server: records `{name, service, cud}` per tool, derives `cud` (read/create/update/delete) from the tool name via `inferCud`, and **enforces write-control** by wrapping every CUD handler. Service files still call `server.registerTool(...)` — `server` is now a `ToolRegistry`.
+- `src/write-control.ts` — `resolvePolicy()` (env → policy) + `isAllowed()` (deny-by-default verdict) + `config check` rendering.
+- `src/token-store.ts` — encrypted token store (AES-256-GCM, key from `MASTER_KEY`); `readToken`/`writeToken` + the `migrate-tokens` source.
+- `src/auth.ts` — OAuth flow + scope tiers (`BASE_SCOPES` always, `OPTIONAL_SCOPE_BUNDLES` env-gated, `ADMIN_SCOPES` per-account).
+- `src/client.ts` — `getClient(account)`: cached OAuth2Client from the encrypted token; refreshes + re-encrypts.
+- `src/accounts.ts` — parses `GOOGLE_ACCOUNTS`; token dir defaults to `~/.config/mcp-google-multi/tokens` (override `TOKEN_STORE_PATH`).
+- `src/tools/_errors.ts` — `mapGoogleError` typed taxonomy + per-service `handle<Service>Error` shims.
+- `src/tools/_coerce.ts` — `coerceArray`/`coerceJson`/`coerceBoolean` for string-encoded client args.
 
-## Adding a new tool
-
-Every tool follows the same skeleton:
+## Adding a tool
 
 ```ts
 server.registerTool(
-  'service_action_name',                       // snake_case, prefixed by service
+  'service_action_name',                 // snake_case, service-prefixed; cud inferred from the verb
   {
-    description: '<one sentence; explain when to use this tool>',
+    description: '<one sentence; when to use it>',
     inputSchema: {
-      account: accountEnum.describe('Google account alias'),  // always first
-      // ...other params as a flat zod object
+      account: accountEnum.describe('Google account alias'),   // always first
+      // wrap array/object/bool params with coerceArray / coerceJson / coerceBoolean
     },
   },
-  async ({ account, /* destructure inputs */ }) => {
+  async ({ account, /* … */ }) => {
     try {
       const auth = await getClient(account as Account);
       const svc = google.<service>({ version: '<v>', auth });
-      const res = await svc.<resource>.<method>({ /* params */ });
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
-      };
+      const res = await svc.<resource>.<method>({ /* … */ });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }] };
     } catch (error: any) {
       return handle<Service>Error(error, account as Account);
     }
@@ -40,81 +40,53 @@ server.registerTool(
 ```
 
 **Hard rules:**
-- `inputSchema` is a flat object of `zod` schemas. Do not nest into another `z.object` at the top level.
-- `account: accountEnum` is the first field of every input schema.
-- Wrap the handler body in try/catch. Call the file's `handle<Service>Error` helper in the catch.
-- Return `{ content: [{ type: 'text' as const, text: JSON.stringify(...) }] }`. Stringify the response payload so MCP clients can re-parse it.
-- For errors, also set `isError: true`.
-- Every file has a 3-line `handle<Service>Error` shim at the bottom that delegates to `handleGoogleApiError` in `src/tools/_errors.ts` — the shared 401/403/429/fallback mapper. Pass an optional service-specific `forbiddenHint` string to the shared helper for services where 403 has a known fix (e.g. admin scopes, optional scope bundle not enabled).
+- Flat `zod` `inputSchema`; `account` first. Coerce array/object/bool inputs — clients send them string-encoded.
+- `cud` is inferred from the tool name (no manual flag). CUD tools are auto-gated by write-control; **never** add your own write gate. Fix a misclassified verb in `CUD_OVERRIDES` (`registry.ts`).
+- Wrap handlers in try/catch → `handle<Service>Error` (→ `mapGoogleError`); errors return `{error, message, hint?, retriable, account}` with `isError: true`. **Never embed the raw error / `error.config` / `error.response`** — token-leak.
+- Return `{ content: [{ type: 'text', text: JSON.stringify(...) }] }`.
 
-## Adding a new service
+## Adding a service
 
-1. Create `src/tools/<service>.ts` exporting `register<Service>Tools(server)`.
-2. Add scope(s) to `src/auth.ts`:
-   - Always-on → append to `BASE_SCOPES`.
-   - Optional bundle → add a new key to `OPTIONAL_SCOPE_BUNDLES`.
-   - Admin-only → append to `ADMIN_SCOPES`.
-3. Wire registration in `src/index.ts`. Always-on calls go in the unconditional block; optional bundles check `optional.has('<key>')` (where `optional` is built from `getOptionalBundles()`); admin tools register only if `getAdminAccounts().length > 0`.
-4. Update README scope table, tool table, and tool count in the Features bullet.
-5. Update CHANGELOG.md.
+1. `src/tools/<service>.ts` exporting `register<Service>Tools(server: ToolRegistry)`.
+2. Scopes in `auth.ts`: always-on → `BASE_SCOPES` (breaking — forces re-auth → `feat!:`); optional → `OPTIONAL_SCOPE_BUNDLES`; admin → `ADMIN_SCOPES`.
+3. Wire into `buildRegistry()` (`index.ts`).
+4. Update `COVERAGE.md` + `README.md`.
 
-## Drive-specific: shared drive support
+## Auth / tokens
 
-Every Drive API call that takes a `fileId` must pass `supportsAllDrives: true`. List operations also need `includeItemsFromAllDrives: true`. Forgetting these silently breaks shared-drive content. Existing tools already have them — preserve when refactoring.
+- Tokens are **encrypted at rest** — never write plaintext. `MASTER_KEY` is required; it lives only in env (never in the store, never logged).
+- Always go through `getClient(account)` (handles refresh + re-encrypt). Token files are `0600`.
 
-## Drive-specific: import conversion
+## Write-control
 
-To convert an upload into a native Workspace file, set the **resource** (`requestBody`) `mimeType` to a `application/vnd.google-apps.*` type while the `media` carries the importable source type. The media mimeType is the source; the resource mimeType is the target. `drive_upload`'s `convertTo` param does exactly this. Drive v3 has no separate `convert` flag (the v2 one is deprecated). `drive_export` is the reverse direction only.
+Reads are never gated. CUD is **deny-by-default**: `GOOGLE_PROFILE` (read-only / safe-writes / full-writes) + `GOOGLE_READ_ONLY` + `GOOGLE_WRITE_ALLOW`/`DENY` globs. Verdict + precedence in `write-control.ts`, tested in `tests/write-control.test.ts`.
 
-## Sheets/Docs: fields masks
+## Drive specifics
 
-`spreadsheets.batchUpdate` Request types like `RepeatCell` and `updateParagraphStyle` require explicit `fields` masks. Compute the mask from supplied input keys; never use wildcards. The helpers `buildCellFormat` (in `sheets.ts`), `buildParagraphStyle`, and `buildDocumentStyle` (in `docs.ts`) are the reference implementations and are unit-tested in `tests/field-mask-helpers.test.ts`. If you add a new format dimension, extend the helper, add a test, and bump the input schema.
+- Every `fileId` call: `supportsAllDrives: true`; lists: `includeItemsFromAllDrives: true`.
+- `drive_upload` `convertTo`: resource mimeType = target `application/vnd.google-apps.*`, media = source. `drive_export` is the reverse.
+- Comment text field is `content`. Comments/Replies API requires `fields` on every call (see `*_FIELDS` constants in `drive.ts`).
 
-## Escape hatches
+## Sheets/Docs field masks
 
-`sheets_batch_update` and `docs_batch_update` accept the full Request union as `z.array(z.record(z.string(), z.any()))`. Don't add a per-Request-type tool unless it's high-frequency or has a high-value default-computing facade (like `format_cells`). The catch-all keeps the tool count tractable.
+`batchUpdate` Request types need explicit `fields` masks — compute from input keys, never wildcards. Helpers `buildCellFormat` / `buildParagraphStyle` / `buildDocumentStyle` are unit-tested in `tests/field-mask-helpers.test.ts`.
 
-## Comments / Replies (Drive)
+## Versioning & releases (automated — CI controls it)
 
-- Comment text field is `content`, not `body`. Confirmed against the Drive v3 Comment resource.
-- `replies.create` accepts `action: 'resolve' | 'reopen'` to close/reopen a thread in the same call.
-- Comments/Replies API **requires** the `fields` query param on every call — never omit. See the `COMMENT_FIELDS`, `COMMENT_LIST_FIELDS`, `REPLY_FIELDS`, `REPLY_LIST_FIELDS` constants at the top of `drive.ts`.
-
-## Admin SDK safety
-
-- Admin tools only register if `GOOGLE_ADMIN_ACCOUNTS` is set.
-- Destructive admin writes (`admin_users_update`) must check `adminWritesEnabled()` (imported from `auth.ts`) and refuse if `GOOGLE_ALLOW_ADMIN_WRITES` is not exactly `'true'`. Do not relax this gate.
-- Admin tools 403 on personal Gmail accounts. The `handleAdminError` helper surfaces this hint clearly — keep it.
-
-## Alert Center is NOT an admin scope
-
-- `apps.alerts` (Alert Center) is **not** in `ADMIN_SCOPES`. Google does not grant it through the interactive user-consent OAuth flow this server uses — it requires a service account with domain-wide delegation. Putting it in the user-OAuth admin bundle made the *entire* admin consent fail with `Error 400: invalid_scope`.
-- It lives in the `alertcenter` key of `OPTIONAL_SCOPE_BUNDLES`, and `registerAlertCenterTools` (in `admin.ts`) registers behind `optional.has('alertcenter')` — never behind `getAdminAccounts()`. Keep these decoupled so a missing/ungrantable `apps.alerts` can never block the working Admin SDK tools.
-- Until service-account + domain-wide-delegation auth exists, the `alertcenter` bundle is declared-but-non-functional under user OAuth. `handleAlertCenterError` surfaces this — keep the hint.
-
-## Versioning & releases (automated)
-
-Releases are cut by **semantic-release** on every push to a release branch — do NOT bump `package.json`, write a changelog, or tag by hand.
-
-- Channels: `dev` → `x.y.z-alpha.n`, `staging` → `x.y.z-beta.n`, `main` → `x.y.z` (stable). Config in `.releaserc.json`; workflow in `.github/workflows/release.yml`.
-- Version is computed from Conventional Commits: `fix:` = patch, `feat:` = minor, `feat!:`/`BREAKING CHANGE:` = major. **A new `BASE_SCOPES` scope is breaking** (tokens become incomplete, forces re-auth) — mark it `feat!:` so it bumps major.
-- **Tags + GitHub Releases only** — no commit-back (`@semantic-release/git`/`@semantic-release/npm` are intentionally NOT used) so nothing fights branch protection; `GITHUB_TOKEN` suffices.
-- `package.json` `version` is a placeholder (`0.0.0-semantically-released`). The git tag / GitHub Release is the source of truth. `CHANGELOG.md` is frozen at v4.2.0; newer notes live in Releases.
+- semantic-release on push to `dev` (alpha) / `staging` (beta) / `main` (stable). Never bump `package.json`, write a changelog, or tag by hand.
+- Conventional Commits: `fix:`=patch, `feat:`=minor, `feat!:`/`BREAKING CHANGE:`=major. A new `BASE_SCOPES` scope is breaking (`feat!:`).
+- **Merge commits only** (squash/rebase disabled) — each branch's commits land individually, so keep them clean Conventional Commits.
+- After a stable release, `.github/workflows/backmerge.yml` resyncs `main → staging → dev`.
 
 ## Testing
 
-- `npm run typecheck && npm run lint && npm run test` must all pass before any PR.
-- Pure-logic helpers (fields-mask builders, validation helpers) get unit tests.
-- Do not try to mock `googleapis` for integration tests — manual smoke testing in Claude Code against real accounts is the truth.
-- Always re-auth after editing `BASE_SCOPES` before manual testing.
+- `npm run typecheck && npm run lint && npm run test && npm run build` before any PR.
+- Unit-test pure logic (write-control verdict, coercion, error mapper, token-store crypto, `inferCud`, field-mask builders). Don't mock `googleapis` — smoke-test handlers against real accounts.
 
 ## Don'ts
 
-- Don't `console.log` from tool handlers in MCP server mode. Stdio is the MCP channel. Use `process.stderr.write` if you really need to.
-- Don't hardcode account aliases. Always read from `ACCOUNTS` / `ACCOUNT_CONFIG`.
-- Don't bypass `getClient(account)` — it handles token refresh persistence.
-- Don't store tokens with permissions wider than `0o600`.
-- Don't expand `BASE_SCOPES` silently. Any scope change is user-visible and requires CHANGELOG documentation + a re-auth note.
-- Don't re-implement error mapping. Always go through `handleGoogleApiError` (via the per-service shim).
-- Don't re-parse `GOOGLE_OPTIONAL_SCOPES` or `GOOGLE_ADMIN_ACCOUNTS` inline. Use `getOptionalBundles()` / `getAdminAccounts()` exported from `auth.ts`.
-- Don't add narrative comments explaining WHAT code does. The CLAUDE.md rule is non-obvious WHY only; section dividers (`// ─── X ───`) are the exception as navigation aids.
+- No `console.log` from handlers (stdio is the MCP channel) — `process.stderr.write` only.
+- Don't hardcode aliases — read `ACCOUNTS` / `ACCOUNT_CONFIG`.
+- Don't bypass `getClient`; don't write plaintext tokens or perms wider than `0o600`.
+- Don't re-implement error mapping or write gating — use the shared helpers.
+- Don't add narrative comments — non-obvious WHY only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ your fork ──PR──▶ dev ──▶ staging ──▶ main (releases tagge
 - **Open all PRs against `dev`.** PRs to `staging` or `main` from contributors will be redirected.
 - The maintainer promotes `dev → staging → main` and cuts releases from `main`.
 - `dev`, `staging`, and `main` are all protected: CI must pass and changes land via pull request.
+- **Merges use merge commits** (squash & rebase are disabled), so keep each branch's commits clean Conventional Commits — they land individually and drive the release version.
 
 ## Dev setup
 
@@ -25,7 +26,7 @@ your fork ──PR──▶ dev ──▶ staging ──▶ main (releases tagge
 git clone https://github.com/bakissation/mcp-google-multi.git
 cd mcp-google-multi
 npm install
-cp .env.example .env          # add your GOOGLE_CLIENT_ID/SECRET and GOOGLE_ACCOUNTS
+cp .env.example .env          # add GOOGLE_CLIENT_ID/SECRET, GOOGLE_ACCOUNTS, and MASTER_KEY
 npm run build
 node dist/index.js auth --account <alias>   # OAuth each account you'll test with
 ```
@@ -49,7 +50,7 @@ npm run build
 
 The full spec lives in [`CLAUDE.md`](./CLAUDE.md). The essentials:
 
-- **One service per file** in `src/tools/<service>.ts`, exporting `register<Service>Tools(server)`.
+- **One service per file** in `src/tools/<service>.ts`, exporting `register<Service>Tools(server: ToolRegistry)`. `cud` (read/create/update/delete) is inferred from the tool name; CUD tools are auto-gated by write-control.
 - **Tool shape:** `server.registerTool(name, { description, inputSchema }, handler)`. `inputSchema` is a flat `zod` object with `account: accountEnum` as the first field. Tool names are `snake_case`, prefixed by service.
 - **Errors:** wrap handlers in `try/catch` and delegate to the per-service `handle<Service>Error` shim (which calls `handleGoogleApiError`). Set `isError: true` on error responses.
 - **Scopes** are tiered in `src/auth.ts`: `BASE_SCOPES` (always), `OPTIONAL_SCOPE_BUNDLES` (env opt-in), `ADMIN_SCOPES` (per-account opt-in). Any new scope must be documented and noted as requiring re-auth.
@@ -62,14 +63,14 @@ Versioning and releases are **fully automated** by [semantic-release](https://se
 
 - `fix:` → patch, `feat:` → minor, `feat!:` / `BREAKING CHANGE:` → major. `docs:`/`chore:`/`refactor:` don't trigger a release.
 - On merge, a release is cut automatically per channel: **`dev` → `x.y.z-alpha.n`**, **`staging` → `x.y.z-beta.n`**, **`main` → `x.y.z`** (stable). Release notes are generated into [GitHub Releases](https://github.com/bakissation/mcp-google-multi/releases).
-- Still update the relevant **README** tables in your PR when you add/change a tool. (`package.json` `version` is a managed placeholder — the git tag / GitHub Release is the source of truth.)
+- Update **[COVERAGE.md](./COVERAGE.md)** when you add/change a tool. (`package.json` `version` is a managed placeholder — the git tag / GitHub Release is the source of truth.)
 
 ## PR checklist
 
 - [ ] Targets `dev`
 - [ ] `typecheck`, `lint`, `test`, `build` all pass
 - [ ] Conventional commit messages
-- [ ] README tables updated (no manual version bump / changelog — automated from your commits)
+- [ ] COVERAGE.md updated (no manual version bump / changelog — automated from your commits)
 - [ ] No secrets, tokens, or `.env` committed
 
 ## Security

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -156,6 +156,6 @@ Requires the listed account to be a Workspace **super-admin** (its own OAuth —
 | `admin_users_update` | User edits (gated by write-control) |
 | `admin_groups_list` / `admin_group_members_list` | Group + member reads |
 
-## Google Alert Center — deferred to v6
+## Not yet available
 
-`alertcenter_alerts_list` / `alertcenter_alert_get` exist behind `GOOGLE_OPTIONAL_SCOPES=alertcenter`, **but the `apps.alerts` scope cannot be granted via user OAuth** — it needs a service account with domain-wide delegation. v5 is user-OAuth only, so these register but the API rejects the tokens. Service-account support (and a working Alert Center) is planned for **[v6](https://github.com/bakissation/mcp-google-multi/milestones)** ([#4](https://github.com/bakissation/mcp-google-multi/issues/4)).
+**Alert Center** (security alerts) requires a service account with domain-wide delegation, which user OAuth can't grant — planned for **[v6](https://github.com/bakissation/mcp-google-multi/milestones)** ([#4](https://github.com/bakissation/mcp-google-multi/issues/4)).

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -1,0 +1,161 @@
+# Tool Coverage
+
+Every tool takes an `account` argument matching one of your `GOOGLE_ACCOUNTS` aliases. **Create / update / delete tools are gated by [write-control](./README.md#write-control-deny-by-default)** — deny-by-default; reads are always available. Run `mcp-google-multi config check` to see exactly which CUD tools your current profile enables.
+
+~170 tools across the services below. (This is the curated surface; discover-first deferral and exhaustive API coverage are on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones).)
+
+## Gmail
+
+| Tool | Description |
+|------|-------------|
+| `gmail_search` | Search messages with Gmail query syntax |
+| `gmail_read` | Read a full message by ID |
+| `gmail_read_thread` | Read all messages in a thread |
+| `gmail_send` | Send an email (optional `htmlBody` for multipart/alternative) |
+| `gmail_download_attachment` | Download an email attachment to local disk |
+| `gmail_create_draft` | Create a draft (optional `htmlBody` for multipart/alternative) |
+| `gmail_modify_labels` | Add/remove labels on a message (star, archive, mark read, etc.) |
+| `gmail_trash` | Move a message to Trash (recoverable) |
+| `gmail_delete` | Permanently delete a message (irreversible) |
+| `gmail_batch_modify` | Bulk add/remove labels across up to 1000 messages |
+| `gmail_batch_delete` | Permanently delete multiple messages (irreversible) |
+| `gmail_list_drafts` | List all drafts |
+| `gmail_get_draft` | Read a specific draft |
+| `gmail_send_draft` | Send an existing draft |
+| `gmail_list_labels` | List all labels (system + custom) |
+| `gmail_create_label` | Create a custom label |
+| `gmail_delete_label` | Delete a label |
+| `gmail_get_profile` | Get account email, message count, history ID |
+| `gmail_list_history` | Get mailbox changes since a history ID |
+| `gmail_get_vacation` | Read vacation responder settings |
+| `gmail_set_vacation` | Enable/disable vacation responder |
+
+## Google Drive
+
+| Tool | Description |
+|------|-------------|
+| `drive_search` | Search files with Drive query syntax (shared drives included) |
+| `drive_read` | Read file content (exports Workspace docs as text) |
+| `drive_list` | List files in a folder or root |
+| `drive_upload` | Upload a local file (optional `convertTo` imports as a native Google Doc/Sheet/Slides) |
+| `drive_download` | Download a binary file to local disk |
+| `drive_export` | Export Docs/Sheets/Slides to PDF, DOCX, XLSX, Markdown, etc. |
+| `drive_create_folder` | Create a new folder |
+| `drive_update` | Rename, move, or replace file content |
+| `drive_delete` | Permanently delete a file (irreversible) |
+| `drive_trash` / `drive_untrash` / `drive_empty_trash` | Trash lifecycle |
+| `drive_copy` / `drive_move` | Duplicate / move a file |
+| `drive_share` | Share with user/group/domain/anyone (`transferOwnership`, `expirationTime`) |
+| `drive_list_permissions` / `drive_permission_update` / `drive_remove_permission` | Permission management |
+| `drive_comment_create` / `_list` / `_get` / `_update` / `_delete` | Comment CRUD with anchors |
+| `drive_reply_create` / `_list` / `_update` / `_delete` | Reply CRUD (`action: resolve｜reopen`) |
+| `drive_revision_list` / `_update` / `_delete` | Version history (`keepForever`) |
+| `drive_access_proposal_list` / `_resolve` | Triage "Request access" submissions |
+| `drive_shared_drives_list` / `drive_shared_drive_get` | Shared drive discovery |
+| `drive_get_about` | Storage quota and account info |
+
+## Google Calendar
+
+| Tool | Description |
+|------|-------------|
+| `calendar_list_calendars` | List all calendars |
+| `calendar_list_events` | List/search events with time range |
+| `calendar_get_event` | Get a single event by ID |
+| `calendar_create_event` / `calendar_update_event` / `calendar_delete_event` | Event CRUD |
+| `calendar_quick_add` | Create event from natural language |
+| `calendar_move_event` | Move an event between calendars |
+| `calendar_list_instances` | List occurrences of a recurring event |
+| `calendar_get_freebusy` | Check free/busy times |
+| `calendar_create_calendar` | Create a new calendar |
+
+## Google Sheets
+
+| Tool | Description |
+|------|-------------|
+| `sheets_create` / `sheets_get` | Create / metadata |
+| `sheets_read_range` / `sheets_batch_read` | Read values |
+| `sheets_write_range` / `sheets_batch_write` / `sheets_append_rows` | Write / append |
+| `sheets_clear_range` / `sheets_batch_clear` | Clear values (keeps formatting) |
+| `sheets_add_sheet` / `sheets_delete_sheet` / `sheets_duplicate_sheet` / `sheets_update_sheet_properties` | Tab management |
+| `sheets_format_cells` / `sheets_update_borders` / `sheets_merge_cells` / `sheets_unmerge_cells` | Formatting |
+| `sheets_add_conditional_format_rule` / `sheets_sort_range` / `sheets_set_basic_filter` / `sheets_clear_basic_filter` | Rules / sort / filter |
+| `sheets_find_replace` / `sheets_auto_resize_dimensions` / `sheets_set_data_validation` | Find-replace / autosize / validation |
+| `sheets_add_named_range` / `sheets_delete_named_range` | Named ranges |
+| `sheets_insert_dimension` / `sheets_delete_dimension` | Insert/delete rows or columns |
+| `sheets_batch_update` | Generic batchUpdate escape hatch |
+
+## Google Docs
+
+| Tool | Description |
+|------|-------------|
+| `docs_create` / `docs_get` / `docs_read` | Create / metadata / read text |
+| `docs_insert_text` / `docs_replace_text` / `docs_delete_range` | Text editing |
+| `docs_update_style` / `docs_update_paragraph_style` / `docs_update_document_style` | Formatting |
+| `docs_insert_table` / `docs_modify_table` | Tables |
+| `docs_create_named_range` / `docs_delete_named_range` / `docs_replace_named_range_content` | Mail-merge primitive |
+| `docs_create_paragraph_bullets` / `docs_delete_paragraph_bullets` | Lists |
+| `docs_insert_inline_image` / `docs_insert_page_break` / `docs_insert_section_break` | Media / layout |
+| `docs_create_header` / `docs_delete_header` / `docs_create_footer` / `docs_delete_footer` | Headers / footers |
+| `docs_add_tab` / `docs_delete_tab` / `docs_update_tab_properties` | Tabs |
+| `docs_batch_update` | Generic batchUpdate escape hatch |
+
+## Google Contacts
+
+| Tool | Description |
+|------|-------------|
+| `contacts_search` / `contacts_get` / `contacts_list` | Read |
+| `contacts_create` / `contacts_update` / `contacts_delete` | Contact CRUD |
+| `contacts_groups_list` / `contacts_group_members` / `contacts_group_create` | Groups |
+
+## Google Search Console
+
+| Tool | Description |
+|------|-------------|
+| `searchconsole_sites_list` / `_get` / `_add` / `_delete` | Property management |
+| `searchconsole_sitemaps_list` / `_get` / `_submit` / `_delete` | Sitemap management |
+| `searchconsole_searchanalytics_query` | Query search analytics |
+| `searchconsole_url_inspect` | Inspect a URL |
+
+## Google Tasks
+
+| Tool | Description |
+|------|-------------|
+| `tasks_lists_list` / `tasks_list_get` / `tasks_list_insert` / `tasks_list_update` / `tasks_list_delete` | Tasklist management |
+| `tasks_list` | List tasks (filter by completion, due, updated) |
+| `tasks_get` / `tasks_insert` / `tasks_update` / `tasks_delete` | Task CRUD |
+| `tasks_move` | Re-parent / re-position / move to another list |
+| `tasks_clear` | Delete every completed task |
+
+## Google Meet
+
+| Tool | Description |
+|------|-------------|
+| `meet_conference_records_list` / `meet_conference_record_get` | Past Meet sessions |
+| `meet_recordings_list` / `meet_transcripts_list` / `meet_transcript_entries_list` | Recordings & transcripts |
+
+## Google Forms — optional bundle (`GOOGLE_OPTIONAL_SCOPES=forms`)
+
+| Tool | Description |
+|------|-------------|
+| `forms_get` / `forms_responses_list` / `forms_response_get` / `forms_watches_list` | Form + responses (read) |
+
+## Google Chat — optional bundle (`GOOGLE_OPTIONAL_SCOPES=chat`)
+
+| Tool | Description |
+|------|-------------|
+| `chat_spaces_list` / `chat_spaces_get` / `chat_messages_create` / `chat_messages_list` | Spaces & messages |
+
+## Google Workspace Admin — `GOOGLE_ADMIN_ACCOUNTS=<alias…>`
+
+Requires the listed account to be a Workspace **super-admin** (its own OAuth — no service account). Personal `@gmail.com` accounts will 403; never list them.
+
+| Tool | Description |
+|------|-------------|
+| `reports_activities_list` | Workspace audit log |
+| `admin_users_list` / `admin_users_get` | User directory reads |
+| `admin_users_update` | User edits (gated by write-control) |
+| `admin_groups_list` / `admin_group_members_list` | Group + member reads |
+
+## Google Alert Center — deferred to v6
+
+`alertcenter_alerts_list` / `alertcenter_alert_get` exist behind `GOOGLE_OPTIONAL_SCOPES=alertcenter`, **but the `apps.alerts` scope cannot be granted via user OAuth** — it needs a service account with domain-wide delegation. v5 is user-OAuth only, so these register but the API rejects the tokens. Service-account support (and a working Alert Center) is planned for **[v6](https://github.com/bakissation/mcp-google-multi/milestones)** ([#4](https://github.com/bakissation/mcp-google-multi/issues/4)).

--- a/README.md
+++ b/README.md
@@ -1,470 +1,127 @@
 # mcp-google-multi
 
-A local [MCP](https://modelcontextprotocol.io) server that gives Claude Code (and any MCP client) access to **Gmail**, **Google Drive**, **Google Calendar**, **Google Sheets**, **Google Docs**, **Google Contacts**, **Google Search Console**, **Google Tasks**, **Google Meet**, and optionally **Google Forms**, **Google Chat**, and **Google Workspace Admin** APIs across multiple Google accounts simultaneously.
+A **local** [MCP](https://modelcontextprotocol.io) server that gives Claude Code (and any MCP client) access to your **Google Workspace** — Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console (plus optional Forms, Chat, and Workspace Admin) — across **multiple Google accounts** at once.
 
 [![npm](https://img.shields.io/npm/v/mcp-google-multi?label=npm&color=cb3837)](https://www.npmjs.com/package/mcp-google-multi)
 
-## Features
+- 🔑 **Multi-account** — drive any number of your Google accounts from one server, each by a short alias.
+- 🔒 **Secure by default** — refresh tokens **encrypted at rest** (AES-256-GCM); **writes are deny-by-default**; no telemetry — it talks only to Google.
+- 📦 **npm-first** — install and run with `npx`; everything configured through env vars.
+- 🧰 **~170 tools** across 12 services → full list in **[COVERAGE.md](./COVERAGE.md)**.
 
-- **Multi-account** — manage any number of Google accounts from a single server
-- **175 tools** across 13 Google services
-- **Tiered OAuth scopes** — base scopes always granted; Forms/Chat/Alert Center are opt-in bundles; Admin scopes are per-account opt-in with a separate safety flag for destructive writes
-- **Config-driven accounts** — defined in `.env`, no code changes needed
-- **Auto-refresh** — OAuth tokens refresh transparently and persist to disk
-- **Stdio transport** — runs as a local subprocess, no hosting needed
+> v5 is **local + user-OAuth only**. Service accounts and hosting (and the APIs they unlock) are on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones). **Upgrading from v4?** Jump to [Upgrading](#upgrading-from-v4).
 
-## Tools
+## Quick start
 
-### Gmail (21 tools)
-
-| Tool | Description |
-|------|-------------|
-| `gmail_search` | Search messages with Gmail query syntax |
-| `gmail_read` | Read a full message by ID |
-| `gmail_read_thread` | Read all messages in a thread |
-| `gmail_send` | Send an email (optional `htmlBody` for multipart/alternative) |
-| `gmail_download_attachment` | Download an email attachment to local disk |
-| `gmail_create_draft` | Create a draft (optional `htmlBody` for multipart/alternative) |
-| `gmail_modify_labels` | Add/remove labels on a message (star, archive, mark read, etc.) |
-| `gmail_trash` | Move a message to Trash (recoverable) |
-| `gmail_delete` | Permanently delete a message (irreversible) |
-| `gmail_batch_modify` | Bulk add/remove labels across up to 1000 messages |
-| `gmail_batch_delete` | Permanently delete multiple messages (irreversible) |
-| `gmail_list_drafts` | List all drafts |
-| `gmail_get_draft` | Read a specific draft |
-| `gmail_send_draft` | Send an existing draft |
-| `gmail_list_labels` | List all labels (system + custom) |
-| `gmail_create_label` | Create a custom label |
-| `gmail_delete_label` | Delete a label |
-| `gmail_get_profile` | Get account email, message count, history ID |
-| `gmail_list_history` | Get mailbox changes since a history ID |
-| `gmail_get_vacation` | Read vacation responder settings |
-| `gmail_set_vacation` | Enable/disable vacation responder |
-
-### Google Drive (35 tools)
-
-| Tool | Description |
-|------|-------------|
-| `drive_search` | Search files with Drive query syntax (shared drives included) |
-| `drive_read` | Read file content (exports Workspace docs as text) |
-| `drive_list` | List files in a folder or root |
-| `drive_upload` | Upload a local file to Drive (optional `convertTo` imports it as a native Google Doc/Sheet/Slides) |
-| `drive_download` | Download a binary file to local disk |
-| `drive_export` | Export Google Docs/Sheets/Slides to PDF, DOCX, XLSX, Markdown, etc. |
-| `drive_create_folder` | Create a new folder |
-| `drive_update` | Rename, move, or replace file content |
-| `drive_delete` | Permanently delete a file (irreversible) |
-| `drive_trash` | Move a file to trash (recoverable) |
-| `drive_untrash` | Restore a trashed file |
-| `drive_empty_trash` | Permanently delete every file in trash |
-| `drive_copy` | Duplicate a file |
-| `drive_move` | Move a file between folders |
-| `drive_share` | Share with user/group/domain/anyone (with `transferOwnership` + `expirationTime`) |
-| `drive_list_permissions` | List who has access to a file |
-| `drive_permission_update` | Change a permission's role / expiration in place |
-| `drive_remove_permission` | Revoke access |
-| `drive_comment_create` / `_list` / `_get` / `_update` / `_delete` | Full comment CRUD with anchor support |
-| `drive_reply_create` / `_list` / `_update` / `_delete` | Reply CRUD; reply.create accepts `action: resolve | reopen` |
-| `drive_revision_list` / `_update` / `_delete` | Version history; `keepForever` pins against the 200-version cap |
-| `drive_access_proposal_list` / `_resolve` | Triage "Request access" submissions |
-| `drive_shared_drives_list` / `drive_shared_drive_get` | Shared drive discovery |
-| `drive_get_about` | Storage quota and account info |
-
-### Google Calendar (11 tools)
-
-| Tool | Description |
-|------|-------------|
-| `calendar_list_calendars` | List all calendars |
-| `calendar_list_events` | List/search events with time range |
-| `calendar_get_event` | Get a single event by ID |
-| `calendar_create_event` | Create an event |
-| `calendar_update_event` | Update an event |
-| `calendar_delete_event` | Delete an event |
-| `calendar_quick_add` | Create event from natural language (e.g. "Lunch Thursday 1pm") |
-| `calendar_move_event` | Move an event between calendars |
-| `calendar_list_instances` | List occurrences of a recurring event |
-| `calendar_get_freebusy` | Check free/busy times for calendars |
-| `calendar_create_calendar` | Create a new calendar |
-
-### Google Sheets (29 tools)
-
-| Tool | Description |
-|------|-------------|
-| `sheets_create` | Create a new spreadsheet |
-| `sheets_get` | Get spreadsheet metadata |
-| `sheets_read_range` / `sheets_batch_read` | Read values |
-| `sheets_write_range` / `sheets_batch_write` | Write values |
-| `sheets_append_rows` | Append after existing data |
-| `sheets_clear_range` / `sheets_batch_clear` | Clear values (preserves formatting) |
-| `sheets_add_sheet` / `sheets_delete_sheet` / `sheets_duplicate_sheet` | Tab management |
-| `sheets_update_sheet_properties` | Rename, freeze, color, hide, resize |
-| `sheets_format_cells` | Colors, fonts, alignment, number formats |
-| `sheets_update_borders` | Cell borders with style + color |
-| `sheets_merge_cells` / `sheets_unmerge_cells` | Cell merging |
-| `sheets_add_conditional_format_rule` | Boolean and gradient conditional formatting |
-| `sheets_sort_range` | Multi-column sort |
-| `sheets_set_basic_filter` / `sheets_clear_basic_filter` | Filter rows |
-| `sheets_find_replace` | Regex-capable, scope-aware find/replace |
-| `sheets_auto_resize_dimensions` | Fit rows/columns to content |
-| `sheets_set_data_validation` | Dropdowns, checkboxes, custom rules |
-| `sheets_add_named_range` / `sheets_delete_named_range` | Named ranges |
-| `sheets_insert_dimension` / `sheets_delete_dimension` | Insert/delete rows or columns |
-| `sheets_batch_update` | Generic batchUpdate escape hatch (any Request type) |
-
-### Google Docs (27 tools)
-
-| Tool | Description |
-|------|-------------|
-| `docs_create` | Create a new document |
-| `docs_get` | Metadata + optional tab content / suggestionsViewMode |
-| `docs_read` | Read document content as plain text |
-| `docs_insert_text` | Insert text at position or end |
-| `docs_replace_text` | Find and replace |
-| `docs_delete_range` | Delete a character range |
-| `docs_update_style` | Inline text formatting (bold, italic, font, size) |
-| `docs_update_paragraph_style` | Alignment, heading, indents, spacing |
-| `docs_update_document_style` | Page size, margins, header/footer behavior |
-| `docs_insert_table` | Insert a table |
-| `docs_modify_table` | insertRow / insertColumn / deleteRow / deleteColumn / mergeCells / unmergeCells |
-| `docs_create_named_range` / `docs_delete_named_range` / `docs_replace_named_range_content` | Mail-merge primitive |
-| `docs_create_paragraph_bullets` / `docs_delete_paragraph_bullets` | Bulleted/numbered lists |
-| `docs_insert_inline_image` | PNG/JPEG/GIF image insertion |
-| `docs_insert_page_break` / `docs_insert_section_break` | Layout breaks |
-| `docs_create_header` / `docs_delete_header` / `docs_create_footer` / `docs_delete_footer` | Branded headers and footers |
-| `docs_add_tab` / `docs_delete_tab` / `docs_update_tab_properties` | Tabs CRUD |
-| `docs_batch_update` | Generic batchUpdate escape hatch (any Request type) |
-
-### Google Contacts (9 tools)
-
-| Tool | Description |
-|------|-------------|
-| `contacts_search` | Search contacts |
-| `contacts_get` | Get one contact |
-| `contacts_list` | List contacts (paginated) |
-| `contacts_create` | Create a contact |
-| `contacts_update` | Update a contact |
-| `contacts_delete` | Delete a contact |
-| `contacts_groups_list` | List groups |
-| `contacts_group_members` | List members of a group |
-| `contacts_group_create` | Create a group |
-
-### Google Search Console (10 tools)
-
-| Tool | Description |
-|------|-------------|
-| `searchconsole_sites_list` | List Search Console properties |
-| `searchconsole_sites_get` | Get a property |
-| `searchconsole_sites_add` | Add a property |
-| `searchconsole_sites_delete` | Remove a property |
-| `searchconsole_sitemaps_list` | List sitemaps |
-| `searchconsole_sitemaps_get` | Sitemap status |
-| `searchconsole_sitemaps_submit` | Submit a sitemap |
-| `searchconsole_sitemaps_delete` | Delete a sitemap |
-| `searchconsole_searchanalytics_query` | Query search analytics |
-| `searchconsole_url_inspect` | Inspect a URL |
-
-### Google Tasks (12 tools) — _new in v4_
-
-| Tool | Description |
-|------|-------------|
-| `tasks_lists_list` / `tasks_list_get` / `tasks_list_insert` / `tasks_list_update` / `tasks_list_delete` | Tasklist management |
-| `tasks_list` | List tasks (filter by completion, due, updated time) |
-| `tasks_get` / `tasks_insert` / `tasks_update` / `tasks_delete` | Task CRUD |
-| `tasks_move` | Re-parent / re-position / move to another list |
-| `tasks_clear` | Delete every completed task |
-
-### Google Meet (5 tools) — _new in v4_
-
-| Tool | Description |
-|------|-------------|
-| `meet_conference_records_list` | List past Meet sessions |
-| `meet_conference_record_get` | Get one record |
-| `meet_recordings_list` | Recordings on a record |
-| `meet_transcripts_list` | Transcripts on a record |
-| `meet_transcript_entries_list` | Per-speaker transcript text |
-
-### Google Forms (4 tools, optional bundle) — _new in v4_
-
-Enable with `GOOGLE_OPTIONAL_SCOPES=forms` in `.env`.
-
-| Tool | Description |
-|------|-------------|
-| `forms_get` | Form definition |
-| `forms_responses_list` | List responses with filter |
-| `forms_response_get` | Single response |
-| `forms_watches_list` | List Pub/Sub watches |
-
-### Google Chat (4 tools, optional bundle) — _new in v4_
-
-Enable with `GOOGLE_OPTIONAL_SCOPES=chat` in `.env` (combine: `GOOGLE_OPTIONAL_SCOPES=forms,chat`).
-
-| Tool | Description |
-|------|-------------|
-| `chat_spaces_list` | Spaces the user is in |
-| `chat_spaces_get` | One space |
-| `chat_messages_create` | Send text or Card v2 |
-| `chat_messages_list` | List messages with filter / orderBy |
-
-### Google Workspace Admin (6 tools, admin bundle) — _new in v4_
-
-Enable per-account with `GOOGLE_ADMIN_ACCOUNTS=alias1,alias2` in `.env`. Requires the account to be a Workspace super-admin. Personal `@gmail.com` accounts will 403 — never list them here. Destructive writes additionally require `GOOGLE_ALLOW_ADMIN_WRITES=true`.
-
-| Tool | Description |
-|------|-------------|
-| `reports_activities_list` | Workspace audit log (login, drive, gmail, admin, token, etc.) |
-| `admin_users_list` / `admin_users_get` | User directory reads |
-| `admin_users_update` | User edits (gated, see env flag above) |
-| `admin_groups_list` / `admin_group_members_list` | Group + member reads |
-
-Every tool accepts an `account` parameter matching one of your configured aliases.
-
-### Google Alert Center (2 tools, optional bundle) — _new in v4_
-
-Enable with `GOOGLE_OPTIONAL_SCOPES=alertcenter` in `.env`.
-
-| Tool | Description |
-|------|-------------|
-| `alertcenter_alerts_list` / `alertcenter_alert_get` | Security alerts (suspicious login, phishing, leaked password, Drive exfil) |
-
-> **⚠ Requires service-account domain-wide delegation.** Unlike every other bundle, the Alert Center `apps.alerts` scope **cannot** be granted through this server's interactive user-consent OAuth flow — Google rejects it with `Error 400: invalid_scope` / "Some requested scopes cannot be shown". Per [Google's docs](https://developers.google.com/workspace/admin/alertcenter/guides/auth), Alert Center requires a service account with domain-wide delegation. This server is user-OAuth only, so enabling this bundle declares the scope and registers the tools, but the API will reject the resulting tokens until service-account auth is added (see [#4](https://github.com/bakissation/mcp-google-multi/issues/4)). The bundle is kept separate precisely so this limitation never blocks the working admin tools above.
-
-## Prerequisites
-
-- Node.js 18+
-- A Google Cloud project with the relevant APIs enabled (see step 1 below)
-- An OAuth 2.0 Client ID (Desktop app type)
-
-## Setup
-
-### 1. Google Cloud Credentials
-
-1. Go to [Google Cloud Console](https://console.cloud.google.com).
-2. Create or select a project.
-3. Enable the APIs you intend to use:
-   - **Always required:** [Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com), [Google Drive API](https://console.cloud.google.com/apis/library/drive.googleapis.com), [Google Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com), [Google Sheets API](https://console.cloud.google.com/apis/library/sheets.googleapis.com), [Google Docs API](https://console.cloud.google.com/apis/library/docs.googleapis.com), [People API](https://console.cloud.google.com/apis/library/people.googleapis.com), [Search Console API](https://console.cloud.google.com/apis/library/searchconsole.googleapis.com), [Google Tasks API](https://console.cloud.google.com/apis/library/tasks.googleapis.com), [Google Meet API](https://console.cloud.google.com/apis/library/meet.googleapis.com).
-   - **Optional bundles (only if you enable them):** [Google Forms API](https://console.cloud.google.com/apis/library/forms.googleapis.com), [Google Chat API](https://console.cloud.google.com/apis/library/chat.googleapis.com), [Alert Center API](https://console.cloud.google.com/apis/library/alertcenter.googleapis.com) (the `alertcenter` bundle also needs service-account domain-wide delegation — see the Alert Center section above).
-   - **Admin bundle (only if you set `GOOGLE_ADMIN_ACCOUNTS`):** [Admin SDK API](https://console.cloud.google.com/apis/library/admin.googleapis.com).
-4. Go to **APIs & Services → Credentials → Create Credentials → OAuth 2.0 Client ID**.
-5. Application type: **Desktop app**.
-6. Add authorized redirect URI: `http://localhost:4242/oauth2callback`.
-7. Copy the **Client ID** and **Client Secret**.
-
-### 2. Install & Configure
-
-**Option A — from npm (no clone):**
+You need **Node 20+**, a Google Cloud OAuth client (~2 min — [setup below](#google-cloud-setup)), and a random 32-byte key.
 
 ```bash
-npm install -g mcp-google-multi    # installs the `mcp-google-multi` CLI
-# …or run on demand without installing: npx mcp-google-multi
+# 1) install
+npm i -g mcp-google-multi
+
+# 2) put your config + creds in the environment (see "Configuration").
+#    Easiest for a quick try — export them, or drop a .env in your working dir:
+#    GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_ACCOUNTS, MASTER_KEY, GOOGLE_PROFILE
+
+# 3) authenticate each account (opens a browser; one-time per account)
+mcp-google-multi auth --account work
+mcp-google-multi auth --account personal
+
+# 4) register with Claude Code
+claude mcp add google-multi -s user -- npx -y mcp-google-multi
 ```
 
-Published with channel dist-tags — `@latest` (stable), `@dev` (alpha), `@staging` (beta); e.g. `npm i -g mcp-google-multi@dev` for the latest alpha.
+Restart your MCP client and the tools appear. Tokens are written **encrypted** to `~/.config/mcp-google-multi/tokens/` (override with `TOKEN_STORE_PATH`) — useless to anyone without your `MASTER_KEY`.
 
-**Option B — from source:**
+Generate a key: `openssl rand -base64 32`.
+
+## Recommended: keep secrets in a vault (Infisical)
+
+A plaintext `.env` is fine to try it out, but for a daily driver, **don't leave `GOOGLE_CLIENT_SECRET` + `MASTER_KEY` on disk** — inject them at launch from a secrets manager. The server just reads `process.env` (it has no idea where the values come from), so wrap it with [Infisical](https://infisical.com):
 
 ```bash
-git clone https://github.com/bakissation/mcp-google-multi.git
-cd mcp-google-multi
-npm install && npm run build
-cp .env.example .env
+#!/usr/bin/env bash
+# ~/.local/bin/mcp-google-multi-run  — chmod +x, then register this as the MCP command
+set -euo pipefail
+export INFISICAL_TOKEN="$(infisical login --method=universal-auth \
+  --client-id "$YOUR_CLIENT_ID" --client-secret "$YOUR_CLIENT_SECRET" --plain --silent)"
+exec infisical run --projectId <project> --env prod --path /mcp-google-multi \
+  -- npx -y mcp-google-multi
 ```
-
-Create a `.env` (from source, `.env.example` is the template; from npm, make one in the directory you'll run the server from) with:
-
-```env
-GOOGLE_CLIENT_ID=your_client_id_here
-GOOGLE_CLIENT_SECRET=your_client_secret_here
-
-# Define your accounts as alias:email pairs (comma-separated)
-GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
-
-# Optional (v4): enable Forms, Chat, and/or Alert Center tool bundles
-# (alertcenter additionally requires service-account domain-wide delegation)
-# GOOGLE_OPTIONAL_SCOPES=forms,chat
-
-# Optional (v4): grant Workspace admin scopes to specific accounts
-# GOOGLE_ADMIN_ACCOUNTS=work
-
-# Optional (v4): unlock destructive admin writes (admin_users_update)
-# GOOGLE_ALLOW_ADMIN_WRITES=true
-```
-
-### 3. Build
 
 ```bash
-npm run build
+claude mcp add google-multi -s user -- ~/.local/bin/mcp-google-multi-run
 ```
 
-### 4. Authenticate Accounts
+Now the only thing on disk is the **encrypted** token store. Pass the token via the `INFISICAL_TOKEN` env var (as above), **not** a `--token` flag, so it never shows up in `ps`. (Any secrets manager works — Doppler, Vault, 1Password CLI, etc. — the pattern is the same.)
 
-```bash
-npm run auth -- work       # opens browser → log in with you@company.com
-npm run auth -- personal   # opens browser → log in with you@gmail.com
-```
+## Configuration
 
-Each saves a token to `tokens/<alias>/token.json`. Tokens auto-refresh — you should only need to do this once per account.
+| Env var | Required | Description |
+|---|---|---|
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | ✓ | OAuth **Desktop** client from Google Cloud |
+| `GOOGLE_ACCOUNTS` | ✓ | `alias:email,…` — e.g. `work:you@co.com,personal:you@gmail.com` |
+| `MASTER_KEY` | ✓ | base64 32-byte key that encrypts the token store (`openssl rand -base64 32`) |
+| `GOOGLE_PROFILE` | — | write policy: `read-only` (default) · `safe-writes` · `full-writes` |
+| `GOOGLE_READ_ONLY` | — | `true` = hard kill-switch for all writes |
+| `GOOGLE_WRITE_ALLOW` / `GOOGLE_WRITE_DENY` | — | glob overrides, e.g. `calendar:*`, `*:delete*` |
+| `GOOGLE_OPTIONAL_SCOPES` | — | extra bundles: `forms`, `chat` |
+| `GOOGLE_ADMIN_ACCOUNTS` | — | aliases granted Workspace-admin scopes (the account's own super-admin OAuth) |
+| `TOKEN_STORE_PATH` | — | override the encrypted token dir (default: `~/.config/mcp-google-multi/tokens`) |
 
-### 5. Register in Claude Code
+Inspect the resolved setup any time: `mcp-google-multi config check`.
 
-```bash
-claude mcp add google-multi -s user -- node /absolute/path/to/mcp-google-multi/dist/index.js
-```
+## Write-control (deny-by-default)
 
-Or add it manually to your Claude Code MCP config:
+Reads are never gated. **Every create/update/delete is off until you opt in** — pick a profile:
 
-```json
-{
-  "mcpServers": {
-    "google-multi": {
-      "command": "node",
-      "args": ["/absolute/path/to/mcp-google-multi/dist/index.js"]
-    }
-  }
-}
-```
+| `GOOGLE_PROFILE` | Allows |
+|---|---|
+| `read-only` (default) | reads only |
+| `safe-writes` | create + update (deletes still blocked) |
+| `full-writes` | everything |
 
-If you installed from npm, point at the package instead and pass config via `env` (authenticate first with `mcp-google-multi auth --account <alias>`):
+`GOOGLE_READ_ONLY=true` overrides all. For fine control: `GOOGLE_WRITE_ALLOW="calendar:*, sheets:update*"` and `GOOGLE_WRITE_DENY="*:delete*"` (deny wins). `mcp-google-multi config check` prints the resolved policy and exactly which tools are enabled.
 
-```json
-{
-  "mcpServers": {
-    "google-multi": {
-      "command": "npx",
-      "args": ["-y", "mcp-google-multi"],
-      "env": {
-        "GOOGLE_CLIENT_ID": "your_client_id_here",
-        "GOOGLE_CLIENT_SECRET": "your_client_secret_here",
-        "GOOGLE_ACCOUNTS": "work:you@company.com,personal:you@gmail.com"
-      }
-    }
-  }
-}
-```
+## What's covered
 
-## Migrating from v3
+~170 tools across Gmail, Drive, Calendar, Sheets, Docs, Contacts, Search Console, Tasks, Meet, and (optional) Forms, Chat, Workspace Admin. **Full per-tool list → [COVERAGE.md](./COVERAGE.md).** Every tool takes an `account` argument matching one of your aliases.
 
-v4.0.0 grows the base OAuth scope set (Tasks and Meet are now included by default). Existing v3 tokens lack those scopes and the corresponding tools will 403.
+## Google Cloud setup
 
-1. `git pull && npm install && npm run build`.
-2. Re-authenticate every account: `npm run auth -- <alias>` for each alias.
-3. If you want Forms or Chat tools: set `GOOGLE_OPTIONAL_SCOPES=forms,chat` in `.env` **before** re-authing.
-4. If you're a Workspace admin: list relevant accounts in `GOOGLE_ADMIN_ACCOUNTS` **before** re-authing those accounts. Set `GOOGLE_ALLOW_ADMIN_WRITES=true` only if you need destructive admin operations.
-5. In Google Cloud Console, enable any new APIs you'll use (Tasks, Meet, Forms, Chat, Admin SDK, Alert Center).
+1. [Google Cloud Console](https://console.cloud.google.com) → create or select a project.
+2. Enable the APIs you'll use: Gmail, Drive, Calendar, Sheets, Docs, People, Search Console, Tasks, Meet (+ Forms / Chat / Admin SDK if you enable those bundles).
+3. **APIs & Services → Credentials → Create Credentials → OAuth client ID → Desktop app**.
+4. Add the redirect URI `http://localhost:4242/oauth2callback`.
+5. Copy the **Client ID** + **Client Secret** into your environment.
 
-## Adding / Removing Accounts
+## Upgrading from v4
 
-Edit the `GOOGLE_ACCOUNTS` variable in `.env`, rebuild, and authenticate the new account:
+v5 is a breaking change, but the migration is a one-time, ~2-minute step:
 
-```bash
-# Add a new account
-# .env: GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com,freelance:you@freelance.com
+1. Update: `npm i -g mcp-google-multi@latest` (or update your client config).
+2. Add **`MASTER_KEY`** to your environment (`openssl rand -base64 32`) — now required.
+3. Encrypt existing tokens: `mcp-google-multi migrate-tokens` (reads your old `tokens/<alias>/token.json` and encrypts them) — or just re-auth each account.
+4. Writes are now **deny-by-default** — set `GOOGLE_PROFILE=safe-writes` (or `full-writes`) to keep writing. (`GOOGLE_ALLOW_ADMIN_WRITES` is gone — replaced by write-control profiles.)
 
-npm run build
-npm run auth -- freelance
-```
+## Security
 
-No code changes required.
+Your OAuth, your machine. Refresh tokens are **AES-256-GCM encrypted at rest** (decryptable only with your `MASTER_KEY`), writes are deny-by-default, and the server has **no telemetry** — it connects only to Google's APIs. Found a vulnerability? Report it privately — see [SECURITY.md](./SECURITY.md), never a public issue.
 
-## OAuth Scopes
+## Roadmap
 
-### Base (always granted)
-
-| Scope | Access |
-|-------|--------|
-| `gmail.modify` | Read, label, trash, delete emails |
-| `gmail.send` | Send emails |
-| `drive` | Full Drive access (read, upload, share, comments, etc.) |
-| `calendar` | Full calendar access |
-| `spreadsheets` | Read/write Google Sheets |
-| `documents` | Read/write Google Docs |
-| `contacts` | Read/write Google Contacts |
-| `webmasters` | Google Search Console |
-| `tasks` | Read/write Google Tasks |
-| `meetings.space.readonly` | Read past Meet conference records and transcripts |
-
-### Optional (per-`GOOGLE_OPTIONAL_SCOPES` env var)
-
-| Bundle key | Scopes |
-|------------|--------|
-| `forms` | `forms.body`, `forms.responses.readonly` |
-| `chat` | `chat.spaces`, `chat.messages`, `chat.messages.create` |
-| `alertcenter` | `apps.alerts` — ⚠ requires service-account domain-wide delegation; not grantable via user OAuth (see Alert Center section) |
-
-### Admin (per-`GOOGLE_ADMIN_ACCOUNTS` env var)
-
-Only granted to accounts explicitly listed. Personal Gmail accounts will 403 on these scopes — never list them.
-
-| Scope | Access |
-|-------|--------|
-| `admin.reports.audit.readonly` | Workspace audit log |
-| `admin.directory.user` | Read/write Workspace users (writes also gated by `GOOGLE_ALLOW_ADMIN_WRITES`) |
-| `admin.directory.group.readonly` | Read groups |
-| `admin.directory.group.member.readonly` | Read group members |
-
-## Project Structure
-
-```
-mcp-google-multi/
-├── src/
-│   ├── index.ts          # Entry point: MCP server or auth CLI
-│   ├── accounts.ts       # Account config parser (reads from .env)
-│   ├── auth.ts           # Scope tier resolution + OAuth flow
-│   ├── client.ts         # OAuth2Client factory with auto-refresh
-│   ├── types.ts          # Shared TypeScript types
-│   └── tools/
-│       ├── _errors.ts          # Shared googleapis error → MCP response mapper
-│       ├── gmail.ts            # Gmail (21)
-│       ├── drive.ts            # Drive (35)
-│       ├── calendar.ts         # Calendar (11)
-│       ├── sheets.ts           # Sheets (29)
-│       ├── docs.ts             # Docs (27)
-│       ├── contacts.ts         # Contacts (9)
-│       ├── searchconsole.ts    # Search Console (10)
-│       ├── tasks.ts            # Tasks (12) — v4
-│       ├── meet.ts             # Meet (5) — v4
-│       ├── forms.ts            # Forms (4, optional) — v4
-│       ├── chat.ts             # Chat (4, optional) — v4
-│       └── admin.ts            # Admin SDK (6, admin) + Alert Center (2, alertcenter bundle) — v4
-├── tests/                # vitest unit tests (gmail-mime, path-safety, field-mask helpers)
-├── tokens/               # OAuth tokens per account (gitignored)
-├── dist/                 # Compiled output (gitignored)
-├── .env                  # Your credentials (gitignored)
-├── .env.example          # Template for .env
-├── CHANGELOG.md
-├── CLAUDE.md             # Conventions for AI assistants working on this codebase
-├── package.json
-├── tsconfig.json
-└── LICENSE
-```
-
-## Troubleshooting
-
-**"GOOGLE_ACCOUNTS is not set"** — Make sure your `.env` file exists in the project root and has the `GOOGLE_ACCOUNTS` variable set.
-
-**"No token file found for account X"** — Run `npm run auth -- <alias>` to authenticate that account.
-
-**"Port 4242 is already in use"** — Another process is using port 4242. Close it and retry the auth flow.
-
-**Token refresh errors** — Delete the token file at `tokens/<alias>/token.json` and re-authenticate.
-
-**Tasks / Meet tools return 403 after upgrading from v3** — You haven't re-authed since the base scope set grew. Run `npm run auth -- <alias>` for every account.
-
-**`forms_*` or `chat_*` tools missing from the tool list** — They're only registered when `GOOGLE_OPTIONAL_SCOPES` includes their bundle key. Set `GOOGLE_OPTIONAL_SCOPES=forms,chat` (or one of them) in `.env`, rebuild, and re-auth the accounts that need them.
-
-**Admin tools missing or returning 403** — Admin tools only register if `GOOGLE_ADMIN_ACCOUNTS` is set. The listed accounts must be Workspace super-admins, and you must re-auth them after adding the env var so the new scopes are granted. `admin_users_update` additionally requires `GOOGLE_ALLOW_ADMIN_WRITES=true`.
+Maintainer-led. Direction is tracked publicly as **[GitHub Milestones](https://github.com/bakissation/mcp-google-multi/milestones)** (discover-first tooling → exhaustive API coverage → service accounts + hosting in v6). Not accepting unsolicited feature PRs; bug reports are welcome.
 
 ## Contributing
 
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) first. In short: **open pull requests against the `dev` branch** — changes are promoted `dev → staging → main`, and `main` is release-only. Run `typecheck`/`lint`/`test`/`build` before submitting, and use Conventional Commits.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md). Security issues go to [SECURITY.md](./SECURITY.md), never a public issue.
 
-By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). For security issues, **do not open a public issue** — see [SECURITY.md](SECURITY.md).
+## Credits
 
-## Author
+Built and maintained by **Abdelbaki Berkati** — [berkati.xyz](https://berkati.xyz) · [@bakissation](https://github.com/bakissation). [Read the case study →](https://berkati.xyz/case-studies/mcp-google-multi/)
 
-**Abdelbaki Berkati** — [berkati.xyz](https://berkati.xyz) · [@bakissation](https://github.com/bakissation)
-
-[Read the case study →](https://berkati.xyz/case-studies/mcp-google-multi/)
+Sponsored by **[IdeaCrafters](https://ideacrafters.com)** ([@IdeaCraftersHQ](https://github.com/IdeaCraftersHQ)).
 
 ## License
 
-[MIT](LICENSE)
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A **local** [MCP](https://modelcontextprotocol.io) server that gives Claude Code
 
 [![npm](https://img.shields.io/npm/v/mcp-google-multi?label=npm&color=cb3837)](https://www.npmjs.com/package/mcp-google-multi)
 
+> Open-source and **funded by [IdeaCrafters](https://github.com/IdeaCraftersHQ)** — the studio that pays for its development and upkeep.
+
 - 🔑 **Multi-account** — drive any number of your Google accounts from one server, each by a short alias.
 - 🔒 **Secure by default** — refresh tokens **encrypted at rest** (AES-256-GCM); **writes are deny-by-default**; no telemetry — it talks only to Google.
 - 📦 **npm-first** — install and run with `npx`; everything configured through env vars.
@@ -120,7 +122,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CON
 
 Built and maintained by **Abdelbaki Berkati** — [berkati.xyz](https://berkati.xyz) · [@bakissation](https://github.com/bakissation). [Read the case study →](https://berkati.xyz/case-studies/mcp-google-multi/)
 
-Sponsored by **[IdeaCrafters](https://ideacrafters.com)** ([@IdeaCraftersHQ](https://github.com/IdeaCraftersHQ)).
+Development is **funded by [IdeaCrafters](https://ideacrafters.com)** ([@IdeaCraftersHQ](https://github.com/IdeaCraftersHQ)) — the studio that pays for this OSS to exist.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ You'll get an acknowledgement and can track the fix in the private advisory. Onc
 
 This server brokers OAuth access to Google accounts — Gmail, Drive, Calendar, and (when enabled) Workspace **Admin SDK** scopes. A vulnerability could expose mail, files, or directory data. Of particular interest:
 
-- **Token handling** — tokens live under `tokens/<alias>/token.json` (mode `0600`) and must never be logged or transmitted.
+- **Token handling** — refresh tokens are **AES-256-GCM encrypted at rest** (`~/.config/mcp-google-multi/tokens/<alias>.enc`, mode `0600`) with a key derived from `MASTER_KEY`; tokens must never be logged or transmitted, and `MASTER_KEY` must never be committed or logged. Error payloads carry only `message` + code — never raw error objects (which can hold the `Authorization` header).
 - **Header / MIME construction** — Gmail tools build raw RFC 5322 messages; injection (e.g. CRLF in headers) is in scope.
 - **Scope escalation** — anything that grants an account scopes it didn't consent to.
 
@@ -31,4 +31,4 @@ This server brokers OAuth access to Google accounts — Gmail, Drive, Calendar, 
 
 ## Good hygiene for everyone
 
-Never paste OAuth tokens, client secrets, authorization codes, or `.env` contents into issues, PRs, or logs.
+Never paste OAuth tokens, client secrets, `MASTER_KEY`, authorization codes, or `.env` contents into issues, PRs, or logs.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-google-multi",
   "version": "0.0.0-semantically-released",
-  "description": "MCP server for Gmail, Google Drive, Calendar, Sheets, Docs, and Contacts with multi-account support",
+  "description": "Local MCP server for Google Workspace (Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console, +Forms/Chat/Admin) across multiple accounts — OAuth-only, encrypted token storage, deny-by-default writes.",
   "type": "module",
   "license": "MIT",
   "bin": {
@@ -36,6 +36,12 @@
     "google-sheets",
     "google-docs",
     "google-contacts",
+    "google-workspace",
+    "google-tasks",
+    "google-meet",
+    "search-console",
+    "oauth",
+    "mcp-server",
     "claude",
     "claude-code"
   ],

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,13 +1,21 @@
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { homedir } from 'node:os';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+dotenv.config();
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+const defaultTokenDir = path.join(
+  process.env.XDG_CONFIG_HOME || path.join(homedir(), '.config'),
+  'mcp-google-multi',
+  'tokens',
+);
 const tokenDir = process.env.TOKEN_STORE_PATH
   ? path.resolve(process.env.TOKEN_STORE_PATH)
-  : path.resolve(__dirname, '..', 'tokens');
+  : defaultTokenDir;
 
 export interface AccountConfig {
   email: string;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -39,13 +39,6 @@ export const OPTIONAL_SCOPE_BUNDLES: Record<string, string[]> = {
     'https://www.googleapis.com/auth/chat.messages',
     'https://www.googleapis.com/auth/chat.messages.create',
   ],
-  // Alert Center's apps.alerts scope is NOT grantable through the interactive
-  // user-consent flow this server uses — it requires a service account with
-  // domain-wide delegation. It lives in its own opt-in bundle so it never
-  // blocks the working Admin SDK admin scopes. See README "Alert Center".
-  alertcenter: [
-    'https://www.googleapis.com/auth/apps.alerts',
-  ],
 };
 
 export const ADMIN_SCOPES = [
@@ -91,10 +84,6 @@ export function resolveScopesForAccount(alias: string): string[] {
   return Array.from(new Set(scopes));
 }
 
-/** True if admin writes are explicitly enabled. Default refuses to prevent accidents on small orgs. */
-export function adminWritesEnabled(): boolean {
-  return process.env.GOOGLE_ALLOW_ADMIN_WRITES === 'true';
-}
 
 export async function runAuthFlow(args: string[]): Promise<void> {
   const accountIdx = args.indexOf('--account');

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { registerTasksTools } from './tools/tasks.js';
 import { registerMeetTools } from './tools/meet.js';
 import { registerFormsTools } from './tools/forms.js';
 import { registerChatTools } from './tools/chat.js';
-import { registerAdminTools, registerAlertCenterTools } from './tools/admin.js';
+import { registerAdminTools } from './tools/admin.js';
 import { getOptionalBundles, getAdminAccounts } from './auth.js';
 import { ToolRegistry } from './registry.js';
 import { resolvePolicy, isAllowed, describePolicy, type Policy } from './write-control.js';
@@ -39,7 +39,6 @@ function buildRegistry(server: McpServer, policy: Policy): ToolRegistry {
   const optional = new Set(getOptionalBundles());
   if (optional.has('forms')) registerFormsTools(registry);
   if (optional.has('chat')) registerChatTools(registry);
-  if (optional.has('alertcenter')) registerAlertCenterTools(registry);
   if (getAdminAccounts().length > 0) registerAdminTools(registry);
   return registry;
 }

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -6,7 +6,6 @@ import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
-import { adminWritesEnabled } from '../auth.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
@@ -14,8 +13,7 @@ const accountEnum = z.enum(ACCOUNTS);
  * Admin SDK tools require Workspace super-admin (or delegated admin) privileges on the target account.
  * Personal `@gmail.com` accounts will 403 on every endpoint.
  *
- * Writes are gated behind GOOGLE_ALLOW_ADMIN_WRITES=true to prevent accidents on small orgs
- * (a stray users.update on a 3-person Workspace is a bad day).
+ * Writes (e.g. admin_users_update) are gated by write-control like any CUD tool.
  */
 export function registerAdminTools(server: ToolRegistry): void {
   // ─── Reports / audit log ───────────────────────────────────────────────
@@ -145,7 +143,7 @@ export function registerAdminTools(server: ToolRegistry): void {
   server.registerTool(
     'admin_users_update',
     {
-      description: 'Update a Workspace user (PATCH semantics). GATED: requires GOOGLE_ALLOW_ADMIN_WRITES=true to prevent accidental destructive ops on small orgs.',
+      description: 'Update a Workspace user (PATCH semantics). Gated by write-control (a CUD tool).',
       inputSchema: {
         account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
         userKey: z.string().describe('User email or ID'),
@@ -159,18 +157,6 @@ export function registerAdminTools(server: ToolRegistry): void {
     },
     async ({ account, userKey, givenName, familyName, suspended, password, changePasswordAtNextLogin, orgUnitPath }) => {
       try {
-        if (!adminWritesEnabled()) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: JSON.stringify({
-                error: 'admin_writes_disabled',
-                hint: 'Admin write operations are disabled by default. Set GOOGLE_ALLOW_ADMIN_WRITES=true in .env and restart to enable.',
-              }),
-            }],
-            isError: true,
-          };
-        }
         const auth = await getClient(account as Account);
         const directory = google.admin({ version: 'directory_v1', auth });
         const requestBody: any = {};
@@ -269,76 +255,6 @@ export function registerAdminTools(server: ToolRegistry): void {
   );
 }
 
-/**
- * Alert Center tools. Gated behind the `alertcenter` optional bundle, NOT the
- * admin bundle: the apps.alerts scope cannot be granted via this server's
- * interactive user-consent OAuth flow — it requires a service account with
- * domain-wide delegation. Registered separately so a missing/ungrantable
- * apps.alerts scope never blocks the working Admin SDK admin tools.
- */
-export function registerAlertCenterTools(server: ToolRegistry): void {
-  server.registerTool(
-    'alertcenter_alerts_list',
-    {
-      description: 'List Workspace security alerts (suspicious login, phishing, leaked password, Drive exfil, etc.). Requires the alertcenter bundle + service-account domain-wide delegation.',
-      inputSchema: {
-        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
-        pageSize: z.number().min(1).max(1000).optional(),
-        pageToken: z.string().optional(),
-        filter: z.string().optional().describe('Filter expression, e.g. "type = \\"Suspicious login\\""'),
-        orderBy: z.string().optional(),
-        customerId: z.string().optional(),
-      },
-    },
-    async ({ account, pageSize, pageToken, filter, orderBy, customerId }) => {
-      try {
-        const auth = await getClient(account as Account);
-        const alertcenter = google.alertcenter({ version: 'v1beta1', auth });
-        const res = await alertcenter.alerts.list({
-          pageSize: pageSize ?? 50,
-          pageToken,
-          filter,
-          orderBy,
-          customerId,
-        });
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
-        };
-      } catch (error: any) {
-        return handleAlertCenterError(error, account as Account);
-      }
-    },
-  );
-
-  server.registerTool(
-    'alertcenter_alert_get',
-    {
-      description: 'Get a single alert by ID. Requires the alertcenter bundle + service-account domain-wide delegation.',
-      inputSchema: {
-        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
-        alertId: z.string().describe('Alert ID'),
-        customerId: z.string().optional(),
-      },
-    },
-    async ({ account, alertId, customerId }) => {
-      try {
-        const auth = await getClient(account as Account);
-        const alertcenter = google.alertcenter({ version: 'v1beta1', auth });
-        const res = await alertcenter.alerts.get({ alertId, customerId });
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
-        };
-      } catch (error: any) {
-        return handleAlertCenterError(error, account as Account);
-      }
-    },
-  );
-}
-
 function handleAdminError(error: any, account: Account) {
   return handleGoogleApiError(error, account, "Admin tools require Workspace super-admin privileges AND the account must be listed in GOOGLE_ADMIN_ACCOUNTS (then re-authenticated). Personal Gmail accounts cannot use these endpoints.");
-}
-
-function handleAlertCenterError(error: any, account: Account) {
-  return handleGoogleApiError(error, account, "Alert Center (apps.alerts) is not grantable via this server's user-consent OAuth flow — it requires a service account with domain-wide delegation. Enabling GOOGLE_OPTIONAL_SCOPES=alertcenter only declares the scope; the API will reject user-OAuth tokens. See README \"Alert Center\".");
 }


### PR DESCRIPTION
Launch prep for the 5.0.0 stable cut.

- **README** rewritten beginner/npm-first: quickstart, **Infisical-recommended** secret injection (with the `infisical run` wrapper, token via env not args), config table, write-control, Upgrading-from-v4, security, roadmap. Keeps maintainer links + IdeaCrafters sponsor.
- **COVERAGE.md** — the full tool list moved out of the README, referenced from it. Alert Center marked deferred → v6.
- **package.json** — description + keywords refreshed.
- **Fix (audit):** default token dir → `~/.config/mcp-google-multi/tokens` (was resolving inside the package/npx cache — broke the npm flow); also load the working-dir `.env`.

`feat!:` + BREAKING CHANGE footer → semantic-release cuts **5.0.0** on promotion to main. 139 tests green; default-path fix verified.