### PR TITLE
Promote staging → main (5.0.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ GOOGLE_CLIENT_SECRET=your_client_secret_here
 # Example: work:you@company.com,personal:you@gmail.com
 GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
 
+# Encryption key for stored OAuth tokens (required). Generate with:
+#   openssl rand -base64 32
+MASTER_KEY=your_base64_32_byte_key_here
+
 # ─── Optional (v4.0.0) ──────────────────────────────────────────────────
 # Opt in to additional scope bundles. Each bundle enables a tool group and
 # its OAuth scopes. Re-auth all accounts after changing this.

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,14 @@ GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
 #   openssl rand -base64 32
 MASTER_KEY=your_base64_32_byte_key_here
 
+# ─── Write-control (CUD gating; reads are never gated) ──────────────────
+# Deny-by-default: all create/update/delete tools are OFF until you opt in.
+# GOOGLE_PROFILE=read-only        # read-only (default) | safe-writes (create+update) | full-writes
+# GOOGLE_READ_ONLY=true           # hard filter: disables ALL writes regardless of profile
+# GOOGLE_WRITE_ALLOW=calendar:*, sheets:update*   # globs (service:cud or service:op) that open holes
+# GOOGLE_WRITE_DENY=*:delete*     # globs; deny wins over allow + profile
+# Inspect the resolved policy: npx mcp-google-multi config check
+
 # ─── Optional (v4.0.0) ──────────────────────────────────────────────────
 # Opt in to additional scope bundles. Each bundle enables a tool group and
 # its OAuth scopes. Re-auth all accounts after changing this.

--- a/.env.example
+++ b/.env.example
@@ -1,38 +1,31 @@
 GOOGLE_CLIENT_ID=your_client_id_here
 GOOGLE_CLIENT_SECRET=your_client_secret_here
 
-# Comma-separated list of alias:email pairs
-# Example: work:you@company.com,personal:you@gmail.com
+# Comma-separated alias:email pairs — e.g. work:you@company.com,personal:you@gmail.com
 GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
 
-# Encryption key for stored OAuth tokens (required). Generate with:
+# Encryption key for the local token store (REQUIRED). Generate with:
 #   openssl rand -base64 32
 MASTER_KEY=your_base64_32_byte_key_here
 
 # ─── Write-control (CUD gating; reads are never gated) ──────────────────
-# Deny-by-default: all create/update/delete tools are OFF until you opt in.
-# GOOGLE_PROFILE=read-only        # read-only (default) | safe-writes (create+update) | full-writes
-# GOOGLE_READ_ONLY=true           # hard filter: disables ALL writes regardless of profile
-# GOOGLE_WRITE_ALLOW=calendar:*, sheets:update*   # globs (service:cud or service:op) that open holes
-# GOOGLE_WRITE_DENY=*:delete*     # globs; deny wins over allow + profile
-# Inspect the resolved policy: npx mcp-google-multi config check
+# Deny-by-default: every create/update/delete tool is OFF until you opt in.
+GOOGLE_PROFILE=read-only              # read-only (default) | safe-writes (create+update) | full-writes
+# GOOGLE_READ_ONLY=true               # hard kill-switch for ALL writes (overrides the profile)
+# GOOGLE_WRITE_ALLOW=calendar:*, sheets:update*   # glob holes (service:cud or service:op)
+# GOOGLE_WRITE_DENY=*:delete*         # globs; deny wins over allow + profile
+# Inspect the resolved policy:  mcp-google-multi config check
 
-# ─── Optional (v4.0.0) ──────────────────────────────────────────────────
-# Opt in to additional scope bundles. Each bundle enables a tool group and
-# its OAuth scopes. Re-auth all accounts after changing this.
-# Supported: forms, chat, alertcenter
-# NOTE: the `alertcenter` bundle (apps.alerts) is NOT grantable via this
-# server's user-consent OAuth flow — it needs a service account with
-# domain-wide delegation, which is not yet supported. Enabling it declares
-# the scope and registers the 2 alert tools, but the API rejects user tokens.
+# ─── Optional tool bundles ──────────────────────────────────────────────
+# Enable extra services + their OAuth scopes; re-auth accounts after changing.
 # GOOGLE_OPTIONAL_SCOPES=forms,chat
 
-# Comma-separated list of account aliases that should be granted Workspace
-# admin scopes (Reports + Directory). Accounts NOT listed here will never
-# request admin scopes — safe for personal Gmail. (Alert Center is no longer
-# part of this bundle; it is the separate `alertcenter` optional bundle above.)
+# ─── Workspace Admin (per-account) ──────────────────────────────────────
+# Aliases granted Admin SDK scopes (the account's own super-admin OAuth).
+# Personal @gmail accounts will 403 — never list them. Admin writes are gated
+# by write-control like any other CUD tool.
 # GOOGLE_ADMIN_ACCOUNTS=work
 
-# Required to unlock destructive admin write operations (admin_users_update).
-# Default refuses to prevent accidents on small orgs.
-# GOOGLE_ALLOW_ADMIN_WRITES=true
+# ─── Token store location (optional) ────────────────────────────────────
+# Default: ~/.config/mcp-google-multi/tokens
+# TOKEN_STORE_PATH=/custom/path/tokens

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,33 @@
+name: backmerge
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backmerge:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open + auto-merge main into staging and dev
+        env:
+          GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -uo pipefail
+          for target in staging dev; do
+            url=$(gh pr create --repo "$REPO" --base "$target" --head main \
+                  --title "chore: back-merge main into $target (resync after $TAG)" \
+                  --body "Automated post-release resync so the \`$target\` prerelease base tracks \`main\` ($TAG). No content change." || true)
+            if [ -n "${url:-}" ]; then
+              gh pr merge "$url" --repo "$REPO" --auto --merge
+              echo "queued auto-merge: $url"
+            else
+              echo "nothing to back-merge into $target"
+            fi
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,37 +1,37 @@
 # Working on mcp-google-multi
 
-Conventions for AI assistants modifying this codebase.
+Conventions for AI assistants modifying this codebase. v5 is **local, stdio, user-OAuth only**.
 
 ## Project shape
 
-- Each Google service lives in `src/tools/<service>.ts` and exports `register<Service>Tools(server: McpServer): void`.
-- `src/index.ts` is the entry point. It wires service registrations into the MCP server, conditional on env-driven scope bundles (Forms/Chat/Alert Center opt-in, Admin opt-in per-account).
-- `src/auth.ts` owns OAuth flow + scope tier resolution. `BASE_SCOPES` are always granted; `OPTIONAL_SCOPE_BUNDLES` are env-gated; `ADMIN_SCOPES` are per-account-gated. `resolveScopesForAccount(alias)` is the authoritative composer.
-- `src/client.ts` is a thin OAuth2Client factory used by every tool handler.
-- `src/accounts.ts` parses the `GOOGLE_ACCOUNTS` env var.
+- `src/index.ts` — entry. `buildRegistry()` registers every service into a `ToolRegistry`; `main()` runs the stdio MCP server, or the `auth` / `migrate-tokens` / `config check` CLI commands.
+- `src/registry.ts` — `ToolRegistry` wraps the MCP server: records `{name, service, cud}` per tool, derives `cud` (read/create/update/delete) from the tool name via `inferCud`, and **enforces write-control** by wrapping every CUD handler. Service files still call `server.registerTool(...)` — `server` is now a `ToolRegistry`.
+- `src/write-control.ts` — `resolvePolicy()` (env → policy) + `isAllowed()` (deny-by-default verdict) + `config check` rendering.
+- `src/token-store.ts` — encrypted token store (AES-256-GCM, key from `MASTER_KEY`); `readToken`/`writeToken` + the `migrate-tokens` source.
+- `src/auth.ts` — OAuth flow + scope tiers (`BASE_SCOPES` always, `OPTIONAL_SCOPE_BUNDLES` env-gated, `ADMIN_SCOPES` per-account).
+- `src/client.ts` — `getClient(account)`: cached OAuth2Client from the encrypted token; refreshes + re-encrypts.
+- `src/accounts.ts` — parses `GOOGLE_ACCOUNTS`; token dir defaults to `~/.config/mcp-google-multi/tokens` (override `TOKEN_STORE_PATH`).
+- `src/tools/_errors.ts` — `mapGoogleError` typed taxonomy + per-service `handle<Service>Error` shims.
+- `src/tools/_coerce.ts` — `coerceArray`/`coerceJson`/`coerceBoolean` for string-encoded client args.
 
-## Adding a new tool
-
-Every tool follows the same skeleton:
+## Adding a tool
 
 ```ts
 server.registerTool(
-  'service_action_name',                       // snake_case, prefixed by service
+  'service_action_name',                 // snake_case, service-prefixed; cud inferred from the verb
   {
-    description: '<one sentence; explain when to use this tool>',
+    description: '<one sentence; when to use it>',
     inputSchema: {
-      account: accountEnum.describe('Google account alias'),  // always first
-      // ...other params as a flat zod object
+      account: accountEnum.describe('Google account alias'),   // always first
+      // wrap array/object/bool params with coerceArray / coerceJson / coerceBoolean
     },
   },
-  async ({ account, /* destructure inputs */ }) => {
+  async ({ account, /* … */ }) => {
     try {
       const auth = await getClient(account as Account);
       const svc = google.<service>({ version: '<v>', auth });
-      const res = await svc.<resource>.<method>({ /* params */ });
-      return {
-        content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
-      };
+      const res = await svc.<resource>.<method>({ /* … */ });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }] };
     } catch (error: any) {
       return handle<Service>Error(error, account as Account);
     }
@@ -40,81 +40,53 @@ server.registerTool(
 ```
 
 **Hard rules:**
-- `inputSchema` is a flat object of `zod` schemas. Do not nest into another `z.object` at the top level.
-- `account: accountEnum` is the first field of every input schema.
-- Wrap the handler body in try/catch. Call the file's `handle<Service>Error` helper in the catch.
-- Return `{ content: [{ type: 'text' as const, text: JSON.stringify(...) }] }`. Stringify the response payload so MCP clients can re-parse it.
-- For errors, also set `isError: true`.
-- Every file has a 3-line `handle<Service>Error` shim at the bottom that delegates to `handleGoogleApiError` in `src/tools/_errors.ts` — the shared 401/403/429/fallback mapper. Pass an optional service-specific `forbiddenHint` string to the shared helper for services where 403 has a known fix (e.g. admin scopes, optional scope bundle not enabled).
+- Flat `zod` `inputSchema`; `account` first. Coerce array/object/bool inputs — clients send them string-encoded.
+- `cud` is inferred from the tool name (no manual flag). CUD tools are auto-gated by write-control; **never** add your own write gate. Fix a misclassified verb in `CUD_OVERRIDES` (`registry.ts`).
+- Wrap handlers in try/catch → `handle<Service>Error` (→ `mapGoogleError`); errors return `{error, message, hint?, retriable, account}` with `isError: true`. **Never embed the raw error / `error.config` / `error.response`** — token-leak.
+- Return `{ content: [{ type: 'text', text: JSON.stringify(...) }] }`.
 
-## Adding a new service
+## Adding a service
 
-1. Create `src/tools/<service>.ts` exporting `register<Service>Tools(server)`.
-2. Add scope(s) to `src/auth.ts`:
-   - Always-on → append to `BASE_SCOPES`.
-   - Optional bundle → add a new key to `OPTIONAL_SCOPE_BUNDLES`.
-   - Admin-only → append to `ADMIN_SCOPES`.
-3. Wire registration in `src/index.ts`. Always-on calls go in the unconditional block; optional bundles check `optional.has('<key>')` (where `optional` is built from `getOptionalBundles()`); admin tools register only if `getAdminAccounts().length > 0`.
-4. Update README scope table, tool table, and tool count in the Features bullet.
-5. Update CHANGELOG.md.
+1. `src/tools/<service>.ts` exporting `register<Service>Tools(server: ToolRegistry)`.
+2. Scopes in `auth.ts`: always-on → `BASE_SCOPES` (breaking — forces re-auth → `feat!:`); optional → `OPTIONAL_SCOPE_BUNDLES`; admin → `ADMIN_SCOPES`.
+3. Wire into `buildRegistry()` (`index.ts`).
+4. Update `COVERAGE.md` + `README.md`.
 
-## Drive-specific: shared drive support
+## Auth / tokens
 
-Every Drive API call that takes a `fileId` must pass `supportsAllDrives: true`. List operations also need `includeItemsFromAllDrives: true`. Forgetting these silently breaks shared-drive content. Existing tools already have them — preserve when refactoring.
+- Tokens are **encrypted at rest** — never write plaintext. `MASTER_KEY` is required; it lives only in env (never in the store, never logged).
+- Always go through `getClient(account)` (handles refresh + re-encrypt). Token files are `0600`.
 
-## Drive-specific: import conversion
+## Write-control
 
-To convert an upload into a native Workspace file, set the **resource** (`requestBody`) `mimeType` to a `application/vnd.google-apps.*` type while the `media` carries the importable source type. The media mimeType is the source; the resource mimeType is the target. `drive_upload`'s `convertTo` param does exactly this. Drive v3 has no separate `convert` flag (the v2 one is deprecated). `drive_export` is the reverse direction only.
+Reads are never gated. CUD is **deny-by-default**: `GOOGLE_PROFILE` (read-only / safe-writes / full-writes) + `GOOGLE_READ_ONLY` + `GOOGLE_WRITE_ALLOW`/`DENY` globs. Verdict + precedence in `write-control.ts`, tested in `tests/write-control.test.ts`.
 
-## Sheets/Docs: fields masks
+## Drive specifics
 
-`spreadsheets.batchUpdate` Request types like `RepeatCell` and `updateParagraphStyle` require explicit `fields` masks. Compute the mask from supplied input keys; never use wildcards. The helpers `buildCellFormat` (in `sheets.ts`), `buildParagraphStyle`, and `buildDocumentStyle` (in `docs.ts`) are the reference implementations and are unit-tested in `tests/field-mask-helpers.test.ts`. If you add a new format dimension, extend the helper, add a test, and bump the input schema.
+- Every `fileId` call: `supportsAllDrives: true`; lists: `includeItemsFromAllDrives: true`.
+- `drive_upload` `convertTo`: resource mimeType = target `application/vnd.google-apps.*`, media = source. `drive_export` is the reverse.
+- Comment text field is `content`. Comments/Replies API requires `fields` on every call (see `*_FIELDS` constants in `drive.ts`).
 
-## Escape hatches
+## Sheets/Docs field masks
 
-`sheets_batch_update` and `docs_batch_update` accept the full Request union as `z.array(z.record(z.string(), z.any()))`. Don't add a per-Request-type tool unless it's high-frequency or has a high-value default-computing facade (like `format_cells`). The catch-all keeps the tool count tractable.
+`batchUpdate` Request types need explicit `fields` masks — compute from input keys, never wildcards. Helpers `buildCellFormat` / `buildParagraphStyle` / `buildDocumentStyle` are unit-tested in `tests/field-mask-helpers.test.ts`.
 
-## Comments / Replies (Drive)
+## Versioning & releases (automated — CI controls it)
 
-- Comment text field is `content`, not `body`. Confirmed against the Drive v3 Comment resource.
-- `replies.create` accepts `action: 'resolve' | 'reopen'` to close/reopen a thread in the same call.
-- Comments/Replies API **requires** the `fields` query param on every call — never omit. See the `COMMENT_FIELDS`, `COMMENT_LIST_FIELDS`, `REPLY_FIELDS`, `REPLY_LIST_FIELDS` constants at the top of `drive.ts`.
-
-## Admin SDK safety
-
-- Admin tools only register if `GOOGLE_ADMIN_ACCOUNTS` is set.
-- Destructive admin writes (`admin_users_update`) must check `adminWritesEnabled()` (imported from `auth.ts`) and refuse if `GOOGLE_ALLOW_ADMIN_WRITES` is not exactly `'true'`. Do not relax this gate.
-- Admin tools 403 on personal Gmail accounts. The `handleAdminError` helper surfaces this hint clearly — keep it.
-
-## Alert Center is NOT an admin scope
-
-- `apps.alerts` (Alert Center) is **not** in `ADMIN_SCOPES`. Google does not grant it through the interactive user-consent OAuth flow this server uses — it requires a service account with domain-wide delegation. Putting it in the user-OAuth admin bundle made the *entire* admin consent fail with `Error 400: invalid_scope`.
-- It lives in the `alertcenter` key of `OPTIONAL_SCOPE_BUNDLES`, and `registerAlertCenterTools` (in `admin.ts`) registers behind `optional.has('alertcenter')` — never behind `getAdminAccounts()`. Keep these decoupled so a missing/ungrantable `apps.alerts` can never block the working Admin SDK tools.
-- Until service-account + domain-wide-delegation auth exists, the `alertcenter` bundle is declared-but-non-functional under user OAuth. `handleAlertCenterError` surfaces this — keep the hint.
-
-## Versioning & releases (automated)
-
-Releases are cut by **semantic-release** on every push to a release branch — do NOT bump `package.json`, write a changelog, or tag by hand.
-
-- Channels: `dev` → `x.y.z-alpha.n`, `staging` → `x.y.z-beta.n`, `main` → `x.y.z` (stable). Config in `.releaserc.json`; workflow in `.github/workflows/release.yml`.
-- Version is computed from Conventional Commits: `fix:` = patch, `feat:` = minor, `feat!:`/`BREAKING CHANGE:` = major. **A new `BASE_SCOPES` scope is breaking** (tokens become incomplete, forces re-auth) — mark it `feat!:` so it bumps major.
-- **Tags + GitHub Releases only** — no commit-back (`@semantic-release/git`/`@semantic-release/npm` are intentionally NOT used) so nothing fights branch protection; `GITHUB_TOKEN` suffices.
-- `package.json` `version` is a placeholder (`0.0.0-semantically-released`). The git tag / GitHub Release is the source of truth. `CHANGELOG.md` is frozen at v4.2.0; newer notes live in Releases.
+- semantic-release on push to `dev` (alpha) / `staging` (beta) / `main` (stable). Never bump `package.json`, write a changelog, or tag by hand.
+- Conventional Commits: `fix:`=patch, `feat:`=minor, `feat!:`/`BREAKING CHANGE:`=major. A new `BASE_SCOPES` scope is breaking (`feat!:`).
+- **Merge commits only** (squash/rebase disabled) — each branch's commits land individually, so keep them clean Conventional Commits.
+- After a stable release, `.github/workflows/backmerge.yml` resyncs `main → staging → dev`.
 
 ## Testing
 
-- `npm run typecheck && npm run lint && npm run test` must all pass before any PR.
-- Pure-logic helpers (fields-mask builders, validation helpers) get unit tests.
-- Do not try to mock `googleapis` for integration tests — manual smoke testing in Claude Code against real accounts is the truth.
-- Always re-auth after editing `BASE_SCOPES` before manual testing.
+- `npm run typecheck && npm run lint && npm run test && npm run build` before any PR.
+- Unit-test pure logic (write-control verdict, coercion, error mapper, token-store crypto, `inferCud`, field-mask builders). Don't mock `googleapis` — smoke-test handlers against real accounts.
 
 ## Don'ts
 
-- Don't `console.log` from tool handlers in MCP server mode. Stdio is the MCP channel. Use `process.stderr.write` if you really need to.
-- Don't hardcode account aliases. Always read from `ACCOUNTS` / `ACCOUNT_CONFIG`.
-- Don't bypass `getClient(account)` — it handles token refresh persistence.
-- Don't store tokens with permissions wider than `0o600`.
-- Don't expand `BASE_SCOPES` silently. Any scope change is user-visible and requires CHANGELOG documentation + a re-auth note.
-- Don't re-implement error mapping. Always go through `handleGoogleApiError` (via the per-service shim).
-- Don't re-parse `GOOGLE_OPTIONAL_SCOPES` or `GOOGLE_ADMIN_ACCOUNTS` inline. Use `getOptionalBundles()` / `getAdminAccounts()` exported from `auth.ts`.
-- Don't add narrative comments explaining WHAT code does. The CLAUDE.md rule is non-obvious WHY only; section dividers (`// ─── X ───`) are the exception as navigation aids.
+- No `console.log` from handlers (stdio is the MCP channel) — `process.stderr.write` only.
+- Don't hardcode aliases — read `ACCOUNTS` / `ACCOUNT_CONFIG`.
+- Don't bypass `getClient`; don't write plaintext tokens or perms wider than `0o600`.
+- Don't re-implement error mapping or write gating — use the shared helpers.
+- Don't add narrative comments — non-obvious WHY only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ your fork ──PR──▶ dev ──▶ staging ──▶ main (releases tagge
 - **Open all PRs against `dev`.** PRs to `staging` or `main` from contributors will be redirected.
 - The maintainer promotes `dev → staging → main` and cuts releases from `main`.
 - `dev`, `staging`, and `main` are all protected: CI must pass and changes land via pull request.
+- **Merges use merge commits** (squash & rebase are disabled), so keep each branch's commits clean Conventional Commits — they land individually and drive the release version.
 
 ## Dev setup
 
@@ -25,7 +26,7 @@ your fork ──PR──▶ dev ──▶ staging ──▶ main (releases tagge
 git clone https://github.com/bakissation/mcp-google-multi.git
 cd mcp-google-multi
 npm install
-cp .env.example .env          # add your GOOGLE_CLIENT_ID/SECRET and GOOGLE_ACCOUNTS
+cp .env.example .env          # add GOOGLE_CLIENT_ID/SECRET, GOOGLE_ACCOUNTS, and MASTER_KEY
 npm run build
 node dist/index.js auth --account <alias>   # OAuth each account you'll test with
 ```
@@ -49,7 +50,7 @@ npm run build
 
 The full spec lives in [`CLAUDE.md`](./CLAUDE.md). The essentials:
 
-- **One service per file** in `src/tools/<service>.ts`, exporting `register<Service>Tools(server)`.
+- **One service per file** in `src/tools/<service>.ts`, exporting `register<Service>Tools(server: ToolRegistry)`. `cud` (read/create/update/delete) is inferred from the tool name; CUD tools are auto-gated by write-control.
 - **Tool shape:** `server.registerTool(name, { description, inputSchema }, handler)`. `inputSchema` is a flat `zod` object with `account: accountEnum` as the first field. Tool names are `snake_case`, prefixed by service.
 - **Errors:** wrap handlers in `try/catch` and delegate to the per-service `handle<Service>Error` shim (which calls `handleGoogleApiError`). Set `isError: true` on error responses.
 - **Scopes** are tiered in `src/auth.ts`: `BASE_SCOPES` (always), `OPTIONAL_SCOPE_BUNDLES` (env opt-in), `ADMIN_SCOPES` (per-account opt-in). Any new scope must be documented and noted as requiring re-auth.
@@ -62,14 +63,14 @@ Versioning and releases are **fully automated** by [semantic-release](https://se
 
 - `fix:` → patch, `feat:` → minor, `feat!:` / `BREAKING CHANGE:` → major. `docs:`/`chore:`/`refactor:` don't trigger a release.
 - On merge, a release is cut automatically per channel: **`dev` → `x.y.z-alpha.n`**, **`staging` → `x.y.z-beta.n`**, **`main` → `x.y.z`** (stable). Release notes are generated into [GitHub Releases](https://github.com/bakissation/mcp-google-multi/releases).
-- Still update the relevant **README** tables in your PR when you add/change a tool. (`package.json` `version` is a managed placeholder — the git tag / GitHub Release is the source of truth.)
+- Update **[COVERAGE.md](./COVERAGE.md)** when you add/change a tool. (`package.json` `version` is a managed placeholder — the git tag / GitHub Release is the source of truth.)
 
 ## PR checklist
 
 - [ ] Targets `dev`
 - [ ] `typecheck`, `lint`, `test`, `build` all pass
 - [ ] Conventional commit messages
-- [ ] README tables updated (no manual version bump / changelog — automated from your commits)
+- [ ] COVERAGE.md updated (no manual version bump / changelog — automated from your commits)
 - [ ] No secrets, tokens, or `.env` committed
 
 ## Security

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -156,6 +156,6 @@ Requires the listed account to be a Workspace **super-admin** (its own OAuth —
 | `admin_users_update` | User edits (gated by write-control) |
 | `admin_groups_list` / `admin_group_members_list` | Group + member reads |
 
-## Google Alert Center — deferred to v6
+## Not yet available
 
-`alertcenter_alerts_list` / `alertcenter_alert_get` exist behind `GOOGLE_OPTIONAL_SCOPES=alertcenter`, **but the `apps.alerts` scope cannot be granted via user OAuth** — it needs a service account with domain-wide delegation. v5 is user-OAuth only, so these register but the API rejects the tokens. Service-account support (and a working Alert Center) is planned for **[v6](https://github.com/bakissation/mcp-google-multi/milestones)** ([#4](https://github.com/bakissation/mcp-google-multi/issues/4)).
+**Alert Center** (security alerts) requires a service account with domain-wide delegation, which user OAuth can't grant — planned for **[v6](https://github.com/bakissation/mcp-google-multi/milestones)** ([#4](https://github.com/bakissation/mcp-google-multi/issues/4)).

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -1,0 +1,161 @@
+# Tool Coverage
+
+Every tool takes an `account` argument matching one of your `GOOGLE_ACCOUNTS` aliases. **Create / update / delete tools are gated by [write-control](./README.md#write-control-deny-by-default)** — deny-by-default; reads are always available. Run `mcp-google-multi config check` to see exactly which CUD tools your current profile enables.
+
+~170 tools across the services below. (This is the curated surface; discover-first deferral and exhaustive API coverage are on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones).)
+
+## Gmail
+
+| Tool | Description |
+|------|-------------|
+| `gmail_search` | Search messages with Gmail query syntax |
+| `gmail_read` | Read a full message by ID |
+| `gmail_read_thread` | Read all messages in a thread |
+| `gmail_send` | Send an email (optional `htmlBody` for multipart/alternative) |
+| `gmail_download_attachment` | Download an email attachment to local disk |
+| `gmail_create_draft` | Create a draft (optional `htmlBody` for multipart/alternative) |
+| `gmail_modify_labels` | Add/remove labels on a message (star, archive, mark read, etc.) |
+| `gmail_trash` | Move a message to Trash (recoverable) |
+| `gmail_delete` | Permanently delete a message (irreversible) |
+| `gmail_batch_modify` | Bulk add/remove labels across up to 1000 messages |
+| `gmail_batch_delete` | Permanently delete multiple messages (irreversible) |
+| `gmail_list_drafts` | List all drafts |
+| `gmail_get_draft` | Read a specific draft |
+| `gmail_send_draft` | Send an existing draft |
+| `gmail_list_labels` | List all labels (system + custom) |
+| `gmail_create_label` | Create a custom label |
+| `gmail_delete_label` | Delete a label |
+| `gmail_get_profile` | Get account email, message count, history ID |
+| `gmail_list_history` | Get mailbox changes since a history ID |
+| `gmail_get_vacation` | Read vacation responder settings |
+| `gmail_set_vacation` | Enable/disable vacation responder |
+
+## Google Drive
+
+| Tool | Description |
+|------|-------------|
+| `drive_search` | Search files with Drive query syntax (shared drives included) |
+| `drive_read` | Read file content (exports Workspace docs as text) |
+| `drive_list` | List files in a folder or root |
+| `drive_upload` | Upload a local file (optional `convertTo` imports as a native Google Doc/Sheet/Slides) |
+| `drive_download` | Download a binary file to local disk |
+| `drive_export` | Export Docs/Sheets/Slides to PDF, DOCX, XLSX, Markdown, etc. |
+| `drive_create_folder` | Create a new folder |
+| `drive_update` | Rename, move, or replace file content |
+| `drive_delete` | Permanently delete a file (irreversible) |
+| `drive_trash` / `drive_untrash` / `drive_empty_trash` | Trash lifecycle |
+| `drive_copy` / `drive_move` | Duplicate / move a file |
+| `drive_share` | Share with user/group/domain/anyone (`transferOwnership`, `expirationTime`) |
+| `drive_list_permissions` / `drive_permission_update` / `drive_remove_permission` | Permission management |
+| `drive_comment_create` / `_list` / `_get` / `_update` / `_delete` | Comment CRUD with anchors |
+| `drive_reply_create` / `_list` / `_update` / `_delete` | Reply CRUD (`action: resolve｜reopen`) |
+| `drive_revision_list` / `_update` / `_delete` | Version history (`keepForever`) |
+| `drive_access_proposal_list` / `_resolve` | Triage "Request access" submissions |
+| `drive_shared_drives_list` / `drive_shared_drive_get` | Shared drive discovery |
+| `drive_get_about` | Storage quota and account info |
+
+## Google Calendar
+
+| Tool | Description |
+|------|-------------|
+| `calendar_list_calendars` | List all calendars |
+| `calendar_list_events` | List/search events with time range |
+| `calendar_get_event` | Get a single event by ID |
+| `calendar_create_event` / `calendar_update_event` / `calendar_delete_event` | Event CRUD |
+| `calendar_quick_add` | Create event from natural language |
+| `calendar_move_event` | Move an event between calendars |
+| `calendar_list_instances` | List occurrences of a recurring event |
+| `calendar_get_freebusy` | Check free/busy times |
+| `calendar_create_calendar` | Create a new calendar |
+
+## Google Sheets
+
+| Tool | Description |
+|------|-------------|
+| `sheets_create` / `sheets_get` | Create / metadata |
+| `sheets_read_range` / `sheets_batch_read` | Read values |
+| `sheets_write_range` / `sheets_batch_write` / `sheets_append_rows` | Write / append |
+| `sheets_clear_range` / `sheets_batch_clear` | Clear values (keeps formatting) |
+| `sheets_add_sheet` / `sheets_delete_sheet` / `sheets_duplicate_sheet` / `sheets_update_sheet_properties` | Tab management |
+| `sheets_format_cells` / `sheets_update_borders` / `sheets_merge_cells` / `sheets_unmerge_cells` | Formatting |
+| `sheets_add_conditional_format_rule` / `sheets_sort_range` / `sheets_set_basic_filter` / `sheets_clear_basic_filter` | Rules / sort / filter |
+| `sheets_find_replace` / `sheets_auto_resize_dimensions` / `sheets_set_data_validation` | Find-replace / autosize / validation |
+| `sheets_add_named_range` / `sheets_delete_named_range` | Named ranges |
+| `sheets_insert_dimension` / `sheets_delete_dimension` | Insert/delete rows or columns |
+| `sheets_batch_update` | Generic batchUpdate escape hatch |
+
+## Google Docs
+
+| Tool | Description |
+|------|-------------|
+| `docs_create` / `docs_get` / `docs_read` | Create / metadata / read text |
+| `docs_insert_text` / `docs_replace_text` / `docs_delete_range` | Text editing |
+| `docs_update_style` / `docs_update_paragraph_style` / `docs_update_document_style` | Formatting |
+| `docs_insert_table` / `docs_modify_table` | Tables |
+| `docs_create_named_range` / `docs_delete_named_range` / `docs_replace_named_range_content` | Mail-merge primitive |
+| `docs_create_paragraph_bullets` / `docs_delete_paragraph_bullets` | Lists |
+| `docs_insert_inline_image` / `docs_insert_page_break` / `docs_insert_section_break` | Media / layout |
+| `docs_create_header` / `docs_delete_header` / `docs_create_footer` / `docs_delete_footer` | Headers / footers |
+| `docs_add_tab` / `docs_delete_tab` / `docs_update_tab_properties` | Tabs |
+| `docs_batch_update` | Generic batchUpdate escape hatch |
+
+## Google Contacts
+
+| Tool | Description |
+|------|-------------|
+| `contacts_search` / `contacts_get` / `contacts_list` | Read |
+| `contacts_create` / `contacts_update` / `contacts_delete` | Contact CRUD |
+| `contacts_groups_list` / `contacts_group_members` / `contacts_group_create` | Groups |
+
+## Google Search Console
+
+| Tool | Description |
+|------|-------------|
+| `searchconsole_sites_list` / `_get` / `_add` / `_delete` | Property management |
+| `searchconsole_sitemaps_list` / `_get` / `_submit` / `_delete` | Sitemap management |
+| `searchconsole_searchanalytics_query` | Query search analytics |
+| `searchconsole_url_inspect` | Inspect a URL |
+
+## Google Tasks
+
+| Tool | Description |
+|------|-------------|
+| `tasks_lists_list` / `tasks_list_get` / `tasks_list_insert` / `tasks_list_update` / `tasks_list_delete` | Tasklist management |
+| `tasks_list` | List tasks (filter by completion, due, updated) |
+| `tasks_get` / `tasks_insert` / `tasks_update` / `tasks_delete` | Task CRUD |
+| `tasks_move` | Re-parent / re-position / move to another list |
+| `tasks_clear` | Delete every completed task |
+
+## Google Meet
+
+| Tool | Description |
+|------|-------------|
+| `meet_conference_records_list` / `meet_conference_record_get` | Past Meet sessions |
+| `meet_recordings_list` / `meet_transcripts_list` / `meet_transcript_entries_list` | Recordings & transcripts |
+
+## Google Forms — optional bundle (`GOOGLE_OPTIONAL_SCOPES=forms`)
+
+| Tool | Description |
+|------|-------------|
+| `forms_get` / `forms_responses_list` / `forms_response_get` / `forms_watches_list` | Form + responses (read) |
+
+## Google Chat — optional bundle (`GOOGLE_OPTIONAL_SCOPES=chat`)
+
+| Tool | Description |
+|------|-------------|
+| `chat_spaces_list` / `chat_spaces_get` / `chat_messages_create` / `chat_messages_list` | Spaces & messages |
+
+## Google Workspace Admin — `GOOGLE_ADMIN_ACCOUNTS=<alias…>`
+
+Requires the listed account to be a Workspace **super-admin** (its own OAuth — no service account). Personal `@gmail.com` accounts will 403; never list them.
+
+| Tool | Description |
+|------|-------------|
+| `reports_activities_list` | Workspace audit log |
+| `admin_users_list` / `admin_users_get` | User directory reads |
+| `admin_users_update` | User edits (gated by write-control) |
+| `admin_groups_list` / `admin_group_members_list` | Group + member reads |
+
+## Google Alert Center — deferred to v6
+
+`alertcenter_alerts_list` / `alertcenter_alert_get` exist behind `GOOGLE_OPTIONAL_SCOPES=alertcenter`, **but the `apps.alerts` scope cannot be granted via user OAuth** — it needs a service account with domain-wide delegation. v5 is user-OAuth only, so these register but the API rejects the tokens. Service-account support (and a working Alert Center) is planned for **[v6](https://github.com/bakissation/mcp-google-multi/milestones)** ([#4](https://github.com/bakissation/mcp-google-multi/issues/4)).

--- a/README.md
+++ b/README.md
@@ -1,470 +1,127 @@
 # mcp-google-multi
 
-A local [MCP](https://modelcontextprotocol.io) server that gives Claude Code (and any MCP client) access to **Gmail**, **Google Drive**, **Google Calendar**, **Google Sheets**, **Google Docs**, **Google Contacts**, **Google Search Console**, **Google Tasks**, **Google Meet**, and optionally **Google Forms**, **Google Chat**, and **Google Workspace Admin** APIs across multiple Google accounts simultaneously.
+A **local** [MCP](https://modelcontextprotocol.io) server that gives Claude Code (and any MCP client) access to your **Google Workspace** — Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console (plus optional Forms, Chat, and Workspace Admin) — across **multiple Google accounts** at once.
 
 [![npm](https://img.shields.io/npm/v/mcp-google-multi?label=npm&color=cb3837)](https://www.npmjs.com/package/mcp-google-multi)
 
-## Features
+- 🔑 **Multi-account** — drive any number of your Google accounts from one server, each by a short alias.
+- 🔒 **Secure by default** — refresh tokens **encrypted at rest** (AES-256-GCM); **writes are deny-by-default**; no telemetry — it talks only to Google.
+- 📦 **npm-first** — install and run with `npx`; everything configured through env vars.
+- 🧰 **~170 tools** across 12 services → full list in **[COVERAGE.md](./COVERAGE.md)**.
 
-- **Multi-account** — manage any number of Google accounts from a single server
-- **175 tools** across 13 Google services
-- **Tiered OAuth scopes** — base scopes always granted; Forms/Chat/Alert Center are opt-in bundles; Admin scopes are per-account opt-in with a separate safety flag for destructive writes
-- **Config-driven accounts** — defined in `.env`, no code changes needed
-- **Auto-refresh** — OAuth tokens refresh transparently and persist to disk
-- **Stdio transport** — runs as a local subprocess, no hosting needed
+> v5 is **local + user-OAuth only**. Service accounts and hosting (and the APIs they unlock) are on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones). **Upgrading from v4?** Jump to [Upgrading](#upgrading-from-v4).
 
-## Tools
+## Quick start
 
-### Gmail (21 tools)
-
-| Tool | Description |
-|------|-------------|
-| `gmail_search` | Search messages with Gmail query syntax |
-| `gmail_read` | Read a full message by ID |
-| `gmail_read_thread` | Read all messages in a thread |
-| `gmail_send` | Send an email (optional `htmlBody` for multipart/alternative) |
-| `gmail_download_attachment` | Download an email attachment to local disk |
-| `gmail_create_draft` | Create a draft (optional `htmlBody` for multipart/alternative) |
-| `gmail_modify_labels` | Add/remove labels on a message (star, archive, mark read, etc.) |
-| `gmail_trash` | Move a message to Trash (recoverable) |
-| `gmail_delete` | Permanently delete a message (irreversible) |
-| `gmail_batch_modify` | Bulk add/remove labels across up to 1000 messages |
-| `gmail_batch_delete` | Permanently delete multiple messages (irreversible) |
-| `gmail_list_drafts` | List all drafts |
-| `gmail_get_draft` | Read a specific draft |
-| `gmail_send_draft` | Send an existing draft |
-| `gmail_list_labels` | List all labels (system + custom) |
-| `gmail_create_label` | Create a custom label |
-| `gmail_delete_label` | Delete a label |
-| `gmail_get_profile` | Get account email, message count, history ID |
-| `gmail_list_history` | Get mailbox changes since a history ID |
-| `gmail_get_vacation` | Read vacation responder settings |
-| `gmail_set_vacation` | Enable/disable vacation responder |
-
-### Google Drive (35 tools)
-
-| Tool | Description |
-|------|-------------|
-| `drive_search` | Search files with Drive query syntax (shared drives included) |
-| `drive_read` | Read file content (exports Workspace docs as text) |
-| `drive_list` | List files in a folder or root |
-| `drive_upload` | Upload a local file to Drive (optional `convertTo` imports it as a native Google Doc/Sheet/Slides) |
-| `drive_download` | Download a binary file to local disk |
-| `drive_export` | Export Google Docs/Sheets/Slides to PDF, DOCX, XLSX, Markdown, etc. |
-| `drive_create_folder` | Create a new folder |
-| `drive_update` | Rename, move, or replace file content |
-| `drive_delete` | Permanently delete a file (irreversible) |
-| `drive_trash` | Move a file to trash (recoverable) |
-| `drive_untrash` | Restore a trashed file |
-| `drive_empty_trash` | Permanently delete every file in trash |
-| `drive_copy` | Duplicate a file |
-| `drive_move` | Move a file between folders |
-| `drive_share` | Share with user/group/domain/anyone (with `transferOwnership` + `expirationTime`) |
-| `drive_list_permissions` | List who has access to a file |
-| `drive_permission_update` | Change a permission's role / expiration in place |
-| `drive_remove_permission` | Revoke access |
-| `drive_comment_create` / `_list` / `_get` / `_update` / `_delete` | Full comment CRUD with anchor support |
-| `drive_reply_create` / `_list` / `_update` / `_delete` | Reply CRUD; reply.create accepts `action: resolve | reopen` |
-| `drive_revision_list` / `_update` / `_delete` | Version history; `keepForever` pins against the 200-version cap |
-| `drive_access_proposal_list` / `_resolve` | Triage "Request access" submissions |
-| `drive_shared_drives_list` / `drive_shared_drive_get` | Shared drive discovery |
-| `drive_get_about` | Storage quota and account info |
-
-### Google Calendar (11 tools)
-
-| Tool | Description |
-|------|-------------|
-| `calendar_list_calendars` | List all calendars |
-| `calendar_list_events` | List/search events with time range |
-| `calendar_get_event` | Get a single event by ID |
-| `calendar_create_event` | Create an event |
-| `calendar_update_event` | Update an event |
-| `calendar_delete_event` | Delete an event |
-| `calendar_quick_add` | Create event from natural language (e.g. "Lunch Thursday 1pm") |
-| `calendar_move_event` | Move an event between calendars |
-| `calendar_list_instances` | List occurrences of a recurring event |
-| `calendar_get_freebusy` | Check free/busy times for calendars |
-| `calendar_create_calendar` | Create a new calendar |
-
-### Google Sheets (29 tools)
-
-| Tool | Description |
-|------|-------------|
-| `sheets_create` | Create a new spreadsheet |
-| `sheets_get` | Get spreadsheet metadata |
-| `sheets_read_range` / `sheets_batch_read` | Read values |
-| `sheets_write_range` / `sheets_batch_write` | Write values |
-| `sheets_append_rows` | Append after existing data |
-| `sheets_clear_range` / `sheets_batch_clear` | Clear values (preserves formatting) |
-| `sheets_add_sheet` / `sheets_delete_sheet` / `sheets_duplicate_sheet` | Tab management |
-| `sheets_update_sheet_properties` | Rename, freeze, color, hide, resize |
-| `sheets_format_cells` | Colors, fonts, alignment, number formats |
-| `sheets_update_borders` | Cell borders with style + color |
-| `sheets_merge_cells` / `sheets_unmerge_cells` | Cell merging |
-| `sheets_add_conditional_format_rule` | Boolean and gradient conditional formatting |
-| `sheets_sort_range` | Multi-column sort |
-| `sheets_set_basic_filter` / `sheets_clear_basic_filter` | Filter rows |
-| `sheets_find_replace` | Regex-capable, scope-aware find/replace |
-| `sheets_auto_resize_dimensions` | Fit rows/columns to content |
-| `sheets_set_data_validation` | Dropdowns, checkboxes, custom rules |
-| `sheets_add_named_range` / `sheets_delete_named_range` | Named ranges |
-| `sheets_insert_dimension` / `sheets_delete_dimension` | Insert/delete rows or columns |
-| `sheets_batch_update` | Generic batchUpdate escape hatch (any Request type) |
-
-### Google Docs (27 tools)
-
-| Tool | Description |
-|------|-------------|
-| `docs_create` | Create a new document |
-| `docs_get` | Metadata + optional tab content / suggestionsViewMode |
-| `docs_read` | Read document content as plain text |
-| `docs_insert_text` | Insert text at position or end |
-| `docs_replace_text` | Find and replace |
-| `docs_delete_range` | Delete a character range |
-| `docs_update_style` | Inline text formatting (bold, italic, font, size) |
-| `docs_update_paragraph_style` | Alignment, heading, indents, spacing |
-| `docs_update_document_style` | Page size, margins, header/footer behavior |
-| `docs_insert_table` | Insert a table |
-| `docs_modify_table` | insertRow / insertColumn / deleteRow / deleteColumn / mergeCells / unmergeCells |
-| `docs_create_named_range` / `docs_delete_named_range` / `docs_replace_named_range_content` | Mail-merge primitive |
-| `docs_create_paragraph_bullets` / `docs_delete_paragraph_bullets` | Bulleted/numbered lists |
-| `docs_insert_inline_image` | PNG/JPEG/GIF image insertion |
-| `docs_insert_page_break` / `docs_insert_section_break` | Layout breaks |
-| `docs_create_header` / `docs_delete_header` / `docs_create_footer` / `docs_delete_footer` | Branded headers and footers |
-| `docs_add_tab` / `docs_delete_tab` / `docs_update_tab_properties` | Tabs CRUD |
-| `docs_batch_update` | Generic batchUpdate escape hatch (any Request type) |
-
-### Google Contacts (9 tools)
-
-| Tool | Description |
-|------|-------------|
-| `contacts_search` | Search contacts |
-| `contacts_get` | Get one contact |
-| `contacts_list` | List contacts (paginated) |
-| `contacts_create` | Create a contact |
-| `contacts_update` | Update a contact |
-| `contacts_delete` | Delete a contact |
-| `contacts_groups_list` | List groups |
-| `contacts_group_members` | List members of a group |
-| `contacts_group_create` | Create a group |
-
-### Google Search Console (10 tools)
-
-| Tool | Description |
-|------|-------------|
-| `searchconsole_sites_list` | List Search Console properties |
-| `searchconsole_sites_get` | Get a property |
-| `searchconsole_sites_add` | Add a property |
-| `searchconsole_sites_delete` | Remove a property |
-| `searchconsole_sitemaps_list` | List sitemaps |
-| `searchconsole_sitemaps_get` | Sitemap status |
-| `searchconsole_sitemaps_submit` | Submit a sitemap |
-| `searchconsole_sitemaps_delete` | Delete a sitemap |
-| `searchconsole_searchanalytics_query` | Query search analytics |
-| `searchconsole_url_inspect` | Inspect a URL |
-
-### Google Tasks (12 tools) — _new in v4_
-
-| Tool | Description |
-|------|-------------|
-| `tasks_lists_list` / `tasks_list_get` / `tasks_list_insert` / `tasks_list_update` / `tasks_list_delete` | Tasklist management |
-| `tasks_list` | List tasks (filter by completion, due, updated time) |
-| `tasks_get` / `tasks_insert` / `tasks_update` / `tasks_delete` | Task CRUD |
-| `tasks_move` | Re-parent / re-position / move to another list |
-| `tasks_clear` | Delete every completed task |
-
-### Google Meet (5 tools) — _new in v4_
-
-| Tool | Description |
-|------|-------------|
-| `meet_conference_records_list` | List past Meet sessions |
-| `meet_conference_record_get` | Get one record |
-| `meet_recordings_list` | Recordings on a record |
-| `meet_transcripts_list` | Transcripts on a record |
-| `meet_transcript_entries_list` | Per-speaker transcript text |
-
-### Google Forms (4 tools, optional bundle) — _new in v4_
-
-Enable with `GOOGLE_OPTIONAL_SCOPES=forms` in `.env`.
-
-| Tool | Description |
-|------|-------------|
-| `forms_get` | Form definition |
-| `forms_responses_list` | List responses with filter |
-| `forms_response_get` | Single response |
-| `forms_watches_list` | List Pub/Sub watches |
-
-### Google Chat (4 tools, optional bundle) — _new in v4_
-
-Enable with `GOOGLE_OPTIONAL_SCOPES=chat` in `.env` (combine: `GOOGLE_OPTIONAL_SCOPES=forms,chat`).
-
-| Tool | Description |
-|------|-------------|
-| `chat_spaces_list` | Spaces the user is in |
-| `chat_spaces_get` | One space |
-| `chat_messages_create` | Send text or Card v2 |
-| `chat_messages_list` | List messages with filter / orderBy |
-
-### Google Workspace Admin (6 tools, admin bundle) — _new in v4_
-
-Enable per-account with `GOOGLE_ADMIN_ACCOUNTS=alias1,alias2` in `.env`. Requires the account to be a Workspace super-admin. Personal `@gmail.com` accounts will 403 — never list them here. Destructive writes additionally require `GOOGLE_ALLOW_ADMIN_WRITES=true`.
-
-| Tool | Description |
-|------|-------------|
-| `reports_activities_list` | Workspace audit log (login, drive, gmail, admin, token, etc.) |
-| `admin_users_list` / `admin_users_get` | User directory reads |
-| `admin_users_update` | User edits (gated, see env flag above) |
-| `admin_groups_list` / `admin_group_members_list` | Group + member reads |
-
-Every tool accepts an `account` parameter matching one of your configured aliases.
-
-### Google Alert Center (2 tools, optional bundle) — _new in v4_
-
-Enable with `GOOGLE_OPTIONAL_SCOPES=alertcenter` in `.env`.
-
-| Tool | Description |
-|------|-------------|
-| `alertcenter_alerts_list` / `alertcenter_alert_get` | Security alerts (suspicious login, phishing, leaked password, Drive exfil) |
-
-> **⚠ Requires service-account domain-wide delegation.** Unlike every other bundle, the Alert Center `apps.alerts` scope **cannot** be granted through this server's interactive user-consent OAuth flow — Google rejects it with `Error 400: invalid_scope` / "Some requested scopes cannot be shown". Per [Google's docs](https://developers.google.com/workspace/admin/alertcenter/guides/auth), Alert Center requires a service account with domain-wide delegation. This server is user-OAuth only, so enabling this bundle declares the scope and registers the tools, but the API will reject the resulting tokens until service-account auth is added (see [#4](https://github.com/bakissation/mcp-google-multi/issues/4)). The bundle is kept separate precisely so this limitation never blocks the working admin tools above.
-
-## Prerequisites
-
-- Node.js 18+
-- A Google Cloud project with the relevant APIs enabled (see step 1 below)
-- An OAuth 2.0 Client ID (Desktop app type)
-
-## Setup
-
-### 1. Google Cloud Credentials
-
-1. Go to [Google Cloud Console](https://console.cloud.google.com).
-2. Create or select a project.
-3. Enable the APIs you intend to use:
-   - **Always required:** [Gmail API](https://console.cloud.google.com/apis/library/gmail.googleapis.com), [Google Drive API](https://console.cloud.google.com/apis/library/drive.googleapis.com), [Google Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com), [Google Sheets API](https://console.cloud.google.com/apis/library/sheets.googleapis.com), [Google Docs API](https://console.cloud.google.com/apis/library/docs.googleapis.com), [People API](https://console.cloud.google.com/apis/library/people.googleapis.com), [Search Console API](https://console.cloud.google.com/apis/library/searchconsole.googleapis.com), [Google Tasks API](https://console.cloud.google.com/apis/library/tasks.googleapis.com), [Google Meet API](https://console.cloud.google.com/apis/library/meet.googleapis.com).
-   - **Optional bundles (only if you enable them):** [Google Forms API](https://console.cloud.google.com/apis/library/forms.googleapis.com), [Google Chat API](https://console.cloud.google.com/apis/library/chat.googleapis.com), [Alert Center API](https://console.cloud.google.com/apis/library/alertcenter.googleapis.com) (the `alertcenter` bundle also needs service-account domain-wide delegation — see the Alert Center section above).
-   - **Admin bundle (only if you set `GOOGLE_ADMIN_ACCOUNTS`):** [Admin SDK API](https://console.cloud.google.com/apis/library/admin.googleapis.com).
-4. Go to **APIs & Services → Credentials → Create Credentials → OAuth 2.0 Client ID**.
-5. Application type: **Desktop app**.
-6. Add authorized redirect URI: `http://localhost:4242/oauth2callback`.
-7. Copy the **Client ID** and **Client Secret**.
-
-### 2. Install & Configure
-
-**Option A — from npm (no clone):**
+You need **Node 20+**, a Google Cloud OAuth client (~2 min — [setup below](#google-cloud-setup)), and a random 32-byte key.
 
 ```bash
-npm install -g mcp-google-multi    # installs the `mcp-google-multi` CLI
-# …or run on demand without installing: npx mcp-google-multi
+# 1) install
+npm i -g mcp-google-multi
+
+# 2) put your config + creds in the environment (see "Configuration").
+#    Easiest for a quick try — export them, or drop a .env in your working dir:
+#    GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_ACCOUNTS, MASTER_KEY, GOOGLE_PROFILE
+
+# 3) authenticate each account (opens a browser; one-time per account)
+mcp-google-multi auth --account work
+mcp-google-multi auth --account personal
+
+# 4) register with Claude Code
+claude mcp add google-multi -s user -- npx -y mcp-google-multi
 ```
 
-Published with channel dist-tags — `@latest` (stable), `@dev` (alpha), `@staging` (beta); e.g. `npm i -g mcp-google-multi@dev` for the latest alpha.
+Restart your MCP client and the tools appear. Tokens are written **encrypted** to `~/.config/mcp-google-multi/tokens/` (override with `TOKEN_STORE_PATH`) — useless to anyone without your `MASTER_KEY`.
 
-**Option B — from source:**
+Generate a key: `openssl rand -base64 32`.
+
+## Recommended: keep secrets in a vault (Infisical)
+
+A plaintext `.env` is fine to try it out, but for a daily driver, **don't leave `GOOGLE_CLIENT_SECRET` + `MASTER_KEY` on disk** — inject them at launch from a secrets manager. The server just reads `process.env` (it has no idea where the values come from), so wrap it with [Infisical](https://infisical.com):
 
 ```bash
-git clone https://github.com/bakissation/mcp-google-multi.git
-cd mcp-google-multi
-npm install && npm run build
-cp .env.example .env
+#!/usr/bin/env bash
+# ~/.local/bin/mcp-google-multi-run  — chmod +x, then register this as the MCP command
+set -euo pipefail
+export INFISICAL_TOKEN="$(infisical login --method=universal-auth \
+  --client-id "$YOUR_CLIENT_ID" --client-secret "$YOUR_CLIENT_SECRET" --plain --silent)"
+exec infisical run --projectId <project> --env prod --path /mcp-google-multi \
+  -- npx -y mcp-google-multi
 ```
-
-Create a `.env` (from source, `.env.example` is the template; from npm, make one in the directory you'll run the server from) with:
-
-```env
-GOOGLE_CLIENT_ID=your_client_id_here
-GOOGLE_CLIENT_SECRET=your_client_secret_here
-
-# Define your accounts as alias:email pairs (comma-separated)
-GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
-
-# Optional (v4): enable Forms, Chat, and/or Alert Center tool bundles
-# (alertcenter additionally requires service-account domain-wide delegation)
-# GOOGLE_OPTIONAL_SCOPES=forms,chat
-
-# Optional (v4): grant Workspace admin scopes to specific accounts
-# GOOGLE_ADMIN_ACCOUNTS=work
-
-# Optional (v4): unlock destructive admin writes (admin_users_update)
-# GOOGLE_ALLOW_ADMIN_WRITES=true
-```
-
-### 3. Build
 
 ```bash
-npm run build
+claude mcp add google-multi -s user -- ~/.local/bin/mcp-google-multi-run
 ```
 
-### 4. Authenticate Accounts
+Now the only thing on disk is the **encrypted** token store. Pass the token via the `INFISICAL_TOKEN` env var (as above), **not** a `--token` flag, so it never shows up in `ps`. (Any secrets manager works — Doppler, Vault, 1Password CLI, etc. — the pattern is the same.)
 
-```bash
-npm run auth -- work       # opens browser → log in with you@company.com
-npm run auth -- personal   # opens browser → log in with you@gmail.com
-```
+## Configuration
 
-Each saves a token to `tokens/<alias>/token.json`. Tokens auto-refresh — you should only need to do this once per account.
+| Env var | Required | Description |
+|---|---|---|
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | ✓ | OAuth **Desktop** client from Google Cloud |
+| `GOOGLE_ACCOUNTS` | ✓ | `alias:email,…` — e.g. `work:you@co.com,personal:you@gmail.com` |
+| `MASTER_KEY` | ✓ | base64 32-byte key that encrypts the token store (`openssl rand -base64 32`) |
+| `GOOGLE_PROFILE` | — | write policy: `read-only` (default) · `safe-writes` · `full-writes` |
+| `GOOGLE_READ_ONLY` | — | `true` = hard kill-switch for all writes |
+| `GOOGLE_WRITE_ALLOW` / `GOOGLE_WRITE_DENY` | — | glob overrides, e.g. `calendar:*`, `*:delete*` |
+| `GOOGLE_OPTIONAL_SCOPES` | — | extra bundles: `forms`, `chat` |
+| `GOOGLE_ADMIN_ACCOUNTS` | — | aliases granted Workspace-admin scopes (the account's own super-admin OAuth) |
+| `TOKEN_STORE_PATH` | — | override the encrypted token dir (default: `~/.config/mcp-google-multi/tokens`) |
 
-### 5. Register in Claude Code
+Inspect the resolved setup any time: `mcp-google-multi config check`.
 
-```bash
-claude mcp add google-multi -s user -- node /absolute/path/to/mcp-google-multi/dist/index.js
-```
+## Write-control (deny-by-default)
 
-Or add it manually to your Claude Code MCP config:
+Reads are never gated. **Every create/update/delete is off until you opt in** — pick a profile:
 
-```json
-{
-  "mcpServers": {
-    "google-multi": {
-      "command": "node",
-      "args": ["/absolute/path/to/mcp-google-multi/dist/index.js"]
-    }
-  }
-}
-```
+| `GOOGLE_PROFILE` | Allows |
+|---|---|
+| `read-only` (default) | reads only |
+| `safe-writes` | create + update (deletes still blocked) |
+| `full-writes` | everything |
 
-If you installed from npm, point at the package instead and pass config via `env` (authenticate first with `mcp-google-multi auth --account <alias>`):
+`GOOGLE_READ_ONLY=true` overrides all. For fine control: `GOOGLE_WRITE_ALLOW="calendar:*, sheets:update*"` and `GOOGLE_WRITE_DENY="*:delete*"` (deny wins). `mcp-google-multi config check` prints the resolved policy and exactly which tools are enabled.
 
-```json
-{
-  "mcpServers": {
-    "google-multi": {
-      "command": "npx",
-      "args": ["-y", "mcp-google-multi"],
-      "env": {
-        "GOOGLE_CLIENT_ID": "your_client_id_here",
-        "GOOGLE_CLIENT_SECRET": "your_client_secret_here",
-        "GOOGLE_ACCOUNTS": "work:you@company.com,personal:you@gmail.com"
-      }
-    }
-  }
-}
-```
+## What's covered
 
-## Migrating from v3
+~170 tools across Gmail, Drive, Calendar, Sheets, Docs, Contacts, Search Console, Tasks, Meet, and (optional) Forms, Chat, Workspace Admin. **Full per-tool list → [COVERAGE.md](./COVERAGE.md).** Every tool takes an `account` argument matching one of your aliases.
 
-v4.0.0 grows the base OAuth scope set (Tasks and Meet are now included by default). Existing v3 tokens lack those scopes and the corresponding tools will 403.
+## Google Cloud setup
 
-1. `git pull && npm install && npm run build`.
-2. Re-authenticate every account: `npm run auth -- <alias>` for each alias.
-3. If you want Forms or Chat tools: set `GOOGLE_OPTIONAL_SCOPES=forms,chat` in `.env` **before** re-authing.
-4. If you're a Workspace admin: list relevant accounts in `GOOGLE_ADMIN_ACCOUNTS` **before** re-authing those accounts. Set `GOOGLE_ALLOW_ADMIN_WRITES=true` only if you need destructive admin operations.
-5. In Google Cloud Console, enable any new APIs you'll use (Tasks, Meet, Forms, Chat, Admin SDK, Alert Center).
+1. [Google Cloud Console](https://console.cloud.google.com) → create or select a project.
+2. Enable the APIs you'll use: Gmail, Drive, Calendar, Sheets, Docs, People, Search Console, Tasks, Meet (+ Forms / Chat / Admin SDK if you enable those bundles).
+3. **APIs & Services → Credentials → Create Credentials → OAuth client ID → Desktop app**.
+4. Add the redirect URI `http://localhost:4242/oauth2callback`.
+5. Copy the **Client ID** + **Client Secret** into your environment.
 
-## Adding / Removing Accounts
+## Upgrading from v4
 
-Edit the `GOOGLE_ACCOUNTS` variable in `.env`, rebuild, and authenticate the new account:
+v5 is a breaking change, but the migration is a one-time, ~2-minute step:
 
-```bash
-# Add a new account
-# .env: GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com,freelance:you@freelance.com
+1. Update: `npm i -g mcp-google-multi@latest` (or update your client config).
+2. Add **`MASTER_KEY`** to your environment (`openssl rand -base64 32`) — now required.
+3. Encrypt existing tokens: `mcp-google-multi migrate-tokens` (reads your old `tokens/<alias>/token.json` and encrypts them) — or just re-auth each account.
+4. Writes are now **deny-by-default** — set `GOOGLE_PROFILE=safe-writes` (or `full-writes`) to keep writing. (`GOOGLE_ALLOW_ADMIN_WRITES` is gone — replaced by write-control profiles.)
 
-npm run build
-npm run auth -- freelance
-```
+## Security
 
-No code changes required.
+Your OAuth, your machine. Refresh tokens are **AES-256-GCM encrypted at rest** (decryptable only with your `MASTER_KEY`), writes are deny-by-default, and the server has **no telemetry** — it connects only to Google's APIs. Found a vulnerability? Report it privately — see [SECURITY.md](./SECURITY.md), never a public issue.
 
-## OAuth Scopes
+## Roadmap
 
-### Base (always granted)
-
-| Scope | Access |
-|-------|--------|
-| `gmail.modify` | Read, label, trash, delete emails |
-| `gmail.send` | Send emails |
-| `drive` | Full Drive access (read, upload, share, comments, etc.) |
-| `calendar` | Full calendar access |
-| `spreadsheets` | Read/write Google Sheets |
-| `documents` | Read/write Google Docs |
-| `contacts` | Read/write Google Contacts |
-| `webmasters` | Google Search Console |
-| `tasks` | Read/write Google Tasks |
-| `meetings.space.readonly` | Read past Meet conference records and transcripts |
-
-### Optional (per-`GOOGLE_OPTIONAL_SCOPES` env var)
-
-| Bundle key | Scopes |
-|------------|--------|
-| `forms` | `forms.body`, `forms.responses.readonly` |
-| `chat` | `chat.spaces`, `chat.messages`, `chat.messages.create` |
-| `alertcenter` | `apps.alerts` — ⚠ requires service-account domain-wide delegation; not grantable via user OAuth (see Alert Center section) |
-
-### Admin (per-`GOOGLE_ADMIN_ACCOUNTS` env var)
-
-Only granted to accounts explicitly listed. Personal Gmail accounts will 403 on these scopes — never list them.
-
-| Scope | Access |
-|-------|--------|
-| `admin.reports.audit.readonly` | Workspace audit log |
-| `admin.directory.user` | Read/write Workspace users (writes also gated by `GOOGLE_ALLOW_ADMIN_WRITES`) |
-| `admin.directory.group.readonly` | Read groups |
-| `admin.directory.group.member.readonly` | Read group members |
-
-## Project Structure
-
-```
-mcp-google-multi/
-├── src/
-│   ├── index.ts          # Entry point: MCP server or auth CLI
-│   ├── accounts.ts       # Account config parser (reads from .env)
-│   ├── auth.ts           # Scope tier resolution + OAuth flow
-│   ├── client.ts         # OAuth2Client factory with auto-refresh
-│   ├── types.ts          # Shared TypeScript types
-│   └── tools/
-│       ├── _errors.ts          # Shared googleapis error → MCP response mapper
-│       ├── gmail.ts            # Gmail (21)
-│       ├── drive.ts            # Drive (35)
-│       ├── calendar.ts         # Calendar (11)
-│       ├── sheets.ts           # Sheets (29)
-│       ├── docs.ts             # Docs (27)
-│       ├── contacts.ts         # Contacts (9)
-│       ├── searchconsole.ts    # Search Console (10)
-│       ├── tasks.ts            # Tasks (12) — v4
-│       ├── meet.ts             # Meet (5) — v4
-│       ├── forms.ts            # Forms (4, optional) — v4
-│       ├── chat.ts             # Chat (4, optional) — v4
-│       └── admin.ts            # Admin SDK (6, admin) + Alert Center (2, alertcenter bundle) — v4
-├── tests/                # vitest unit tests (gmail-mime, path-safety, field-mask helpers)
-├── tokens/               # OAuth tokens per account (gitignored)
-├── dist/                 # Compiled output (gitignored)
-├── .env                  # Your credentials (gitignored)
-├── .env.example          # Template for .env
-├── CHANGELOG.md
-├── CLAUDE.md             # Conventions for AI assistants working on this codebase
-├── package.json
-├── tsconfig.json
-└── LICENSE
-```
-
-## Troubleshooting
-
-**"GOOGLE_ACCOUNTS is not set"** — Make sure your `.env` file exists in the project root and has the `GOOGLE_ACCOUNTS` variable set.
-
-**"No token file found for account X"** — Run `npm run auth -- <alias>` to authenticate that account.
-
-**"Port 4242 is already in use"** — Another process is using port 4242. Close it and retry the auth flow.
-
-**Token refresh errors** — Delete the token file at `tokens/<alias>/token.json` and re-authenticate.
-
-**Tasks / Meet tools return 403 after upgrading from v3** — You haven't re-authed since the base scope set grew. Run `npm run auth -- <alias>` for every account.
-
-**`forms_*` or `chat_*` tools missing from the tool list** — They're only registered when `GOOGLE_OPTIONAL_SCOPES` includes their bundle key. Set `GOOGLE_OPTIONAL_SCOPES=forms,chat` (or one of them) in `.env`, rebuild, and re-auth the accounts that need them.
-
-**Admin tools missing or returning 403** — Admin tools only register if `GOOGLE_ADMIN_ACCOUNTS` is set. The listed accounts must be Workspace super-admins, and you must re-auth them after adding the env var so the new scopes are granted. `admin_users_update` additionally requires `GOOGLE_ALLOW_ADMIN_WRITES=true`.
+Maintainer-led. Direction is tracked publicly as **[GitHub Milestones](https://github.com/bakissation/mcp-google-multi/milestones)** (discover-first tooling → exhaustive API coverage → service accounts + hosting in v6). Not accepting unsolicited feature PRs; bug reports are welcome.
 
 ## Contributing
 
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) first. In short: **open pull requests against the `dev` branch** — changes are promoted `dev → staging → main`, and `main` is release-only. Run `typecheck`/`lint`/`test`/`build` before submitting, and use Conventional Commits.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md). Security issues go to [SECURITY.md](./SECURITY.md), never a public issue.
 
-By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). For security issues, **do not open a public issue** — see [SECURITY.md](SECURITY.md).
+## Credits
 
-## Author
+Built and maintained by **Abdelbaki Berkati** — [berkati.xyz](https://berkati.xyz) · [@bakissation](https://github.com/bakissation). [Read the case study →](https://berkati.xyz/case-studies/mcp-google-multi/)
 
-**Abdelbaki Berkati** — [berkati.xyz](https://berkati.xyz) · [@bakissation](https://github.com/bakissation)
-
-[Read the case study →](https://berkati.xyz/case-studies/mcp-google-multi/)
+Sponsored by **[IdeaCrafters](https://ideacrafters.com)** ([@IdeaCraftersHQ](https://github.com/IdeaCraftersHQ)).
 
 ## License
 
-[MIT](LICENSE)
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A **local** [MCP](https://modelcontextprotocol.io) server that gives Claude Code
 
 [![npm](https://img.shields.io/npm/v/mcp-google-multi?label=npm&color=cb3837)](https://www.npmjs.com/package/mcp-google-multi)
 
+> Open-source and **funded by [IdeaCrafters](https://github.com/IdeaCraftersHQ)** — the studio that pays for its development and upkeep.
+
 - 🔑 **Multi-account** — drive any number of your Google accounts from one server, each by a short alias.
 - 🔒 **Secure by default** — refresh tokens **encrypted at rest** (AES-256-GCM); **writes are deny-by-default**; no telemetry — it talks only to Google.
 - 📦 **npm-first** — install and run with `npx`; everything configured through env vars.
@@ -120,7 +122,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CON
 
 Built and maintained by **Abdelbaki Berkati** — [berkati.xyz](https://berkati.xyz) · [@bakissation](https://github.com/bakissation). [Read the case study →](https://berkati.xyz/case-studies/mcp-google-multi/)
 
-Sponsored by **[IdeaCrafters](https://ideacrafters.com)** ([@IdeaCraftersHQ](https://github.com/IdeaCraftersHQ)).
+Development is **funded by [IdeaCrafters](https://ideacrafters.com)** ([@IdeaCraftersHQ](https://github.com/IdeaCraftersHQ)) — the studio that pays for this OSS to exist.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ You'll get an acknowledgement and can track the fix in the private advisory. Onc
 
 This server brokers OAuth access to Google accounts — Gmail, Drive, Calendar, and (when enabled) Workspace **Admin SDK** scopes. A vulnerability could expose mail, files, or directory data. Of particular interest:
 
-- **Token handling** — tokens live under `tokens/<alias>/token.json` (mode `0600`) and must never be logged or transmitted.
+- **Token handling** — refresh tokens are **AES-256-GCM encrypted at rest** (`~/.config/mcp-google-multi/tokens/<alias>.enc`, mode `0600`) with a key derived from `MASTER_KEY`; tokens must never be logged or transmitted, and `MASTER_KEY` must never be committed or logged. Error payloads carry only `message` + code — never raw error objects (which can hold the `Authorization` header).
 - **Header / MIME construction** — Gmail tools build raw RFC 5322 messages; injection (e.g. CRLF in headers) is in scope.
 - **Scope escalation** — anything that grants an account scopes it didn't consent to.
 
@@ -31,4 +31,4 @@ This server brokers OAuth access to Google accounts — Gmail, Drive, Calendar, 
 
 ## Good hygiene for everyone
 
-Never paste OAuth tokens, client secrets, authorization codes, or `.env` contents into issues, PRs, or logs.
+Never paste OAuth tokens, client secrets, `MASTER_KEY`, authorization codes, or `.env` contents into issues, PRs, or logs.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "prepublishOnly": "npm run build",
     "watch": "tsc --watch",
     "auth": "node dist/index.js auth --account",
+    "migrate-tokens": "node dist/index.js migrate-tokens",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-google-multi",
   "version": "0.0.0-semantically-released",
-  "description": "MCP server for Gmail, Google Drive, Calendar, Sheets, Docs, and Contacts with multi-account support",
+  "description": "Local MCP server for Google Workspace (Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console, +Forms/Chat/Admin) across multiple accounts — OAuth-only, encrypted token storage, deny-by-default writes.",
   "type": "module",
   "license": "MIT",
   "bin": {
@@ -36,6 +36,12 @@
     "google-sheets",
     "google-docs",
     "google-contacts",
+    "google-workspace",
+    "google-tasks",
+    "google-meet",
+    "search-console",
+    "oauth",
+    "mcp-server",
     "claude",
     "claude-code"
   ],

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -5,11 +5,14 @@ import path from 'node:path';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
-const tokenDir = path.resolve(__dirname, '..', 'tokens');
+const tokenDir = process.env.TOKEN_STORE_PATH
+  ? path.resolve(process.env.TOKEN_STORE_PATH)
+  : path.resolve(__dirname, '..', 'tokens');
 
 export interface AccountConfig {
   email: string;
   tokenPath: string;
+  encPath: string;
 }
 
 /**
@@ -61,6 +64,7 @@ function parseAccounts(): { aliases: [string, ...string[]]; configs: Record<stri
     configs[alias] = {
       email,
       tokenPath: path.join(tokenDir, alias, 'token.json'),
+      encPath: path.join(tokenDir, `${alias}.enc`),
     };
   }
 

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,13 +1,21 @@
 import dotenv from 'dotenv';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { homedir } from 'node:os';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+dotenv.config();
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+const defaultTokenDir = path.join(
+  process.env.XDG_CONFIG_HOME || path.join(homedir(), '.config'),
+  'mcp-google-multi',
+  'tokens',
+);
 const tokenDir = process.env.TOKEN_STORE_PATH
   ? path.resolve(process.env.TOKEN_STORE_PATH)
-  : path.resolve(__dirname, '..', 'tokens');
+  : defaultTokenDir;
 
 export interface AccountConfig {
   email: string;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,11 +2,10 @@ import { google } from 'googleapis';
 import http from 'node:http';
 import { URL } from 'node:url';
 import { randomBytes } from 'node:crypto';
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import open from 'open';
 import destroyer from 'server-destroy';
 import { ACCOUNTS, ACCOUNT_CONFIG } from './accounts.js';
+import { writeToken } from './token-store.js';
 
 // ─── Scope tiers ────────────────────────────────────────────────────────
 //
@@ -114,6 +113,13 @@ export async function runAuthFlow(args: string[]): Promise<void> {
   const config = ACCOUNT_CONFIG[alias];
   const scopes = resolveScopesForAccount(alias);
 
+  if (!process.env.MASTER_KEY) {
+    console.error(
+      'MASTER_KEY is not set. Generate one (openssl rand -base64 32) and add it to .env before authenticating.',
+    );
+    process.exit(1);
+  }
+
   const oauth2Client = new google.auth.OAuth2(
     process.env.GOOGLE_CLIENT_ID,
     process.env.GOOGLE_CLIENT_SECRET,
@@ -174,13 +180,7 @@ export async function runAuthFlow(args: string[]): Promise<void> {
 
             const { tokens } = await oauth2Client.getToken(code);
 
-            await fs.mkdir(path.dirname(config.tokenPath), { recursive: true });
-            // 0o600: tokens grant full account access; keep them user-only.
-            await fs.writeFile(
-              config.tokenPath,
-              JSON.stringify(tokens, null, 2),
-              { mode: 0o600 },
-            );
+            writeToken(alias, tokens);
 
             res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end(
@@ -188,7 +188,7 @@ export async function runAuthFlow(args: string[]): Promise<void> {
             );
             (server as any).destroy();
 
-            console.log(`Token saved to ${config.tokenPath}`);
+            console.log(`Token saved (encrypted) for ${alias}.`);
             resolve();
           }
         } catch (e) {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -39,13 +39,6 @@ export const OPTIONAL_SCOPE_BUNDLES: Record<string, string[]> = {
     'https://www.googleapis.com/auth/chat.messages',
     'https://www.googleapis.com/auth/chat.messages.create',
   ],
-  // Alert Center's apps.alerts scope is NOT grantable through the interactive
-  // user-consent flow this server uses — it requires a service account with
-  // domain-wide delegation. It lives in its own opt-in bundle so it never
-  // blocks the working Admin SDK admin scopes. See README "Alert Center".
-  alertcenter: [
-    'https://www.googleapis.com/auth/apps.alerts',
-  ],
 };
 
 export const ADMIN_SCOPES = [
@@ -91,10 +84,6 @@ export function resolveScopesForAccount(alias: string): string[] {
   return Array.from(new Set(scopes));
 }
 
-/** True if admin writes are explicitly enabled. Default refuses to prevent accidents on small orgs. */
-export function adminWritesEnabled(): boolean {
-  return process.env.GOOGLE_ALLOW_ADMIN_WRITES === 'true';
-}
 
 export async function runAuthFlow(args: string[]): Promise<void> {
   const accountIdx = args.indexOf('--account');

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,7 @@
 import { google } from 'googleapis';
-import fs from 'node:fs/promises';
 import { ACCOUNT_CONFIG } from './accounts.js';
 import type { Account } from './accounts.js';
-import type { TokenData } from './types.js';
+import { readToken, writeToken } from './token-store.js';
 
 export async function getClient(account: Account) {
   const config = ACCOUNT_CONFIG[account];
@@ -20,30 +19,19 @@ export async function getClient(account: Account) {
     'http://localhost:4242/oauth2callback',
   );
 
-  let tokenData: TokenData;
-  try {
-    const raw = await fs.readFile(config.tokenPath, 'utf-8');
-    tokenData = JSON.parse(raw);
-  } catch {
+  const tokenData = readToken(account);
+  if (!tokenData) {
     throw new Error(
-      `No token file found for account "${account}" at ${config.tokenPath}. ` +
-        `Run: node dist/index.js auth --account ${account}`,
+      `No token found for account "${account}" (${config.email}). ` +
+        `Run: npx mcp-google-multi auth --account ${account}`,
     );
   }
 
   oauth2Client.setCredentials(tokenData);
 
-  // 0o600: tokens grant full account access; keep them user-only.
-  oauth2Client.on('tokens', async (tokens) => {
-    try {
-      const existing = JSON.parse(
-        await fs.readFile(config.tokenPath, 'utf-8'),
-      );
-      const merged = { ...existing, ...tokens };
-      await fs.writeFile(config.tokenPath, JSON.stringify(merged, null, 2), { mode: 0o600 });
-    } catch {
-      await fs.writeFile(config.tokenPath, JSON.stringify(tokens, null, 2), { mode: 0o600 });
-    }
+  oauth2Client.on('tokens', (tokens) => {
+    const existing = readToken(account) ?? {};
+    writeToken(account, { ...existing, ...tokens });
   });
 
   return oauth2Client;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,29 +20,13 @@ import { registerChatTools } from './tools/chat.js';
 import { registerAdminTools, registerAlertCenterTools } from './tools/admin.js';
 import { getOptionalBundles, getAdminAccounts } from './auth.js';
 import { ToolRegistry } from './registry.js';
+import { resolvePolicy, isAllowed, describePolicy, type Policy } from './write-control.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'));
 
-async function main() {
-  if (process.argv.includes('auth')) {
-    const { runAuthFlow } = await import('./auth.js');
-    await runAuthFlow(process.argv);
-    return;
-  }
-
-  if (process.argv.includes('migrate-tokens')) {
-    const { runMigrateTokens } = await import('./migrate-tokens.js');
-    runMigrateTokens();
-    return;
-  }
-
-  // MCP server mode — no console.log (stdio is the MCP channel)
-  const server = new McpServer({
-    name: 'mcp-google-multi',
-    version: pkg.version,
-  });
-  const registry = new ToolRegistry(server);
+function buildRegistry(server: McpServer, policy: Policy): ToolRegistry {
+  const registry = new ToolRegistry(server, policy);
   registerGmailTools(registry);
   registerDriveTools(registry);
   registerCalendarTools(registry);
@@ -57,6 +41,42 @@ async function main() {
   if (optional.has('chat')) registerChatTools(registry);
   if (optional.has('alertcenter')) registerAlertCenterTools(registry);
   if (getAdminAccounts().length > 0) registerAdminTools(registry);
+  return registry;
+}
+
+async function main() {
+  if (process.argv.includes('auth')) {
+    const { runAuthFlow } = await import('./auth.js');
+    await runAuthFlow(process.argv);
+    return;
+  }
+
+  if (process.argv.includes('migrate-tokens')) {
+    const { runMigrateTokens } = await import('./migrate-tokens.js');
+    runMigrateTokens();
+    return;
+  }
+
+  if (process.argv.includes('config') && process.argv.includes('check')) {
+    const policy = resolvePolicy();
+    const registry = buildRegistry(
+      new McpServer({ name: 'mcp-google-multi', version: pkg.version }),
+      policy,
+    );
+    const cud = registry.tools.filter((t) => t.cud !== 'read');
+    const disabled = cud.filter((t) => !isAllowed(t, policy));
+    console.log(`Write-control: ${describePolicy(policy)}`);
+    console.log(`CUD tools enabled: ${cud.length - disabled.length}/${cud.length}`);
+    console.log(`Disabled: ${disabled.map((t) => t.name).join(', ') || '(none)'}`);
+    return;
+  }
+
+  const policy = resolvePolicy();
+  const server = new McpServer({
+    name: 'mcp-google-multi',
+    version: pkg.version,
+  });
+  buildRegistry(server, policy);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import { registerTasksTools } from './tools/tasks.js';
 import { registerMeetTools } from './tools/meet.js';
 import { registerFormsTools } from './tools/forms.js';
 import { registerChatTools } from './tools/chat.js';
-import { registerAdminTools, registerAlertCenterTools } from './tools/admin.js';
+import { registerAdminTools } from './tools/admin.js';
 import { getOptionalBundles, getAdminAccounts } from './auth.js';
 import { ToolRegistry } from './registry.js';
 import { resolvePolicy, isAllowed, describePolicy, type Policy } from './write-control.js';
@@ -39,7 +39,6 @@ function buildRegistry(server: McpServer, policy: Policy): ToolRegistry {
   const optional = new Set(getOptionalBundles());
   if (optional.has('forms')) registerFormsTools(registry);
   if (optional.has('chat')) registerChatTools(registry);
-  if (optional.has('alertcenter')) registerAlertCenterTools(registry);
   if (getAdminAccounts().length > 0) registerAdminTools(registry);
   return registry;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { registerFormsTools } from './tools/forms.js';
 import { registerChatTools } from './tools/chat.js';
 import { registerAdminTools, registerAlertCenterTools } from './tools/admin.js';
 import { getOptionalBundles, getAdminAccounts } from './auth.js';
+import { ToolRegistry } from './registry.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'));
@@ -41,20 +42,21 @@ async function main() {
     name: 'mcp-google-multi',
     version: pkg.version,
   });
-  registerGmailTools(server);
-  registerDriveTools(server);
-  registerCalendarTools(server);
-  registerSheetsTools(server);
-  registerDocsTools(server);
-  registerContactsTools(server);
-  registerSearchConsoleTools(server);
-  registerTasksTools(server);
-  registerMeetTools(server);
+  const registry = new ToolRegistry(server);
+  registerGmailTools(registry);
+  registerDriveTools(registry);
+  registerCalendarTools(registry);
+  registerSheetsTools(registry);
+  registerDocsTools(registry);
+  registerContactsTools(registry);
+  registerSearchConsoleTools(registry);
+  registerTasksTools(registry);
+  registerMeetTools(registry);
   const optional = new Set(getOptionalBundles());
-  if (optional.has('forms')) registerFormsTools(server);
-  if (optional.has('chat')) registerChatTools(server);
-  if (optional.has('alertcenter')) registerAlertCenterTools(server);
-  if (getAdminAccounts().length > 0) registerAdminTools(server);
+  if (optional.has('forms')) registerFormsTools(registry);
+  if (optional.has('chat')) registerChatTools(registry);
+  if (optional.has('alertcenter')) registerAlertCenterTools(registry);
+  if (getAdminAccounts().length > 0) registerAdminTools(registry);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,12 @@ async function main() {
     return;
   }
 
+  if (process.argv.includes('migrate-tokens')) {
+    const { runMigrateTokens } = await import('./migrate-tokens.js');
+    runMigrateTokens();
+    return;
+  }
+
   // MCP server mode — no console.log (stdio is the MCP channel)
   const server = new McpServer({
     name: 'mcp-google-multi',

--- a/src/migrate-tokens.ts
+++ b/src/migrate-tokens.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import { ACCOUNTS, ACCOUNT_CONFIG } from './accounts.js';
+import { writeToken, hasToken } from './token-store.js';
+
+export function runMigrateTokens(): void {
+  let migrated = 0;
+  let skipped = 0;
+  for (const alias of ACCOUNTS) {
+    const plain = ACCOUNT_CONFIG[alias].tokenPath;
+    if (!fs.existsSync(plain)) continue;
+    if (hasToken(alias)) {
+      console.log(`• ${alias}: encrypted token already exists, skipping`);
+      skipped++;
+      continue;
+    }
+    writeToken(alias, JSON.parse(fs.readFileSync(plain, 'utf8')));
+    console.log(`✓ ${alias}: migrated ${plain} → encrypted store`);
+    migrated++;
+  }
+  console.log(
+    `Done. ${migrated} migrated, ${skipped} skipped. ` +
+      'Delete the plaintext tokens/<alias>/token.json once verified.',
+  );
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,39 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export type Cud = 'read' | 'create' | 'update' | 'delete';
+
+export interface ToolEntry {
+  name: string;
+  service: string;
+  cud: Cud;
+}
+
+const CUD_OVERRIDES: Record<string, Cud> = {
+  drive_untrash: 'update',
+};
+
+const DELETE_VERB = /(^|_)(delete|remove|trash|clear|empty)(_|$)/;
+const CREATE_VERB = /(^|_)(create|add|insert|send|upload|copy|import|append|submit|duplicate|share|quick)(_|$)/;
+const UPDATE_VERB = /(^|_)(update|patch|modify|set|move|write|format|merge|unmerge|sort|replace|resize|publish|resolve)(_|$)/;
+
+export function inferCud(name: string): Cud {
+  const override = CUD_OVERRIDES[name];
+  if (override) return override;
+  if (DELETE_VERB.test(name)) return 'delete';
+  if (CREATE_VERB.test(name)) return 'create';
+  if (UPDATE_VERB.test(name)) return 'update';
+  return 'read';
+}
+
+export class ToolRegistry {
+  readonly tools: ToolEntry[] = [];
+  readonly registerTool: McpServer['registerTool'];
+
+  constructor(server: McpServer) {
+    this.registerTool = ((name: string, ...rest: unknown[]) => {
+      const service = name.includes('_') ? name.slice(0, name.indexOf('_')) : name;
+      this.tools.push({ name, service, cud: inferCud(name) });
+      return (server.registerTool as (...args: unknown[]) => unknown)(name, ...rest);
+    }) as McpServer['registerTool'];
+  }
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { type Policy, isAllowed, writeDisabledResult } from './write-control.js';
 
 export type Cud = 'read' | 'create' | 'update' | 'delete';
 
@@ -29,11 +30,19 @@ export class ToolRegistry {
   readonly tools: ToolEntry[] = [];
   readonly registerTool: McpServer['registerTool'];
 
-  constructor(server: McpServer) {
-    this.registerTool = ((name: string, ...rest: unknown[]) => {
+  constructor(server: McpServer, policy: Policy) {
+    this.registerTool = ((name: string, config: unknown, handler: (...a: unknown[]) => unknown) => {
       const service = name.includes('_') ? name.slice(0, name.indexOf('_')) : name;
-      this.tools.push({ name, service, cud: inferCud(name) });
-      return (server.registerTool as (...args: unknown[]) => unknown)(name, ...rest);
+      const cud = inferCud(name);
+      this.tools.push({ name, service, cud });
+      const guarded =
+        cud === 'read'
+          ? handler
+          : (...args: unknown[]) =>
+              isAllowed({ name, service, cud }, policy)
+                ? handler(...args)
+                : writeDisabledResult({ name, service, cud }, policy);
+      return (server.registerTool as (...a: unknown[]) => unknown)(name, config, guarded);
     }) as McpServer['registerTool'];
   }
 }

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -1,0 +1,82 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { ACCOUNT_CONFIG } from './accounts.js';
+import type { TokenData } from './types.js';
+
+const ENC_VERSION = 1;
+const ALGO = 'aes-256-gcm';
+
+interface EncFile {
+  v: number;
+  iv: string;
+  tag: string;
+  data: string;
+}
+
+export function deriveKey(masterKey: string): Buffer {
+  if (!masterKey) {
+    throw new Error(
+      'MASTER_KEY is required to encrypt/decrypt tokens. Generate one with: openssl rand -base64 32',
+    );
+  }
+  const raw = Buffer.from(masterKey, 'base64');
+  if (raw.length === 32) return raw;
+  return createHash('sha256').update(masterKey, 'utf8').digest();
+}
+
+export function encryptToken(data: object, masterKey: string): string {
+  const key = deriveKey(masterKey);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv(ALGO, key, iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(Buffer.from(JSON.stringify(data), 'utf8')),
+    cipher.final(),
+  ]);
+  const file: EncFile = {
+    v: ENC_VERSION,
+    iv: iv.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64'),
+    data: ciphertext.toString('base64'),
+  };
+  return JSON.stringify(file);
+}
+
+export function decryptToken(fileContents: string, masterKey: string): TokenData {
+  const key = deriveKey(masterKey);
+  const file = JSON.parse(fileContents) as EncFile;
+  if (file.v !== ENC_VERSION) {
+    throw new Error(`Unsupported token file version: ${file.v}`);
+  }
+  const decipher = createDecipheriv(ALGO, key, Buffer.from(file.iv, 'base64'));
+  decipher.setAuthTag(Buffer.from(file.tag, 'base64'));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(file.data, 'base64')),
+    decipher.final(),
+  ]);
+  return JSON.parse(plaintext.toString('utf8')) as TokenData;
+}
+
+function masterKey(): string {
+  return process.env.MASTER_KEY ?? '';
+}
+
+export function readToken(alias: string): TokenData | null {
+  let contents: string;
+  try {
+    contents = fs.readFileSync(ACCOUNT_CONFIG[alias].encPath, 'utf8');
+  } catch {
+    return null;
+  }
+  return decryptToken(contents, masterKey());
+}
+
+export function writeToken(alias: string, data: object): void {
+  const p = ACCOUNT_CONFIG[alias].encPath;
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, encryptToken(data, masterKey()), { mode: 0o600 });
+}
+
+export function hasToken(alias: string): boolean {
+  return fs.existsSync(ACCOUNT_CONFIG[alias].encPath);
+}

--- a/src/tools/_coerce.ts
+++ b/src/tools/_coerce.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+function parseJsonLoose(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}
+
+export function coerceArray<T extends z.ZodTypeAny>(element: T) {
+  return z.preprocess((val) => {
+    if (typeof val !== 'string') return val;
+    const t = val.trim();
+    if (t === '') return [];
+    if (t.startsWith('[')) return parseJsonLoose(t);
+    return t.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+  }, z.array(element));
+}
+
+export function coerceJson<T extends z.ZodTypeAny>(schema: T) {
+  return z.preprocess((val) => (typeof val === 'string' ? parseJsonLoose(val) : val), schema);
+}
+
+export const coerceBoolean = z.preprocess((val) => {
+  if (typeof val === 'boolean') return val;
+  if (typeof val === 'string') {
+    const t = val.trim().toLowerCase();
+    if (['true', '1', 'yes', 'y'].includes(t)) return true;
+    if (['false', '0', 'no', 'n'].includes(t)) return false;
+  }
+  return val;
+}, z.boolean());

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -1,44 +1,91 @@
 import type { Account } from '../accounts.js';
 
-/** Maps googleapis errors to MCP tool responses. 401 → re-auth instruction; 403 + hint → structured hint payload; 429 → retry-after; else → {error, code}. */
+export interface ErrorEnvelope {
+  error: string;
+  message: string;
+  hint?: string;
+  retriable: boolean;
+  account: string;
+}
+
+function statusOf(error: any): number | undefined {
+  const c = error?.code ?? error?.status ?? error?.response?.status;
+  const n = typeof c === 'string' ? Number(c) : c;
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function reasonOf(error: any): string | undefined {
+  return (
+    error?.errors?.[0]?.reason ??
+    error?.response?.data?.error?.errors?.[0]?.reason ??
+    error?.response?.data?.error?.status
+  );
+}
+
+function messageOf(error: any): string {
+  return error?.response?.data?.error?.message ?? error?.message ?? String(error);
+}
+
+export function mapGoogleError(
+  error: any,
+  account: Account,
+  forbiddenHint?: string,
+): ErrorEnvelope {
+  const status = statusOf(error);
+  const reason = reasonOf(error);
+  const message = messageOf(error);
+
+  if (status === 401) {
+    return {
+      error: 'auth_required',
+      message: `Authentication failed for account "${account}".`,
+      hint: `Run: npx mcp-google-multi auth --account ${account}`,
+      retriable: false,
+      account,
+    };
+  }
+  if (status === 403) {
+    const scopeIssue =
+      reason === 'insufficientPermissions' ||
+      reason === 'ACCESS_TOKEN_SCOPE_INSUFFICIENT' ||
+      /insufficient.*scope/i.test(message);
+    if (scopeIssue) {
+      return {
+        error: 'insufficient_scope',
+        message,
+        hint: forbiddenHint ?? `Re-auth "${account}" with the scope this operation needs.`,
+        retriable: false,
+        account,
+      };
+    }
+    return { error: 'forbidden', message, hint: forbiddenHint, retriable: false, account };
+  }
+  if (status === 400 && /invalid[_ ]scope/i.test(message)) {
+    return { error: 'invalid_scope', message, retriable: false, account };
+  }
+  if (status === 404) {
+    return { error: 'not_found', message, retriable: false, account };
+  }
+  if (status === 429) {
+    const retryAfter = error?.response?.headers?.['retry-after'];
+    return {
+      error: 'rate_limited',
+      message,
+      hint: retryAfter ? `Retry after ${retryAfter}s.` : 'Back off and retry.',
+      retriable: true,
+      account,
+    };
+  }
+  if (status !== undefined && status >= 500) {
+    return { error: 'upstream_error', message, retriable: true, account };
+  }
+  return { error: 'upstream_error', message, retriable: false, account };
+}
+
 export function handleGoogleApiError(error: any, account: Account, forbiddenHint?: string) {
-  if (error.code === 401) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: `Authentication error for account "${account}". Run: node dist/index.js auth --account ${account}`,
-      }],
-      isError: true as const,
-    };
-  }
-  if (error.code === 403 && forbiddenHint) {
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({
-          error: 'forbidden',
-          hint: forbiddenHint,
-          original: error.message ?? String(error),
-        }),
-      }],
-      isError: true as const,
-    };
-  }
-  if (error.code === 429) {
-    const retryAfter = error.response?.headers?.['retry-after'] ?? 'unknown';
-    return {
-      content: [{
-        type: 'text' as const,
-        text: JSON.stringify({ error: 'rate_limited', retryAfter }),
-      }],
-      isError: true as const,
-    };
-  }
+  const envelope = mapGoogleError(error, account, forbiddenHint);
   return {
-    content: [{
-      type: 'text' as const,
-      text: JSON.stringify({ error: error.message ?? String(error), code: error.code }),
-    }],
+    content: [{ type: 'text' as const, text: JSON.stringify(envelope) }],
     isError: true as const,
   };
 }

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
@@ -17,7 +17,7 @@ const accountEnum = z.enum(ACCOUNTS);
  * Writes are gated behind GOOGLE_ALLOW_ADMIN_WRITES=true to prevent accidents on small orgs
  * (a stray users.update on a 3-person Workspace is a bad day).
  */
-export function registerAdminTools(server: McpServer): void {
+export function registerAdminTools(server: ToolRegistry): void {
   // ─── Reports / audit log ───────────────────────────────────────────────
 
   server.registerTool(
@@ -276,7 +276,7 @@ export function registerAdminTools(server: McpServer): void {
  * domain-wide delegation. Registered separately so a missing/ungrantable
  * apps.alerts scope never blocks the working Admin SDK admin tools.
  */
-export function registerAlertCenterTools(server: McpServer): void {
+export function registerAlertCenterTools(server: ToolRegistry): void {
   server.registerTool(
     'alertcenter_alerts_list',
     {

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -6,7 +6,6 @@ import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
-import { adminWritesEnabled } from '../auth.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
@@ -14,8 +13,7 @@ const accountEnum = z.enum(ACCOUNTS);
  * Admin SDK tools require Workspace super-admin (or delegated admin) privileges on the target account.
  * Personal `@gmail.com` accounts will 403 on every endpoint.
  *
- * Writes are gated behind GOOGLE_ALLOW_ADMIN_WRITES=true to prevent accidents on small orgs
- * (a stray users.update on a 3-person Workspace is a bad day).
+ * Writes (e.g. admin_users_update) are gated by write-control like any CUD tool.
  */
 export function registerAdminTools(server: ToolRegistry): void {
   // ─── Reports / audit log ───────────────────────────────────────────────
@@ -145,7 +143,7 @@ export function registerAdminTools(server: ToolRegistry): void {
   server.registerTool(
     'admin_users_update',
     {
-      description: 'Update a Workspace user (PATCH semantics). GATED: requires GOOGLE_ALLOW_ADMIN_WRITES=true to prevent accidental destructive ops on small orgs.',
+      description: 'Update a Workspace user (PATCH semantics). Gated by write-control (a CUD tool).',
       inputSchema: {
         account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
         userKey: z.string().describe('User email or ID'),
@@ -159,18 +157,6 @@ export function registerAdminTools(server: ToolRegistry): void {
     },
     async ({ account, userKey, givenName, familyName, suspended, password, changePasswordAtNextLogin, orgUnitPath }) => {
       try {
-        if (!adminWritesEnabled()) {
-          return {
-            content: [{
-              type: 'text' as const,
-              text: JSON.stringify({
-                error: 'admin_writes_disabled',
-                hint: 'Admin write operations are disabled by default. Set GOOGLE_ALLOW_ADMIN_WRITES=true in .env and restart to enable.',
-              }),
-            }],
-            isError: true,
-          };
-        }
         const auth = await getClient(account as Account);
         const directory = google.admin({ version: 'directory_v1', auth });
         const requestBody: any = {};
@@ -269,76 +255,6 @@ export function registerAdminTools(server: ToolRegistry): void {
   );
 }
 
-/**
- * Alert Center tools. Gated behind the `alertcenter` optional bundle, NOT the
- * admin bundle: the apps.alerts scope cannot be granted via this server's
- * interactive user-consent OAuth flow — it requires a service account with
- * domain-wide delegation. Registered separately so a missing/ungrantable
- * apps.alerts scope never blocks the working Admin SDK admin tools.
- */
-export function registerAlertCenterTools(server: ToolRegistry): void {
-  server.registerTool(
-    'alertcenter_alerts_list',
-    {
-      description: 'List Workspace security alerts (suspicious login, phishing, leaked password, Drive exfil, etc.). Requires the alertcenter bundle + service-account domain-wide delegation.',
-      inputSchema: {
-        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
-        pageSize: z.number().min(1).max(1000).optional(),
-        pageToken: z.string().optional(),
-        filter: z.string().optional().describe('Filter expression, e.g. "type = \\"Suspicious login\\""'),
-        orderBy: z.string().optional(),
-        customerId: z.string().optional(),
-      },
-    },
-    async ({ account, pageSize, pageToken, filter, orderBy, customerId }) => {
-      try {
-        const auth = await getClient(account as Account);
-        const alertcenter = google.alertcenter({ version: 'v1beta1', auth });
-        const res = await alertcenter.alerts.list({
-          pageSize: pageSize ?? 50,
-          pageToken,
-          filter,
-          orderBy,
-          customerId,
-        });
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
-        };
-      } catch (error: any) {
-        return handleAlertCenterError(error, account as Account);
-      }
-    },
-  );
-
-  server.registerTool(
-    'alertcenter_alert_get',
-    {
-      description: 'Get a single alert by ID. Requires the alertcenter bundle + service-account domain-wide delegation.',
-      inputSchema: {
-        account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
-        alertId: z.string().describe('Alert ID'),
-        customerId: z.string().optional(),
-      },
-    },
-    async ({ account, alertId, customerId }) => {
-      try {
-        const auth = await getClient(account as Account);
-        const alertcenter = google.alertcenter({ version: 'v1beta1', auth });
-        const res = await alertcenter.alerts.get({ alertId, customerId });
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
-        };
-      } catch (error: any) {
-        return handleAlertCenterError(error, account as Account);
-      }
-    },
-  );
-}
-
 function handleAdminError(error: any, account: Account) {
   return handleGoogleApiError(error, account, "Admin tools require Workspace super-admin privileges AND the account must be listed in GOOGLE_ADMIN_ACCOUNTS (then re-authenticated). Personal Gmail accounts cannot use these endpoints.");
-}
-
-function handleAlertCenterError(error: any, account: Account) {
-  return handleGoogleApiError(error, account, "Alert Center (apps.alerts) is not grantable via this server's user-consent OAuth flow — it requires a service account with domain-wide delegation. Enabling GOOGLE_OPTIONAL_SCOPES=alertcenter only declares the scope; the API will reject user-OAuth tokens. See README \"Alert Center\".");
 }

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -87,7 +88,7 @@ export function registerAdminTools(server: McpServer): void {
         maxResults: z.number().min(1).max(500).optional(),
         pageToken: z.string().optional(),
         orderBy: z.enum(['email', 'familyName', 'givenName']).optional(),
-        showDeleted: z.boolean().optional(),
+        showDeleted: coerceBoolean.optional(),
         projection: z.enum(['basic', 'custom', 'full']).optional(),
       },
     },
@@ -150,9 +151,9 @@ export function registerAdminTools(server: McpServer): void {
         userKey: z.string().describe('User email or ID'),
         givenName: z.string().optional(),
         familyName: z.string().optional(),
-        suspended: z.boolean().optional(),
+        suspended: coerceBoolean.optional(),
         password: z.string().optional(),
-        changePasswordAtNextLogin: z.boolean().optional(),
+        changePasswordAtNextLogin: coerceBoolean.optional(),
         orgUnitPath: z.string().optional(),
       },
     },
@@ -242,7 +243,7 @@ export function registerAdminTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias (must be a Workspace admin)'),
         groupKey: z.string().describe('Group email or ID'),
         roles: z.string().optional().describe('Comma-separated roles to include (OWNER, MANAGER, MEMBER)'),
-        includeDerivedMembership: z.boolean().optional(),
+        includeDerivedMembership: coerceBoolean.optional(),
         maxResults: z.number().min(1).max(200).optional(),
         pageToken: z.string().optional(),
       },

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -134,7 +135,7 @@ export function registerCalendarTools(server: McpServer): void {
           .describe('Comma-separated email addresses of attendees'),
         calendarId: z.string().default('primary').optional()
           .describe('Calendar ID (default: primary)'),
-        allDay: z.boolean().default(false).optional()
+        allDay: coerceBoolean.default(false).optional()
           .describe('If true, start/end are dates (YYYY-MM-DD) not datetimes'),
       },
     },
@@ -280,7 +281,7 @@ export function registerCalendarTools(server: McpServer): void {
         calendarId: z.string().default('primary').optional()
           .describe('Calendar ID (default: primary)'),
         text: z.string().describe('Natural language event, e.g. "Lunch with Farouk Thursday 1pm at Le Boulanger"'),
-        sendNotifications: z.boolean().optional().describe('Send notifications to attendees (default: false)'),
+        sendNotifications: coerceBoolean.optional().describe('Send notifications to attendees (default: false)'),
       },
     },
     async ({ account, calendarId, text, sendNotifications }) => {
@@ -310,7 +311,7 @@ export function registerCalendarTools(server: McpServer): void {
         calendarId: z.string().describe('Source calendar ID'),
         eventId: z.string().describe('Event ID to move'),
         destinationCalendarId: z.string().describe('Destination calendar ID'),
-        sendNotifications: z.boolean().optional().describe('Send notifications (default: false)'),
+        sendNotifications: coerceBoolean.optional().describe('Send notifications (default: false)'),
       },
     },
     async ({ account, calendarId, eventId, destinationCalendarId, sendNotifications }) => {
@@ -374,7 +375,7 @@ export function registerCalendarTools(server: McpServer): void {
       description: 'Check free/busy times for one or more calendars within a time window. Returns only busy blocks, not event details.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
-        calendarIds: z.array(z.string()).describe('Calendar IDs to check, e.g. ["primary", "user@example.com"]'),
+        calendarIds: coerceArray(z.string()).describe('Calendar IDs to check, e.g. ["primary", "user@example.com"]'),
         timeMin: z.string().describe('ISO 8601 start of window'),
         timeMax: z.string().describe('ISO 8601 end of window'),
         timeZone: z.string().optional().describe('Timezone (default: UTC)'),

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
@@ -9,7 +9,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerCalendarTools(server: McpServer): void {
+export function registerCalendarTools(server: ToolRegistry): void {
   server.registerTool(
     'calendar_list_calendars',
     {

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -69,7 +70,7 @@ export function registerChatTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         parent: z.string().describe('Space resource name, format: spaces/{space}'),
         text: z.string().optional().describe('Plain message text'),
-        cardsV2: z.array(z.record(z.string(), z.any())).optional().describe('Optional Card v2 payloads'),
+        cardsV2: coerceJson(z.array(z.record(z.string(), z.any()))).optional().describe('Optional Card v2 payloads'),
         threadKey: z.string().optional().describe('Thread key to group messages'),
         messageReplyOption: z.enum(['MESSAGE_REPLY_OPTION_UNSPECIFIED', 'REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD', 'REPLY_MESSAGE_OR_FAIL']).optional(),
       },

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
@@ -9,7 +9,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerChatTools(server: McpServer): void {
+export function registerChatTools(server: ToolRegistry): void {
   server.registerTool(
     'chat_spaces_list',
     {

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
@@ -37,7 +37,7 @@ function formatContact(person: any) {
   };
 }
 
-export function registerContactsTools(server: McpServer): void {
+export function registerContactsTools(server: ToolRegistry): void {
   server.registerTool(
     'contacts_search',
     {

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceBoolean, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
@@ -30,7 +30,7 @@ function extractPlainText(body: any): string {
   return text;
 }
 
-export function registerDocsTools(server: McpServer): void {
+export function registerDocsTools(server: ToolRegistry): void {
   server.registerTool(
     'docs_create',
     {

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceBoolean, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -65,7 +66,7 @@ export function registerDocsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         documentId: z.string().describe('Google Docs document ID'),
-        includeTabsContent: z.boolean().optional()
+        includeTabsContent: coerceBoolean.optional()
           .describe('Include full content for every tab (default: false — first tab only)'),
         suggestionsViewMode: z.enum([
           'DEFAULT_FOR_CURRENT_ACCESS',
@@ -176,7 +177,7 @@ export function registerDocsTools(server: McpServer): void {
         documentId: z.string().describe('Google Docs document ID'),
         findText: z.string().describe('Text to search for'),
         replaceText: z.string().describe('Replacement text'),
-        matchCase: z.boolean().default(true).optional()
+        matchCase: coerceBoolean.default(true).optional()
           .describe('Case-sensitive match (default: true)'),
       },
     },
@@ -254,9 +255,9 @@ export function registerDocsTools(server: McpServer): void {
         documentId: z.string().describe('Google Docs document ID'),
         startIndex: z.number().min(1).describe('Start index (inclusive, 1-based)'),
         endIndex: z.number().min(2).describe('End index (exclusive)'),
-        bold: z.boolean().optional().describe('Set bold'),
-        italic: z.boolean().optional().describe('Set italic'),
-        underline: z.boolean().optional().describe('Set underline'),
+        bold: coerceBoolean.optional().describe('Set bold'),
+        italic: coerceBoolean.optional().describe('Set italic'),
+        underline: coerceBoolean.optional().describe('Set underline'),
         fontSize: z.number().min(1).optional().describe('Font size in points'),
         fontFamily: z.string().optional().describe('Font family name (e.g. "Arial", "Times New Roman")'),
       },
@@ -489,9 +490,9 @@ export function registerDocsTools(server: McpServer): void {
         indentEnd: z.number().optional().describe('End indent in points'),
         indentFirstLine: z.number().optional().describe('First-line indent in points'),
         direction: z.enum(['LEFT_TO_RIGHT', 'RIGHT_TO_LEFT']).optional(),
-        keepLinesTogether: z.boolean().optional(),
-        keepWithNext: z.boolean().optional(),
-        avoidWidowAndOrphan: z.boolean().optional(),
+        keepLinesTogether: coerceBoolean.optional(),
+        keepWithNext: coerceBoolean.optional(),
+        avoidWidowAndOrphan: coerceBoolean.optional(),
       },
     },
     async ({ account, documentId, startIndex, endIndex, ...style }) => {
@@ -539,9 +540,9 @@ export function registerDocsTools(server: McpServer): void {
         marginHeader: z.number().optional(),
         marginFooter: z.number().optional(),
         pageNumberStart: z.number().optional(),
-        useFirstPageHeaderFooter: z.boolean().optional(),
-        useEvenPageHeaderFooter: z.boolean().optional(),
-        useCustomHeaderFooterMargins: z.boolean().optional(),
+        useFirstPageHeaderFooter: coerceBoolean.optional(),
+        useEvenPageHeaderFooter: coerceBoolean.optional(),
+        useCustomHeaderFooterMargins: coerceBoolean.optional(),
       },
     },
     async ({ account, documentId, ...style }) => {
@@ -892,8 +893,8 @@ export function registerDocsTools(server: McpServer): void {
         tableStartIndex: z.number().min(1).describe('Start index of the table in the document'),
         rowIndex: z.number().min(0).describe('Target row (0-based)'),
         columnIndex: z.number().min(0).describe('Target column (0-based)'),
-        insertBelow: z.boolean().optional().describe('insertRow only: insert below the target row (default: false)'),
-        insertRight: z.boolean().optional().describe('insertColumn only: insert right of the target column (default: false)'),
+        insertBelow: coerceBoolean.optional().describe('insertRow only: insert below the target row (default: false)'),
+        insertRight: coerceBoolean.optional().describe('insertColumn only: insert right of the target column (default: false)'),
         rowSpan: z.number().min(1).optional().describe('mergeCells only: how many rows the merged cell spans (default 1)'),
         columnSpan: z.number().min(1).optional().describe('mergeCells/unmergeCells: column span (default 1)'),
       },
@@ -1073,7 +1074,7 @@ export function registerDocsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         documentId: z.string().describe('Google Docs document ID'),
-        requests: z.array(z.record(z.string(), z.any())).describe('Array of Request objects, each with one request-type key'),
+        requests: coerceJson(z.array(z.record(z.string(), z.any()))).describe('Array of Request objects, each with one request-type key'),
         writeControl: z.object({
           requiredRevisionId: z.string().optional(),
           targetRevisionId: z.string().optional(),

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
@@ -30,7 +30,7 @@ const COMMENT_LIST_FIELDS = `nextPageToken,comments(${COMMENT_BASE_FIELDS},repli
 const REPLY_FIELDS = `kind,htmlContent,${REPLY_SUBFIELDS}`;
 const REPLY_LIST_FIELDS = `nextPageToken,replies(${REPLY_FIELDS})`;
 
-export function registerDriveTools(server: McpServer): void {
+export function registerDriveTools(server: ToolRegistry): void {
   // ─── Read / search / list ──────────────────────────────────────────────
 
   server.registerTool(

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -607,9 +608,9 @@ export function registerDriveTools(server: McpServer): void {
         role: z.enum(['reader', 'commenter', 'writer', 'fileOrganizer', 'organizer', 'owner']).describe('Permission role'),
         emailAddress: z.string().optional().describe('Required when type is "user" or "group"'),
         domain: z.string().optional().describe('Required when type is "domain"'),
-        sendNotification: z.boolean().optional().describe('Send notification email (default: true)'),
+        sendNotification: coerceBoolean.optional().describe('Send notification email (default: true)'),
         emailMessage: z.string().optional().describe('Custom message in notification email'),
-        transferOwnership: z.boolean().optional().describe('Transfer ownership to the recipient. Requires role="owner". Recipient must accept ownership.'),
+        transferOwnership: coerceBoolean.optional().describe('Transfer ownership to the recipient. Requires role="owner". Recipient must accept ownership.'),
         expirationTime: z.string().optional().describe('RFC 3339 timestamp when access expires. Only valid for role="reader" or "commenter".'),
       },
     },
@@ -677,9 +678,9 @@ export function registerDriveTools(server: McpServer): void {
           .describe('New role'),
         expirationTime: z.string().optional()
           .describe('New RFC 3339 expiration timestamp. Only valid for role "reader" or "commenter".'),
-        removeExpiration: z.boolean().optional()
+        removeExpiration: coerceBoolean.optional()
           .describe('Clear the existing expirationTime'),
-        transferOwnership: z.boolean().optional()
+        transferOwnership: coerceBoolean.optional()
           .describe('Promote to owner. Requires role="owner".'),
       },
     },
@@ -779,7 +780,7 @@ export function registerDriveTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
-        includeDeleted: z.boolean().optional().describe('Include deleted comments (default: false)'),
+        includeDeleted: coerceBoolean.optional().describe('Include deleted comments (default: false)'),
         pageSize: z.number().min(1).max(100).optional().describe('Max comments per page (default: 20)'),
         pageToken: z.string().optional().describe('Token from a previous page'),
         startModifiedTime: z.string().optional().describe('Only return comments modified after this RFC 3339 timestamp'),
@@ -814,7 +815,7 @@ export function registerDriveTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
         commentId: z.string().describe('Comment ID'),
-        includeDeleted: z.boolean().optional(),
+        includeDeleted: coerceBoolean.optional(),
       },
     },
     async ({ account, fileId, commentId, includeDeleted }) => {
@@ -935,7 +936,7 @@ export function registerDriveTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
         commentId: z.string().describe('Parent comment ID'),
-        includeDeleted: z.boolean().optional(),
+        includeDeleted: coerceBoolean.optional(),
         pageSize: z.number().min(1).max(100).optional(),
         pageToken: z.string().optional(),
       },
@@ -1058,10 +1059,10 @@ export function registerDriveTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         fileId: z.string().describe('Google Drive file ID'),
         revisionId: z.string().describe('Revision ID'),
-        keepForever: z.boolean().optional().describe('Pin this revision indefinitely'),
-        published: z.boolean().optional().describe('Toggle published state (Docs only)'),
-        publishAuto: z.boolean().optional().describe('Auto-publish subsequent revisions'),
-        publishedOutsideDomain: z.boolean().optional().describe('Allow publish outside domain'),
+        keepForever: coerceBoolean.optional().describe('Pin this revision indefinitely'),
+        published: coerceBoolean.optional().describe('Toggle published state (Docs only)'),
+        publishAuto: coerceBoolean.optional().describe('Auto-publish subsequent revisions'),
+        publishedOutsideDomain: coerceBoolean.optional().describe('Allow publish outside domain'),
       },
     },
     async ({ account, fileId, revisionId, keepForever, published, publishAuto, publishedOutsideDomain }) => {
@@ -1153,10 +1154,10 @@ export function registerDriveTools(server: McpServer): void {
         fileId: z.string().describe('Google Drive file ID'),
         proposalId: z.string().describe('Access proposal ID'),
         action: z.enum(['ACCEPT', 'DENY']).describe('Whether to accept or deny the proposal'),
-        role: z.array(z.enum(['reader', 'commenter', 'writer', 'fileOrganizer'])).optional()
+        role: coerceArray(z.enum(['reader', 'commenter', 'writer', 'fileOrganizer'])).optional()
           .describe('Required when action is ACCEPT'),
         view: z.string().optional().describe('Optional view, e.g. "published"'),
-        sendNotification: z.boolean().optional()
+        sendNotification: coerceBoolean.optional()
           .describe('Email the requester about the resolution'),
       },
     },

--- a/src/tools/forms.ts
+++ b/src/tools/forms.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
@@ -8,7 +8,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerFormsTools(server: McpServer): void {
+export function registerFormsTools(server: ToolRegistry): void {
   server.registerTool(
     'forms_get',
     {

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -381,8 +382,8 @@ export function registerGmailTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         messageId: z.string().describe('Gmail message ID'),
-        addLabelIds: z.array(z.string()).optional().describe('Label IDs to add'),
-        removeLabelIds: z.array(z.string()).optional().describe('Label IDs to remove'),
+        addLabelIds: coerceArray(z.string()).optional().describe('Label IDs to add'),
+        removeLabelIds: coerceArray(z.string()).optional().describe('Label IDs to remove'),
       },
     },
     async ({ account, messageId, addLabelIds, removeLabelIds }) => {
@@ -458,9 +459,9 @@ export function registerGmailTools(server: McpServer): void {
       description: 'Add/remove labels across up to 1000 Gmail messages at once. Useful for bulk archiving, marking as read, etc.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
-        messageIds: z.array(z.string()).describe('Message IDs (up to 1000)'),
-        addLabelIds: z.array(z.string()).optional().describe('Label IDs to add'),
-        removeLabelIds: z.array(z.string()).optional().describe('Label IDs to remove'),
+        messageIds: coerceArray(z.string()).describe('Message IDs (up to 1000)'),
+        addLabelIds: coerceArray(z.string()).optional().describe('Label IDs to add'),
+        removeLabelIds: coerceArray(z.string()).optional().describe('Label IDs to remove'),
       },
     },
     async ({ account, messageIds, addLabelIds, removeLabelIds }) => {
@@ -490,7 +491,7 @@ export function registerGmailTools(server: McpServer): void {
       description: 'Permanently delete multiple Gmail messages. Irreversible.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
-        messageIds: z.array(z.string()).describe('Message IDs (up to 1000)'),
+        messageIds: coerceArray(z.string()).describe('Message IDs (up to 1000)'),
       },
     },
     async ({ account, messageIds }) => {
@@ -702,7 +703,7 @@ export function registerGmailTools(server: McpServer): void {
         startHistoryId: z.string().describe('History ID from a previous gmail_get_profile or gmail_read response'),
         maxResults: z.number().min(1).max(500).default(100).optional()
           .describe('Max results to return (default: 100)'),
-        historyTypes: z.array(z.enum(['messageAdded', 'messageDeleted', 'labelAdded', 'labelRemoved'])).optional()
+        historyTypes: coerceArray(z.enum(['messageAdded', 'messageDeleted', 'labelAdded', 'labelRemoved'])).optional()
           .describe('Filter by history event types'),
       },
     },
@@ -753,13 +754,13 @@ export function registerGmailTools(server: McpServer): void {
       description: 'Enable or disable Gmail vacation responder with a custom message',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
-        enableAutoReply: z.boolean().describe('Whether to enable the vacation responder'),
+        enableAutoReply: coerceBoolean.describe('Whether to enable the vacation responder'),
         responseSubject: z.string().optional().describe('Subject line for auto-reply'),
         responseBodyPlainText: z.string().optional().describe('Plain text body for auto-reply'),
         startTime: z.string().optional().describe('Start time as Unix timestamp in ms'),
         endTime: z.string().optional().describe('End time as Unix timestamp in ms'),
-        restrictToContacts: z.boolean().optional().describe('Only reply to contacts (default: false)'),
-        restrictToDomain: z.boolean().optional().describe('Only reply to same domain (default: false)'),
+        restrictToContacts: coerceBoolean.optional().describe('Only reply to contacts (default: false)'),
+        restrictToDomain: coerceBoolean.optional().describe('Only reply to same domain (default: false)'),
       },
     },
     async ({ account, enableAutoReply, responseSubject, responseBodyPlainText, startTime, endTime, restrictToContacts, restrictToDomain }) => {

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
@@ -80,7 +80,7 @@ function parseMessage(msg: any): GmailMessageFull {
   };
 }
 
-export function registerGmailTools(server: McpServer): void {
+export function registerGmailTools(server: ToolRegistry): void {
   server.registerTool(
     'gmail_search',
     {

--- a/src/tools/meet.ts
+++ b/src/tools/meet.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
@@ -8,7 +8,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerMeetTools(server: McpServer): void {
+export function registerMeetTools(server: ToolRegistry): void {
   // ─── Conference records (past meetings) ────────────────────────────────
 
   server.registerTool(

--- a/src/tools/searchconsole.ts
+++ b/src/tools/searchconsole.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
@@ -9,7 +9,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerSearchConsoleTools(server: McpServer): void {
+export function registerSearchConsoleTools(server: ToolRegistry): void {
   // ─── Sites ───────────────────────────────────────────────
 
   server.registerTool(

--- a/src/tools/searchconsole.ts
+++ b/src/tools/searchconsole.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceArray, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -210,18 +211,18 @@ export function registerSearchConsoleTools(server: McpServer): void {
         siteUrl: z.string().describe('Site URL (e.g. "https://example.com/" or "sc-domain:example.com")'),
         startDate: z.string().describe('Start date (YYYY-MM-DD). Data is available starting ~3 days ago.'),
         endDate: z.string().describe('End date (YYYY-MM-DD)'),
-        dimensions: z.array(z.enum(['query', 'page', 'country', 'device', 'searchAppearance', 'date'])).optional()
+        dimensions: coerceArray(z.enum(['query', 'page', 'country', 'device', 'searchAppearance', 'date'])).optional()
           .describe('Dimensions to group by. Common: ["query", "page"], ["date"], ["query", "date"]'),
         type: z.enum(['web', 'image', 'video', 'news', 'discover', 'googleNews']).optional()
           .describe('Search type filter (default: web)'),
-        dimensionFilterGroups: z.array(z.object({
+        dimensionFilterGroups: coerceJson(z.array(z.object({
           groupType: z.enum(['and']).optional(),
           filters: z.array(z.object({
             dimension: z.enum(['query', 'page', 'country', 'device', 'searchAppearance']),
             operator: z.enum(['contains', 'equals', 'notContains', 'notEquals', 'includingRegex', 'excludingRegex']),
             expression: z.string(),
           })),
-        })).optional()
+        }))).optional()
           .describe('Filters to narrow results. Example: filter by page containing "/blog/" or query containing "keyword"'),
         rowLimit: z.number().min(1).max(25000).optional()
           .describe('Max rows to return (default: 1000, max: 25000)'),

--- a/src/tools/sheets.ts
+++ b/src/tools/sheets.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceArray, coerceBoolean, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -16,7 +17,7 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         title: z.string().describe('Spreadsheet title'),
-        sheetTitles: z.array(z.string()).optional()
+        sheetTitles: coerceArray(z.string()).optional()
           .describe('Optional tab/sheet names (default: one sheet named "Sheet1")'),
       },
     },
@@ -129,7 +130,7 @@ export function registerSheetsTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
         range: z.string().describe('A1 notation target range, e.g. "Sheet1!A1:C3"'),
-        values: z.array(z.array(z.any())).describe('2D array of values (rows x columns)'),
+        values: coerceJson(z.array(z.array(z.any()))).describe('2D array of values (rows x columns)'),
         valueInputOption: z.enum(['RAW', 'USER_ENTERED']).default('USER_ENTERED').optional()
           .describe('How to interpret values: RAW (literal) or USER_ENTERED (formulas/dates parsed). Default: USER_ENTERED'),
       },
@@ -166,7 +167,7 @@ export function registerSheetsTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
         range: z.string().describe('A1 notation range to search for the table (e.g. "Sheet1")'),
-        values: z.array(z.array(z.any())).describe('2D array of rows to append'),
+        values: coerceJson(z.array(z.array(z.any()))).describe('2D array of rows to append'),
         valueInputOption: z.enum(['RAW', 'USER_ENTERED']).default('USER_ENTERED').optional()
           .describe('How to interpret values. Default: USER_ENTERED'),
       },
@@ -233,7 +234,7 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
-        ranges: z.array(z.string()).describe('Array of A1 notation ranges'),
+        ranges: coerceArray(z.string()).describe('Array of A1 notation ranges'),
         valueRenderOption: z.enum(['FORMATTED_VALUE', 'UNFORMATTED_VALUE', 'FORMULA'])
           .default('FORMATTED_VALUE').optional()
           .describe('How to render values. Default: FORMATTED_VALUE'),
@@ -268,10 +269,10 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
-        data: z.array(z.object({
+        data: coerceJson(z.array(z.object({
           range: z.string().describe('A1 notation range'),
-          values: z.array(z.array(z.any())).describe('2D array of values'),
-        })).describe('Array of { range, values } objects to write'),
+          values: coerceJson(z.array(z.array(z.any()))).describe('2D array of values'),
+        }))).describe('Array of { range, values } objects to write'),
         valueInputOption: z.enum(['RAW', 'USER_ENTERED']).default('USER_ENTERED').optional()
           .describe('How to interpret values. Default: USER_ENTERED'),
       },
@@ -427,7 +428,7 @@ export function registerSheetsTools(server: McpServer): void {
         sheetId: z.number().describe('Sheet ID'),
         title: z.string().optional().describe('New tab title'),
         index: z.number().optional().describe('New position among tabs'),
-        hidden: z.boolean().optional().describe('Hide the tab from the UI'),
+        hidden: coerceBoolean.optional().describe('Hide the tab from the UI'),
         tabColor: rgbColorSchema.optional().describe('Tab color (RGB 0..1)'),
         frozenRowCount: z.number().min(0).optional().describe('Number of frozen header rows'),
         frozenColumnCount: z.number().min(0).optional().describe('Number of frozen header columns'),
@@ -498,10 +499,10 @@ export function registerSheetsTools(server: McpServer): void {
         backgroundColor: rgbColorSchema.optional().describe('Cell background (RGB 0..1)'),
         textFormat: z.object({
           foregroundColor: rgbColorSchema.optional(),
-          bold: z.boolean().optional(),
-          italic: z.boolean().optional(),
-          underline: z.boolean().optional(),
-          strikethrough: z.boolean().optional(),
+          bold: coerceBoolean.optional(),
+          italic: coerceBoolean.optional(),
+          underline: coerceBoolean.optional(),
+          strikethrough: coerceBoolean.optional(),
           fontFamily: z.string().optional(),
           fontSize: z.number().min(1).optional(),
         }).optional(),
@@ -658,19 +659,19 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
-        ranges: z.array(gridRangeSchema).describe('Ranges the rule applies to'),
+        ranges: coerceJson(z.array(gridRangeSchema)).describe('Ranges the rule applies to'),
         index: z.number().min(0).optional().describe('Where in the rule order to insert (0 = highest priority)'),
         booleanRule: z.object({
           conditionType: z.string().describe(BOOLEAN_CONDITION_TYPE_DESC),
-          conditionValues: z.array(z.string()).optional().describe('Values for the condition (e.g. ["100"] for NUMBER_GREATER, or ["=A1>10"] for CUSTOM_FORMULA)'),
+          conditionValues: coerceArray(z.string()).optional().describe('Values for the condition (e.g. ["100"] for NUMBER_GREATER, or ["=A1>10"] for CUSTOM_FORMULA)'),
           format: z.object({
             backgroundColor: rgbColorSchema.optional(),
             textFormat: z.object({
               foregroundColor: rgbColorSchema.optional(),
-              bold: z.boolean().optional(),
-              italic: z.boolean().optional(),
-              strikethrough: z.boolean().optional(),
-              underline: z.boolean().optional(),
+              bold: coerceBoolean.optional(),
+              italic: coerceBoolean.optional(),
+              strikethrough: coerceBoolean.optional(),
+              underline: coerceBoolean.optional(),
             }).optional(),
           }).describe('Format to apply when condition is true. Conditional formatting only supports bold/italic/strikethrough/underline/foregroundColor/backgroundColor.'),
         }).optional(),
@@ -749,7 +750,7 @@ export function registerSheetsTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
         range: gridRangeSchema,
-        sortSpecs: z.array(sortSpecSchema).describe('One spec per sort column (in priority order)'),
+        sortSpecs: coerceJson(z.array(sortSpecSchema)).describe('One spec per sort column (in priority order)'),
       },
     },
     async ({ account, spreadsheetId, range, sortSpecs }) => {
@@ -779,13 +780,13 @@ export function registerSheetsTools(server: McpServer): void {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
         range: gridRangeSchema,
-        sortSpecs: z.array(sortSpecSchema).optional(),
-        filterSpecs: z.array(z.object({
+        sortSpecs: coerceJson(z.array(sortSpecSchema)).optional(),
+        filterSpecs: coerceJson(z.array(z.object({
           columnIndex: z.number().min(0),
-          hiddenValues: z.array(z.string()).optional().describe('Values to hide in this column'),
+          hiddenValues: coerceArray(z.string()).optional().describe('Values to hide in this column'),
           conditionType: z.string().optional().describe(BOOLEAN_CONDITION_TYPE_DESC),
-          conditionValues: z.array(z.string()).optional(),
-        })).optional(),
+          conditionValues: coerceArray(z.string()).optional(),
+        }))).optional(),
       },
     },
     async ({ account, spreadsheetId, range, sortSpecs, filterSpecs }) => {
@@ -861,10 +862,10 @@ export function registerSheetsTools(server: McpServer): void {
         scope: z.enum(['allSheets', 'sheet', 'range']).describe('Search scope'),
         sheetId: z.number().optional().describe('Required when scope=sheet'),
         range: gridRangeSchema.optional().describe('Required when scope=range'),
-        matchCase: z.boolean().optional(),
-        matchEntireCell: z.boolean().optional(),
-        searchByRegex: z.boolean().optional(),
-        includeFormulas: z.boolean().optional(),
+        matchCase: coerceBoolean.optional(),
+        matchEntireCell: coerceBoolean.optional(),
+        searchByRegex: coerceBoolean.optional(),
+        includeFormulas: coerceBoolean.optional(),
       },
     },
     async ({ account, spreadsheetId, find, replacement, scope, sheetId, range, matchCase, matchEntireCell, searchByRegex, includeFormulas }) => {
@@ -957,7 +958,7 @@ export function registerSheetsTools(server: McpServer): void {
         dimension: z.enum(['ROWS', 'COLUMNS']),
         startIndex: z.number().min(0).describe('0-based, inclusive'),
         endIndex: z.number().min(1).describe('0-based, exclusive'),
-        inheritFromBefore: z.boolean().optional(),
+        inheritFromBefore: coerceBoolean.optional(),
       },
     },
     async ({ account, spreadsheetId, sheetId, dimension, startIndex, endIndex, inheritFromBefore }) => {
@@ -1031,10 +1032,10 @@ export function registerSheetsTools(server: McpServer): void {
         spreadsheetId: z.string().describe('Spreadsheet ID'),
         range: gridRangeSchema,
         conditionType: z.string().describe(BOOLEAN_CONDITION_TYPE_DESC),
-        conditionValues: z.array(z.string()).optional().describe('Values per condition type (list items for ONE_OF_LIST, range A1 for ONE_OF_RANGE, etc.)'),
+        conditionValues: coerceArray(z.string()).optional().describe('Values per condition type (list items for ONE_OF_LIST, range A1 for ONE_OF_RANGE, etc.)'),
         inputMessage: z.string().optional().describe('Tooltip shown when cell is selected'),
-        strict: z.boolean().optional().describe('Reject invalid input (default: false = warning only)'),
-        showCustomUi: z.boolean().optional().describe('Show dropdown UI for list-type validations'),
+        strict: coerceBoolean.optional().describe('Reject invalid input (default: false = warning only)'),
+        showCustomUi: coerceBoolean.optional().describe('Show dropdown UI for list-type validations'),
       },
     },
     async ({ account, spreadsheetId, range, conditionType, conditionValues, inputMessage, strict, showCustomUi }) => {
@@ -1135,7 +1136,7 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
-        ranges: z.array(z.string()).describe('Array of A1 notation ranges'),
+        ranges: coerceArray(z.string()).describe('Array of A1 notation ranges'),
       },
     },
     async ({ account, spreadsheetId, ranges }) => {
@@ -1164,10 +1165,10 @@ export function registerSheetsTools(server: McpServer): void {
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         spreadsheetId: z.string().describe('Spreadsheet ID'),
-        requests: z.array(z.record(z.string(), z.any())).describe('Array of Request objects. Each object has exactly one key (the request type) like {repeatCell: {...}}, {addChart: {...}}, {updateBanding: {...}}, etc.'),
-        includeSpreadsheetInResponse: z.boolean().optional(),
-        responseRanges: z.array(z.string()).optional(),
-        responseIncludeGridData: z.boolean().optional(),
+        requests: coerceJson(z.array(z.record(z.string(), z.any()))).describe('Array of Request objects. Each object has exactly one key (the request type) like {repeatCell: {...}}, {addChart: {...}}, {updateBanding: {...}}, etc.'),
+        includeSpreadsheetInResponse: coerceBoolean.optional(),
+        responseRanges: coerceArray(z.string()).optional(),
+        responseIncludeGridData: coerceBoolean.optional(),
       },
     },
     async ({ account, spreadsheetId, requests, includeSpreadsheetInResponse, responseRanges, responseIncludeGridData }) => {

--- a/src/tools/sheets.ts
+++ b/src/tools/sheets.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean, coerceJson } from './_coerce.js';
 import { google } from 'googleapis';
@@ -9,7 +9,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerSheetsTools(server: McpServer): void {
+export function registerSheetsTools(server: ToolRegistry): void {
   server.registerTool(
     'sheets_create',
     {

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,5 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
@@ -147,10 +148,10 @@ export function registerTasksTools(server: McpServer): void {
         tasklistId: z.string().describe('Tasklist ID'),
         maxResults: z.number().min(1).max(100).optional(),
         pageToken: z.string().optional(),
-        showCompleted: z.boolean().optional().describe('Include completed tasks (default: true)'),
-        showDeleted: z.boolean().optional(),
-        showHidden: z.boolean().optional(),
-        showAssigned: z.boolean().optional(),
+        showCompleted: coerceBoolean.optional().describe('Include completed tasks (default: true)'),
+        showDeleted: coerceBoolean.optional(),
+        showHidden: coerceBoolean.optional(),
+        showAssigned: coerceBoolean.optional(),
         completedMax: z.string().optional().describe('RFC 3339 upper bound on completion date'),
         completedMin: z.string().optional(),
         dueMax: z.string().optional(),

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceBoolean } from './_coerce.js';
 import { google } from 'googleapis';
@@ -9,7 +9,7 @@ import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
-export function registerTasksTools(server: McpServer): void {
+export function registerTasksTools(server: ToolRegistry): void {
   // ─── Tasklists ─────────────────────────────────────────────────────────
 
   server.registerTool(

--- a/src/write-control.ts
+++ b/src/write-control.ts
@@ -1,0 +1,82 @@
+import type { Cud } from './registry.js';
+
+export type Profile = 'read-only' | 'safe-writes' | 'full-writes';
+
+export interface Policy {
+  profile: Profile;
+  readOnly: boolean;
+  allow: string[];
+  deny: string[];
+}
+
+interface ToolRef {
+  name: string;
+  service: string;
+  cud: Cud;
+}
+
+const PROFILES: Profile[] = ['read-only', 'safe-writes', 'full-writes'];
+
+function parseGlobs(value: string | undefined): string[] {
+  return (value ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+export function resolvePolicy(env: NodeJS.ProcessEnv = process.env): Policy {
+  const raw = (env.GOOGLE_PROFILE ?? 'read-only').trim() as Profile;
+  return {
+    profile: PROFILES.includes(raw) ? raw : 'read-only',
+    readOnly: /^(1|true|yes)$/i.test(env.GOOGLE_READ_ONLY ?? ''),
+    allow: parseGlobs(env.GOOGLE_WRITE_ALLOW),
+    deny: parseGlobs(env.GOOGLE_WRITE_DENY),
+  };
+}
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob.trim().replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function candidates(tool: ToolRef): string[] {
+  const op = tool.name.includes('_') ? tool.name.slice(tool.name.indexOf('_') + 1) : tool.name;
+  return [`${tool.service}:${tool.cud}`, `${tool.service}:${op}`];
+}
+
+function matchesAny(tool: ToolRef, globs: string[]): boolean {
+  if (globs.length === 0) return false;
+  const cands = candidates(tool);
+  return globs.some((g) => {
+    const re = globToRegExp(g);
+    return cands.some((c) => re.test(c));
+  });
+}
+
+function profileAllows(profile: Profile, cud: Cud): boolean {
+  if (profile === 'full-writes') return true;
+  if (profile === 'safe-writes') return cud === 'create' || cud === 'update';
+  return false;
+}
+
+export function isAllowed(tool: ToolRef, policy: Policy): boolean {
+  if (tool.cud === 'read') return true;
+  if (policy.readOnly) return false;
+  if (matchesAny(tool, policy.deny)) return false;
+  if (matchesAny(tool, policy.allow)) return true;
+  return profileAllows(policy.profile, tool.cud);
+}
+
+export function writeDisabledResult(tool: ToolRef, policy: Policy) {
+  const envelope = {
+    error: 'write_disabled',
+    message: `"${tool.name}" (${tool.cud}) is disabled by the current write-control policy (profile: ${policy.profile}${policy.readOnly ? ', GOOGLE_READ_ONLY=true' : ''}).`,
+    hint: `Enable via GOOGLE_PROFILE=safe-writes|full-writes, or GOOGLE_WRITE_ALLOW="${tool.service}:*".`,
+    retriable: false,
+  };
+  return {
+    content: [{ type: 'text' as const, text: JSON.stringify(envelope) }],
+    isError: true as const,
+  };
+}
+
+export function describePolicy(policy: Policy): string {
+  return `profile=${policy.profile} readOnly=${policy.readOnly} allow=[${policy.allow.join(', ')}] deny=[${policy.deny.join(', ')}]`;
+}

--- a/tests/coerce.test.ts
+++ b/tests/coerce.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { coerceArray, coerceJson, coerceBoolean } from '../src/tools/_coerce.js';
+
+describe('coerceArray', () => {
+  const s = coerceArray(z.string());
+  it('passes arrays through', () => expect(s.parse(['a', 'b'])).toEqual(['a', 'b']));
+  it('splits comma strings', () => expect(s.parse('a, b ,c')).toEqual(['a', 'b', 'c']));
+  it('parses JSON arrays', () => expect(s.parse('["x","y"]')).toEqual(['x', 'y']));
+  it('treats empty string as empty array', () => expect(s.parse('')).toEqual([]));
+  it('validates element types', () => {
+    const e = coerceArray(z.enum(['r', 'w']));
+    expect(e.parse('r,w')).toEqual(['r', 'w']);
+    expect(e.safeParse('x').success).toBe(false);
+  });
+});
+
+describe('coerceJson', () => {
+  const o = coerceJson(z.record(z.string(), z.unknown()));
+  it('passes objects through', () => expect(o.parse({ a: 1 })).toEqual({ a: 1 }));
+  it('parses JSON object strings', () => expect(o.parse('{"a":1}')).toEqual({ a: 1 }));
+  it('fails on non-JSON strings', () => expect(o.safeParse('nope').success).toBe(false));
+  it('coerces 2D arrays from a JSON string', () => {
+    const grid = coerceJson(z.array(z.array(z.any())));
+    expect(grid.parse('[[1,2],[3,4]]')).toEqual([[1, 2], [3, 4]]);
+  });
+});
+
+describe('coerceBoolean', () => {
+  it('passes booleans through', () => {
+    expect(coerceBoolean.parse(true)).toBe(true);
+    expect(coerceBoolean.parse(false)).toBe(false);
+  });
+  it('coerces truthy strings', () => {
+    for (const v of ['true', '1', 'yes', 'Y']) expect(coerceBoolean.parse(v)).toBe(true);
+  });
+  it('coerces falsy strings', () => {
+    for (const v of ['false', '0', 'no', 'N']) expect(coerceBoolean.parse(v)).toBe(false);
+  });
+  it('rejects nonsense', () => expect(coerceBoolean.safeParse('maybe').success).toBe(false));
+});

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { mapGoogleError } from '../src/tools/_errors.js';
+
+const acc = 'ic';
+
+describe('mapGoogleError', () => {
+  it('401 → auth_required with a re-auth hint', () => {
+    const e = mapGoogleError({ code: 401, message: 'Invalid Credentials' }, acc);
+    expect(e.error).toBe('auth_required');
+    expect(e.retriable).toBe(false);
+    expect(e.hint).toContain('auth --account ic');
+  });
+
+  it('403 insufficientPermissions → insufficient_scope', () => {
+    const e = mapGoogleError(
+      { code: 403, errors: [{ reason: 'insufficientPermissions' }], message: 'Insufficient Permission' },
+      acc,
+    );
+    expect(e.error).toBe('insufficient_scope');
+  });
+
+  it('403 generic → forbidden, passes the hint through', () => {
+    const e = mapGoogleError({ code: 403, message: 'forbidden' }, acc, 'enable admin writes');
+    expect(e.error).toBe('forbidden');
+    expect(e.hint).toBe('enable admin writes');
+  });
+
+  it('404 → not_found', () => {
+    expect(mapGoogleError({ code: 404, message: 'x' }, acc).error).toBe('not_found');
+  });
+
+  it('429 → rate_limited, retriable, with Retry-After', () => {
+    const e = mapGoogleError(
+      { code: 429, message: 'quota', response: { headers: { 'retry-after': '30' } } },
+      acc,
+    );
+    expect(e.error).toBe('rate_limited');
+    expect(e.retriable).toBe(true);
+    expect(e.hint).toContain('30');
+  });
+
+  it('5xx → upstream_error, retriable', () => {
+    const e = mapGoogleError({ code: 503, message: 'unavailable' }, acc);
+    expect(e.error).toBe('upstream_error');
+    expect(e.retriable).toBe(true);
+  });
+
+  it('never leaks the Authorization header / token from the raw error', () => {
+    const e = mapGoogleError(
+      {
+        code: 403,
+        message: 'Forbidden',
+        config: { headers: { Authorization: 'Bearer SECRET' } },
+        response: { data: { access_token: 'SECRET' } },
+      },
+      acc,
+    );
+    const json = JSON.stringify(e);
+    expect(json).not.toContain('SECRET');
+    expect(json).not.toContain('Authorization');
+  });
+
+  it('reads the nested Google message + reason', () => {
+    const e = mapGoogleError(
+      { response: { status: 404, data: { error: { message: 'Not found here', errors: [{ reason: 'notFound' }] } } } },
+      acc,
+    );
+    expect(e.error).toBe('not_found');
+    expect(e.message).toBe('Not found here');
+  });
+});

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -56,7 +56,7 @@ describe('ToolRegistry', () => {
     const fakeServer = {
       registerTool: (...a: unknown[]) => { calls.push(a); return 'ok'; },
     } as never;
-    const reg = new ToolRegistry(fakeServer);
+    const reg = new ToolRegistry(fakeServer, { profile: 'full-writes', readOnly: false, allow: [], deny: [] });
     const ret = reg.registerTool('gmail_send', { description: 'x' }, () => {});
     expect(ret).toBe('ok');
     expect(calls).toHaveLength(1);

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { inferCud, ToolRegistry } from '../src/registry.js';
+
+describe('inferCud', () => {
+  const cases: [string, string][] = [
+    ['gmail_list_labels', 'read'],
+    ['gmail_get_profile', 'read'],
+    ['gmail_read_thread', 'read'],
+    ['drive_search', 'read'],
+    ['sheets_batch_read', 'read'],
+    ['searchconsole_url_inspect', 'read'],
+    ['searchconsole_searchanalytics_query', 'read'],
+    ['contacts_group_members', 'read'],
+    ['drive_get_about', 'read'],
+    ['gmail_send', 'create'],
+    ['gmail_create_draft', 'create'],
+    ['drive_upload', 'create'],
+    ['drive_copy', 'create'],
+    ['drive_share', 'create'],
+    ['calendar_quick_add', 'create'],
+    ['sheets_append_rows', 'create'],
+    ['searchconsole_sites_add', 'create'],
+    ['docs_insert_text', 'create'],
+    ['gmail_modify_labels', 'update'],
+    ['gmail_batch_modify', 'update'],
+    ['drive_move', 'update'],
+    ['drive_update', 'update'],
+    ['drive_permission_update', 'update'],
+    ['sheets_write_range', 'update'],
+    ['sheets_batch_write', 'update'],
+    ['gmail_set_vacation', 'update'],
+    ['drive_access_proposal_resolve', 'update'],
+    ['drive_untrash', 'update'],
+    ['gmail_delete', 'delete'],
+    ['gmail_batch_delete', 'delete'],
+    ['drive_trash', 'delete'],
+    ['drive_remove_permission', 'delete'],
+    ['drive_empty_trash', 'delete'],
+    ['sheets_clear_range', 'delete'],
+    ['tasks_clear', 'delete'],
+    ['docs_delete_named_range', 'delete'],
+  ];
+  it.each(cases)('%s → %s', (name, expected) => {
+    expect(inferCud(name)).toBe(expected);
+  });
+
+  it('does not confuse "shared" with the "share" verb', () => {
+    expect(inferCud('drive_shared_drives_list')).toBe('read');
+    expect(inferCud('drive_share')).toBe('create');
+  });
+});
+
+describe('ToolRegistry', () => {
+  it('records name/service/cud and forwards to the server', () => {
+    const calls: unknown[][] = [];
+    const fakeServer = {
+      registerTool: (...a: unknown[]) => { calls.push(a); return 'ok'; },
+    } as never;
+    const reg = new ToolRegistry(fakeServer);
+    const ret = reg.registerTool('gmail_send', { description: 'x' }, () => {});
+    expect(ret).toBe('ok');
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0]).toBe('gmail_send');
+    expect(reg.tools).toEqual([{ name: 'gmail_send', service: 'gmail', cud: 'create' }]);
+  });
+});

--- a/tests/token-store.test.ts
+++ b/tests/token-store.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { deriveKey, encryptToken, decryptToken } from '../src/token-store.js';
+
+const KEY = 'test-master-key';
+const sample = { refresh_token: 'r', access_token: 'a', scope: 's', expiry_date: 123 };
+
+describe('token-store crypto', () => {
+  it('round-trips a token object', () => {
+    expect(decryptToken(encryptToken(sample, KEY), KEY)).toEqual(sample);
+  });
+
+  it('never leaks plaintext into the encrypted file', () => {
+    const enc = encryptToken(sample, KEY);
+    expect(enc).not.toContain('refresh_token');
+    expect(enc).not.toContain('"r"');
+    const o = JSON.parse(enc);
+    expect(o).toMatchObject({ v: 1 });
+    expect(o.iv && o.tag && o.data).toBeTruthy();
+  });
+
+  it('uses a fresh IV per call (ciphertext differs each time)', () => {
+    expect(encryptToken(sample, KEY)).not.toBe(encryptToken(sample, KEY));
+  });
+
+  it('fails to decrypt with the wrong key', () => {
+    expect(() => decryptToken(encryptToken(sample, KEY), 'wrong-key')).toThrow();
+  });
+
+  it('fails on tampered ciphertext (GCM auth)', () => {
+    const o = JSON.parse(encryptToken(sample, KEY));
+    const buf = Buffer.from(o.data, 'base64');
+    buf[0] ^= 0xff;
+    o.data = buf.toString('base64');
+    expect(() => decryptToken(JSON.stringify(o), KEY)).toThrow();
+  });
+
+  it('rejects an unsupported file version', () => {
+    const o = JSON.parse(encryptToken(sample, KEY));
+    o.v = 99;
+    expect(() => decryptToken(JSON.stringify(o), KEY)).toThrow(/version/i);
+  });
+
+  it('throws a clear error when MASTER_KEY is empty', () => {
+    expect(() => deriveKey('')).toThrow(/MASTER_KEY/);
+  });
+
+  it('accepts a base64 32-byte key directly', () => {
+    const k = Buffer.alloc(32, 7).toString('base64');
+    expect(deriveKey(k)).toHaveLength(32);
+    expect(decryptToken(encryptToken(sample, k), k)).toEqual(sample);
+  });
+
+  it('derives a 32-byte key from an arbitrary passphrase', () => {
+    expect(deriveKey('short')).toHaveLength(32);
+  });
+});

--- a/tests/write-control.test.ts
+++ b/tests/write-control.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { resolvePolicy, isAllowed, describePolicy, type Policy } from '../src/write-control.js';
+
+const tool = (name: string, cud: 'read' | 'create' | 'update' | 'delete') => ({
+  name,
+  service: name.slice(0, name.indexOf('_')),
+  cud,
+});
+
+describe('resolvePolicy', () => {
+  it('defaults to read-only, no globs', () => {
+    expect(resolvePolicy({})).toEqual({ profile: 'read-only', readOnly: false, allow: [], deny: [] });
+  });
+  it('parses profile, readOnly, and glob lists', () => {
+    const p = resolvePolicy({
+      GOOGLE_PROFILE: 'safe-writes',
+      GOOGLE_READ_ONLY: 'true',
+      GOOGLE_WRITE_ALLOW: 'calendar:*, sheets:update*',
+      GOOGLE_WRITE_DENY: '*:delete*',
+    });
+    expect(p).toEqual({
+      profile: 'safe-writes',
+      readOnly: true,
+      allow: ['calendar:*', 'sheets:update*'],
+      deny: ['*:delete*'],
+    });
+  });
+  it('falls back to read-only on an invalid profile', () => {
+    expect(resolvePolicy({ GOOGLE_PROFILE: 'bogus' }).profile).toBe('read-only');
+  });
+});
+
+describe('isAllowed', () => {
+  const ro: Policy = { profile: 'read-only', readOnly: false, allow: [], deny: [] };
+  const safe: Policy = { profile: 'safe-writes', readOnly: false, allow: [], deny: [] };
+  const full: Policy = { profile: 'full-writes', readOnly: false, allow: [], deny: [] };
+
+  it('reads always pass, even read-only', () => {
+    expect(isAllowed(tool('gmail_search', 'read'), ro)).toBe(true);
+  });
+  it('read-only denies all CUD', () => {
+    expect(isAllowed(tool('gmail_send', 'create'), ro)).toBe(false);
+    expect(isAllowed(tool('drive_delete', 'delete'), ro)).toBe(false);
+  });
+  it('safe-writes allows create+update, denies delete', () => {
+    expect(isAllowed(tool('gmail_send', 'create'), safe)).toBe(true);
+    expect(isAllowed(tool('drive_update', 'update'), safe)).toBe(true);
+    expect(isAllowed(tool('drive_delete', 'delete'), safe)).toBe(false);
+  });
+  it('full-writes allows everything', () => {
+    expect(isAllowed(tool('drive_delete', 'delete'), full)).toBe(true);
+  });
+  it('GOOGLE_READ_ONLY beats any profile', () => {
+    expect(isAllowed(tool('gmail_send', 'create'), { ...full, readOnly: true })).toBe(false);
+  });
+  it('deny glob wins over allow + profile', () => {
+    const p: Policy = { profile: 'full-writes', readOnly: false, allow: ['drive:*'], deny: ['*:delete*'] };
+    expect(isAllowed(tool('drive_delete', 'delete'), p)).toBe(false);
+    expect(isAllowed(tool('drive_update', 'update'), p)).toBe(true);
+  });
+  it('allow glob opens a hole in a restrictive profile', () => {
+    const p: Policy = { profile: 'read-only', readOnly: false, allow: ['calendar:*'], deny: [] };
+    expect(isAllowed(tool('calendar_create_event', 'create'), p)).toBe(true);
+    expect(isAllowed(tool('gmail_send', 'create'), p)).toBe(false);
+  });
+  it('allow matches by operation name (gmail:send)', () => {
+    const p: Policy = { profile: 'read-only', readOnly: false, allow: ['gmail:send'], deny: [] };
+    expect(isAllowed(tool('gmail_send', 'create'), p)).toBe(true);
+  });
+  it('precedence holds: readonly > deny > allow > profile', () => {
+    expect(isAllowed(tool('gmail_send', 'create'), { profile: 'full-writes', readOnly: true, allow: ['*:*'], deny: [] })).toBe(false);
+  });
+});
+
+describe('describePolicy', () => {
+  it('renders a one-line summary', () => {
+    expect(
+      describePolicy({ profile: 'safe-writes', readOnly: false, allow: ['a:*'], deny: ['*:delete*'] }),
+    ).toBe('profile=safe-writes readOnly=false allow=[a:*] deny=[*:delete*]');
+  });
+});


### PR DESCRIPTION
Ship **v5.0.0** stable: local + OAuth-only, encrypted token storage, deny-by-default write-control, error taxonomy + param coercion, tool registry. Alert Center + GOOGLE_ALLOW_ADMIN_WRITES removed (v6 / write-control). npm-first docs. BREAKING — see Upgrading-from-v4 in README.