### PR TITLE
chore: back-merge main into staging (resync after v5.0.0)

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,8 +1,9 @@
 name: backmerge
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["release"]
+    types: [completed]
 
 permissions:
   contents: write
@@ -10,24 +11,36 @@ permissions:
 
 jobs:
   backmerge:
-    if: ${{ !github.event.release.prerelease }}
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
     steps:
-      - name: Open + auto-merge main into staging and dev
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Open + merge main into staging and dev
         env:
           GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN }}
           REPO: ${{ github.repository }}
-          TAG: ${{ github.event.release.tag_name }}
         run: |
-          set -uo pipefail
+          set +e
+          TAG=$(gh release view --repo "$REPO" --json tagName --jq .tagName 2>/dev/null)
           for target in staging dev; do
             url=$(gh pr create --repo "$REPO" --base "$target" --head main \
-                  --title "chore: back-merge main into $target (resync after $TAG)" \
-                  --body "Automated post-release resync so the \`$target\` prerelease base tracks \`main\` ($TAG). No content change." || true)
-            if [ -n "${url:-}" ]; then
-              gh pr merge "$url" --repo "$REPO" --auto --merge
+                  --title "chore: back-merge main into $target (resync after ${TAG:-latest release})" \
+                  --body "Automated post-release resync so the \`$target\` prerelease base tracks \`main\` (${TAG:-latest release}). No content change.")
+            if [ -z "$url" ]; then
+              echo "nothing to back-merge into $target (already in sync or PR exists)"
+              continue
+            fi
+            if gh pr merge "$url" --repo "$REPO" --merge; then
+              echo "merged: $url"
+            elif gh pr merge "$url" --repo "$REPO" --auto --merge; then
               echo "queued auto-merge: $url"
             else
-              echo "nothing to back-merge into $target"
+              echo "could not merge $url (resolve manually)"
             fi
           done
+          exit 0


### PR DESCRIPTION
Automated post-release resync so the `staging` prerelease base tracks `main` (v5.0.0). No content change.