### PR TITLE
feat: discover-first tool architecture with per-service discover tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 tokens/
 .env
+discovery/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,10 @@ Conventions for AI assistants modifying this codebase. v5 is **local, stdio, use
 
 ## Project shape
 
-- `src/index.ts` — entry. `buildRegistry()` registers every service into a `ToolRegistry`; `main()` runs the stdio MCP server, or the `auth` / `migrate-tokens` / `config check` CLI commands.
-- `src/registry.ts` — `ToolRegistry` wraps the MCP server: records `{name, service, cud}` per tool, derives `cud` (read/create/update/delete) from the tool name via `inferCud`, and **enforces write-control** by wrapping every CUD handler. Service files still call `server.registerTool(...)` — `server` is now a `ToolRegistry`.
+- `src/index.ts` — entry. `buildRegistry()` registers every enabled service (the `SERVICES` table, filtered by `GOOGLE_TOOLSETS`) into a `ToolRegistry`, then `registerDiscoverTools()`; `main()` installs the registry's custom `tools/list` handler and runs the stdio MCP server, or the `auth` / `migrate-tokens` / `config check` CLI commands.
+- `src/registry.ts` — `ToolRegistry` wraps the MCP server: records `{name, service, cud, description, inputShape, meta}` per tool, derives `cud` (read/create/update/delete) from the tool name via `inferCud`, **enforces write-control** by wrapping every CUD handler, injects computed annotations (`readOnlyHint`/`destructiveHint`), and owns **discover-first visibility**: all tools register eagerly (always callable — graceful dispatch), but the custom `tools/list` handler only advertises meta tools + `reveal()`ed services. `installListHandler()` must run after registration, before connect. Service files still call `server.registerTool(...)` — `server` is now a `ToolRegistry`.
+- `src/discover.ts` — `registerDiscoverTools()`: one eager `{service}_discover` meta-tool per service; returns the catalog (`registry.catalog`), reveals the service, triggers `tools/list_changed`. Never emit `tool_reference` content blocks or top-level `defer_loading` fields — strict SDK clients reject/strip them (verified against SDK 1.29).
+- `src/toolsets.ts` — `GOOGLE_TOOLSETS` parsing (`all` | CSV of service names).
 - `src/write-control.ts` — `resolvePolicy()` (env → policy) + `isAllowed()` (deny-by-default verdict) + `config check` rendering.
 - `src/token-store.ts` — encrypted token store (AES-256-GCM, key from `MASTER_KEY`); `readToken`/`writeToken` + the `migrate-tokens` source.
 - `src/auth.ts` — OAuth flow + scope tiers (`BASE_SCOPES` always, `OPTIONAL_SCOPE_BUNDLES` env-gated, `ADMIN_SCOPES` per-account).

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -2,7 +2,7 @@
 
 Every tool takes an `account` argument matching one of your `GOOGLE_ACCOUNTS` aliases. **Create / update / delete tools are gated by [write-control](./README.md#write-control-deny-by-default)** — deny-by-default; reads are always available. Run `mcp-google-multi config check` to see exactly which CUD tools your current profile enables.
 
-~170 tools across the services below. (This is the curated surface; discover-first deferral and exhaustive API coverage are on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones).)
+~170 tools across the services below. Tools load **[discover-first](./README.md#discover-first-tools-tiny-idle-context)**: each service also exposes a `{service}_discover` meta-tool, and only those appear in `tools/list` until discovered (everything stays directly callable). `GOOGLE_TOOLSETS` can switch whole services off. (Exhaustive API coverage is on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones).)
 
 ## Gmail
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,16 @@ Now the only thing on disk is the **encrypted** token store. Pass the token via 
 | `GOOGLE_WRITE_ALLOW` / `GOOGLE_WRITE_DENY` | — | glob overrides, e.g. `calendar:*`, `*:delete*` |
 | `GOOGLE_OPTIONAL_SCOPES` | — | extra bundles: `forms`, `chat` |
 | `GOOGLE_ADMIN_ACCOUNTS` | — | aliases granted Workspace-admin scopes (the account's own super-admin OAuth) |
+| `GOOGLE_TOOLSETS` | — | `all` (default) or a CSV filter of: `gmail`, `drive`, `calendar`, `sheets`, `docs`, `contacts`, `searchconsole`, `tasks`, `meet`, `forms`, `chat`, `admin` |
 | `TOKEN_STORE_PATH` | — | override the encrypted token dir (default: `~/.config/mcp-google-multi/tokens`) |
 
 Inspect the resolved setup any time: `mcp-google-multi config check`.
+
+## Discover-first tools (tiny idle context)
+
+The server does **not** dump ~170 tool schemas into your model's context. At boot, `tools/list` exposes only one small `{service}_discover` tool per service (plus nothing else). Calling e.g. `drive_discover` returns that service's operation catalog (name, one-line summary, arguments, read/write class), reveals the operational tools, and emits `notifications/tools/list_changed` so the client re-fetches the list. An optional `query` argument filters the catalog.
+
+Hidden is a listing concept, not a security boundary: operational tools stay callable at all times (existing prompts that call tools directly keep working), and write-control + OAuth scopes remain the real enforcement. Use `GOOGLE_TOOLSETS` to switch entire services off — it is a filter only: listing `forms`/`chat`/`admin` does not enable them without their `GOOGLE_OPTIONAL_SCOPES` / `GOOGLE_ADMIN_ACCOUNTS` gates.
 
 ## Write-control (deny-by-default)
 
@@ -112,7 +119,7 @@ Your OAuth, your machine. Refresh tokens are **AES-256-GCM encrypted at rest** (
 
 ## Roadmap
 
-Maintainer-led. Direction is tracked publicly as **[GitHub Milestones](https://github.com/bakissation/mcp-google-multi/milestones)** (discover-first tooling → exhaustive API coverage → service accounts + hosting in v6). Not accepting unsolicited feature PRs; bug reports are welcome.
+Maintainer-led. Direction is tracked publicly as **[GitHub Milestones](https://github.com/bakissation/mcp-google-multi/milestones)** (exhaustive API coverage → service accounts + hosting in v6). Not accepting unsolicited feature PRs; bug reports are welcome.
 
 ## Contributing
 

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+import type { ToolRegistry } from './registry.js';
+import { describePolicy, type Policy } from './write-control.js';
+
+function opVocabulary(registry: ToolRegistry, service: string): string {
+  const ops = registry.catalog(service).map((o) =>
+    o.tool.startsWith(`${service}_`) ? o.tool.slice(service.length + 1) : o.tool,
+  );
+  return [...new Set(ops)].join(', ');
+}
+
+export function registerDiscoverTools(registry: ToolRegistry, policy: Policy): void {
+  for (const service of registry.services()) {
+    registry.registerMeta(
+      `${service}_discover`,
+      {
+        description:
+          `List the available ${service} operations. Operational ${service} tools are hidden ` +
+          `until discovered — call this first, then call the tool you need by name. ` +
+          `Operations: ${opVocabulary(registry, service)}.`,
+        inputSchema: {
+          query: z.string().optional().describe('Keyword to filter the returned operations'),
+        },
+      },
+      async ({ query }) => {
+        const operations = registry.catalog(service, query as string | undefined);
+        registry.reveal(service);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                service,
+                operations,
+                writeControl: describePolicy(policy),
+                next:
+                  operations.length > 0
+                    ? 'Call the chosen tool by name; it is now listed and callable.'
+                    : `No ${service} operation matches "${query}". Call again without query for the full catalog.`,
+              }),
+            },
+          ],
+        };
+      },
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,26 +20,62 @@ import { registerChatTools } from './tools/chat.js';
 import { registerAdminTools } from './tools/admin.js';
 import { getOptionalBundles, getAdminAccounts } from './auth.js';
 import { ToolRegistry } from './registry.js';
+import { registerDiscoverTools } from './discover.js';
+import { getToolsets, toolsetEnabled } from './toolsets.js';
 import { resolvePolicy, isAllowed, describePolicy, type Policy } from './write-control.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'));
 
+const SERVICES: Array<{
+  name: string;
+  register: (registry: ToolRegistry) => void;
+  enabled?: () => boolean;
+}> = [
+  { name: 'gmail', register: registerGmailTools },
+  { name: 'drive', register: registerDriveTools },
+  { name: 'calendar', register: registerCalendarTools },
+  { name: 'sheets', register: registerSheetsTools },
+  { name: 'docs', register: registerDocsTools },
+  { name: 'contacts', register: registerContactsTools },
+  { name: 'searchconsole', register: registerSearchConsoleTools },
+  { name: 'tasks', register: registerTasksTools },
+  { name: 'meet', register: registerMeetTools },
+  { name: 'forms', register: registerFormsTools, enabled: () => new Set(getOptionalBundles()).has('forms') },
+  { name: 'chat', register: registerChatTools, enabled: () => new Set(getOptionalBundles()).has('chat') },
+  { name: 'admin', register: registerAdminTools, enabled: () => getAdminAccounts().length > 0 },
+];
+
 function buildRegistry(server: McpServer, policy: Policy): ToolRegistry {
   const registry = new ToolRegistry(server, policy);
-  registerGmailTools(registry);
-  registerDriveTools(registry);
-  registerCalendarTools(registry);
-  registerSheetsTools(registry);
-  registerDocsTools(registry);
-  registerContactsTools(registry);
-  registerSearchConsoleTools(registry);
-  registerTasksTools(registry);
-  registerMeetTools(registry);
-  const optional = new Set(getOptionalBundles());
-  if (optional.has('forms')) registerFormsTools(registry);
-  if (optional.has('chat')) registerChatTools(registry);
-  if (getAdminAccounts().length > 0) registerAdminTools(registry);
+  const toolsets = getToolsets();
+  if (toolsets !== 'all') {
+    const known = new Set(SERVICES.map((s) => s.name));
+    for (const requested of toolsets) {
+      if (!known.has(requested)) {
+        process.stderr.write(`GOOGLE_TOOLSETS: unknown service "${requested}" ignored\n`);
+      }
+    }
+  }
+  for (const svc of SERVICES) {
+    if (!toolsetEnabled(toolsets, svc.name)) continue;
+    if (svc.enabled && !svc.enabled()) {
+      if (toolsets !== 'all') {
+        const hint = svc.name === 'admin' ? 'set GOOGLE_ADMIN_ACCOUNTS' : `add "${svc.name}" to GOOGLE_OPTIONAL_SCOPES`;
+        process.stderr.write(`GOOGLE_TOOLSETS: "${svc.name}" requested but not enabled — ${hint}\n`);
+      }
+      continue;
+    }
+    svc.register(registry);
+  }
+  registerDiscoverTools(registry, policy);
+  if (registry.tools.length === 0) {
+    throw new Error(
+      `GOOGLE_TOOLSETS="${process.env.GOOGLE_TOOLSETS ?? ''}" selected no enabled services. ` +
+        `Known services: ${SERVICES.map((s) => s.name).join(', ')}. ` +
+        `Note: forms/chat require GOOGLE_OPTIONAL_SCOPES, admin requires GOOGLE_ADMIN_ACCOUNTS.`,
+    );
+  }
   return registry;
 }
 
@@ -64,9 +100,12 @@ async function main() {
     );
     const cud = registry.tools.filter((t) => t.cud !== 'read');
     const disabled = cud.filter((t) => !isAllowed(t, policy));
+    const counts = registry.visibleCount();
     console.log(`Write-control: ${describePolicy(policy)}`);
     console.log(`CUD tools enabled: ${cud.length - disabled.length}/${cud.length}`);
     console.log(`Disabled: ${disabled.map((t) => t.name).join(', ') || '(none)'}`);
+    console.log(`Services: ${registry.services().join(', ')}`);
+    console.log(`Tool surface: ${counts.eager} eager (discover), ${counts.hidden} deferred until discovery`);
     return;
   }
 
@@ -75,7 +114,8 @@ async function main() {
     name: 'mcp-google-multi',
     version: pkg.version,
   });
-  buildRegistry(server, policy);
+  const registry = buildRegistry(server, policy);
+  registry.installListHandler();
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,4 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
 import { type Policy, isAllowed, writeDisabledResult } from './write-control.js';
 
 export type Cud = 'read' | 'create' | 'update' | 'delete';
@@ -7,10 +9,31 @@ export interface ToolEntry {
   name: string;
   service: string;
   cud: Cud;
+  description: string;
+  inputShape: z.ZodRawShape;
+  annotations: Record<string, unknown>;
+  meta: boolean;
+}
+
+export interface CatalogOperation {
+  tool: string;
+  summary: string;
+  args: string[];
+  cud: Cud;
+}
+
+interface ToolConfig {
+  description?: string;
+  inputSchema?: z.ZodRawShape;
+  annotations?: Record<string, unknown>;
 }
 
 const CUD_OVERRIDES: Record<string, Cud> = {
   drive_untrash: 'update',
+};
+
+const SERVICE_OVERRIDES: Record<string, string> = {
+  reports_activities_list: 'admin',
 };
 
 const DELETE_VERB = /(^|_)(delete|remove|trash|clear|empty)(_|$)/;
@@ -29,12 +52,33 @@ export function inferCud(name: string): Cud {
 export class ToolRegistry {
   readonly tools: ToolEntry[] = [];
   readonly registerTool: McpServer['registerTool'];
+  private readonly revealed = new Set<string>();
+  private readonly jsonSchemaCache = new Map<string, unknown>();
+  private registeringMeta = false;
 
-  constructor(server: McpServer, policy: Policy) {
-    this.registerTool = ((name: string, config: unknown, handler: (...a: unknown[]) => unknown) => {
-      const service = name.includes('_') ? name.slice(0, name.indexOf('_')) : name;
+  constructor(
+    private readonly server: McpServer,
+    policy: Policy,
+  ) {
+    this.registerTool = ((name: string, config: ToolConfig, handler: (...a: unknown[]) => unknown) => {
+      const service =
+        SERVICE_OVERRIDES[name] ?? (name.includes('_') ? name.slice(0, name.indexOf('_')) : name);
       const cud = inferCud(name);
-      this.tools.push({ name, service, cud });
+      // destructiveHint=false claims "additive only" (MCP spec) — updates overwrite, so they stay true.
+      const annotations = {
+        readOnlyHint: cud === 'read',
+        destructiveHint: cud === 'delete' || cud === 'update',
+        ...config.annotations,
+      };
+      this.tools.push({
+        name,
+        service,
+        cud,
+        description: config.description ?? '',
+        inputShape: config.inputSchema ?? {},
+        annotations,
+        meta: this.registeringMeta,
+      });
       const guarded =
         cud === 'read'
           ? handler
@@ -42,7 +86,75 @@ export class ToolRegistry {
               isAllowed({ name, service, cud }, policy)
                 ? handler(...args)
                 : writeDisabledResult({ name, service, cud }, policy);
-      return (server.registerTool as (...a: unknown[]) => unknown)(name, config, guarded);
+      return (server.registerTool as (...a: unknown[]) => unknown)(name, { ...config, annotations }, guarded);
     }) as McpServer['registerTool'];
+  }
+
+  registerMeta: McpServer['registerTool'] = ((name: string, config: unknown, handler: unknown) => {
+    this.registeringMeta = true;
+    try {
+      return (this.registerTool as (...a: unknown[]) => unknown)(name, config, handler);
+    } finally {
+      this.registeringMeta = false;
+    }
+  }) as McpServer['registerTool'];
+
+  services(): string[] {
+    return [...new Set(this.tools.filter((t) => !t.meta).map((t) => t.service))];
+  }
+
+  catalog(service: string, query?: string): CatalogOperation[] {
+    const q = query?.trim().toLowerCase();
+    return this.tools
+      .filter((t) => !t.meta && t.service === service)
+      .filter((t) => !q || t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q))
+      .map((t) => ({
+        tool: t.name,
+        summary: t.description,
+        args: Object.keys(t.inputShape),
+        cud: t.cud,
+      }));
+  }
+
+  reveal(service: string): boolean {
+    if (this.revealed.has(service)) return false;
+    this.revealed.add(service);
+    this.server.sendToolListChanged();
+    return true;
+  }
+
+  isVisible(tool: ToolEntry): boolean {
+    return tool.meta || this.revealed.has(tool.service);
+  }
+
+  visibleCount(): { eager: number; revealed: number; hidden: number } {
+    const meta = this.tools.filter((t) => t.meta).length;
+    const visible = this.tools.filter((t) => !t.meta && this.isVisible(t)).length;
+    return { eager: meta, revealed: visible, hidden: this.tools.length - meta - visible };
+  }
+
+  // Replaces the SDK list handler so hidden tools stay registered (and callable —
+  // graceful dispatch) while tools/list only advertises the visible set.
+  installListHandler(): void {
+    if (this.tools.length === 0) {
+      throw new Error('installListHandler() requires at least one registered tool');
+    }
+    this.server.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: this.tools.filter((t) => this.isVisible(t)).map((t) => this.toToolJson(t)),
+    }));
+  }
+
+  private toToolJson(tool: ToolEntry): { name: string; description: string; inputSchema: unknown; annotations: Record<string, unknown> } {
+    let inputSchema = this.jsonSchemaCache.get(tool.name);
+    if (!inputSchema) {
+      inputSchema = z.toJSONSchema(z.object(tool.inputShape), { target: 'draft-7', io: 'input' });
+      this.jsonSchemaCache.set(tool.name, inputSchema);
+    }
+    return {
+      name: tool.name,
+      description: tool.description,
+      inputSchema,
+      annotations: tool.annotations,
+    };
   }
 }

--- a/src/toolsets.ts
+++ b/src/toolsets.ts
@@ -1,0 +1,14 @@
+export type Toolsets = 'all' | Set<string>;
+
+export function getToolsets(env: NodeJS.ProcessEnv = process.env): Toolsets {
+  const parts = (env.GOOGLE_TOOLSETS ?? '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+  if (parts.length === 0 || parts.includes('all')) return 'all';
+  return new Set(parts);
+}
+
+export function toolsetEnabled(toolsets: Toolsets, service: string): boolean {
+  return toolsets === 'all' || toolsets.has(service);
+}

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import { ToolRegistry } from '../src/registry.js';
+import { registerDiscoverTools } from '../src/discover.js';
+import type { Policy } from '../src/write-control.js';
+
+const POLICY: Policy = { profile: 'safe-writes', readOnly: false, allow: [], deny: [] };
+
+function setup() {
+  const registered: { name: string; config: { description: string }; handler: (args: Record<string, unknown>) => Promise<{ content: { text: string }[] }> }[] = [];
+  const server = {
+    registerTool: (name: string, config: never, handler: never) => {
+      registered.push({ name, config, handler });
+      return 'ok';
+    },
+    sendToolListChanged: vi.fn(),
+    server: { setRequestHandler: () => {} },
+  };
+  const registry = new ToolRegistry(server as never, POLICY);
+  registry.registerTool('gmail_search', { description: 'Search messages', inputSchema: { account: z.string(), query: z.string() } }, () => {});
+  registry.registerTool('gmail_send', { description: 'Send an email', inputSchema: { account: z.string(), to: z.string() } }, () => {});
+  registry.registerTool('drive_search', { description: 'Search files', inputSchema: { account: z.string() } }, () => {});
+  registerDiscoverTools(registry, POLICY);
+  return { registry, registered, server };
+}
+
+describe('registerDiscoverTools', () => {
+  it('registers one discover tool per service with the op vocabulary inline', () => {
+    const { registered } = setup();
+    const discoverNames = registered.filter((r) => r.name.endsWith('_discover')).map((r) => r.name);
+    expect(discoverNames).toEqual(['gmail_discover', 'drive_discover']);
+    const gmail = registered.find((r) => r.name === 'gmail_discover')!;
+    expect(gmail.config.description).toContain('hidden');
+    expect(gmail.config.description).toContain('search, send');
+  });
+
+  it('discover returns the catalog, reveals the service, and notifies once', async () => {
+    const { registry, registered, server } = setup();
+    const gmail = registered.find((r) => r.name === 'gmail_discover')!;
+
+    const result = await gmail.handler({ query: undefined });
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.service).toBe('gmail');
+    expect(payload.operations).toEqual([
+      { tool: 'gmail_search', summary: 'Search messages', args: ['account', 'query'], cud: 'read' },
+      { tool: 'gmail_send', summary: 'Send an email', args: ['account', 'to'], cud: 'create' },
+    ]);
+    expect(payload.writeControl).toContain('profile=safe-writes');
+    expect(server.sendToolListChanged).toHaveBeenCalledTimes(1);
+    expect(registry.isVisible(registry.tools.find((t) => t.name === 'gmail_search')!)).toBe(true);
+    expect(registry.isVisible(registry.tools.find((t) => t.name === 'drive_search')!)).toBe(false);
+
+    await gmail.handler({ query: undefined });
+    expect(server.sendToolListChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('discover filters by query and hints when nothing matches', async () => {
+    const { registered } = setup();
+    const gmail = registered.find((r) => r.name === 'gmail_discover')!;
+
+    const filtered = JSON.parse((await gmail.handler({ query: 'send' })).content[0].text);
+    expect(filtered.operations.map((o: { tool: string }) => o.tool)).toEqual(['gmail_send']);
+
+    const empty = JSON.parse((await gmail.handler({ query: 'zzz' })).content[0].text);
+    expect(empty.operations).toEqual([]);
+    expect(empty.next).toContain('without query');
+  });
+});

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
 import { inferCud, ToolRegistry } from '../src/registry.js';
+import type { Policy } from '../src/write-control.js';
 
 describe('inferCud', () => {
   const cases: [string, string][] = [
@@ -50,17 +52,166 @@ describe('inferCud', () => {
   });
 });
 
+const FULL_WRITES: Policy = { profile: 'full-writes', readOnly: false, allow: [], deny: [] };
+
+function fakeServer() {
+  const registered: { name: string; config: Record<string, unknown>; handler: (...a: unknown[]) => unknown }[] = [];
+  let listHandler: (() => Promise<{ tools: unknown[] }>) | undefined;
+  const server = {
+    registerTool: (name: string, config: Record<string, unknown>, handler: (...a: unknown[]) => unknown) => {
+      registered.push({ name, config, handler });
+      return 'ok';
+    },
+    sendToolListChanged: vi.fn(),
+    server: {
+      setRequestHandler: (_schema: unknown, handler: () => Promise<{ tools: unknown[] }>) => {
+        listHandler = handler;
+      },
+    },
+  };
+  return { server, registered, getListHandler: () => listHandler };
+}
+
 describe('ToolRegistry', () => {
-  it('records name/service/cud and forwards to the server', () => {
-    const calls: unknown[][] = [];
-    const fakeServer = {
-      registerTool: (...a: unknown[]) => { calls.push(a); return 'ok'; },
-    } as never;
-    const reg = new ToolRegistry(fakeServer, { profile: 'full-writes', readOnly: false, allow: [], deny: [] });
-    const ret = reg.registerTool('gmail_send', { description: 'x' }, () => {});
+  it('records the tool entry and forwards to the server', () => {
+    const { server, registered } = fakeServer();
+    const reg = new ToolRegistry(server as never, FULL_WRITES);
+    const ret = reg.registerTool('gmail_send', { description: 'x', inputSchema: { to: z.string() } }, () => {});
     expect(ret).toBe('ok');
-    expect(calls).toHaveLength(1);
-    expect(calls[0][0]).toBe('gmail_send');
-    expect(reg.tools).toEqual([{ name: 'gmail_send', service: 'gmail', cud: 'create' }]);
+    expect(registered).toHaveLength(1);
+    expect(registered[0].name).toBe('gmail_send');
+    expect(reg.tools).toMatchObject([
+      { name: 'gmail_send', service: 'gmail', cud: 'create', description: 'x', meta: false },
+    ]);
+  });
+
+  it('computes annotations per cud class on both the registration and list paths', async () => {
+    const { server, registered, getListHandler } = fakeServer();
+    const reg = new ToolRegistry(server as never, FULL_WRITES);
+    reg.registerTool('gmail_search', { description: 'x' }, () => {});
+    reg.registerTool('gmail_create_draft', { description: 'x' }, () => {});
+    reg.registerTool('gmail_modify_labels', { description: 'x' }, () => {});
+    reg.registerTool('gmail_delete', { description: 'x' }, () => {});
+    const expected: Record<string, { readOnlyHint: boolean; destructiveHint: boolean }> = {
+      gmail_search: { readOnlyHint: true, destructiveHint: false },
+      gmail_create_draft: { readOnlyHint: false, destructiveHint: false },
+      gmail_modify_labels: { readOnlyHint: false, destructiveHint: true },
+      gmail_delete: { readOnlyHint: false, destructiveHint: true },
+    };
+    for (const r of registered) {
+      expect(r.config.annotations, r.name).toMatchObject(expected[r.name]);
+    }
+    reg.installListHandler();
+    reg.reveal('gmail');
+    const listed = (await getListHandler()!()).tools as { name: string; annotations: Record<string, unknown> }[];
+    for (const t of listed) {
+      expect(t.annotations, t.name).toMatchObject(expected[t.name]);
+    }
+  });
+
+  it('explicit annotation overrides survive through to the list handler', async () => {
+    const { server, registered, getListHandler } = fakeServer();
+    const reg = new ToolRegistry(server as never, FULL_WRITES);
+    reg.registerTool('gmail_search', { description: 'x', annotations: { readOnlyHint: false, idempotentHint: true } }, () => {});
+    reg.installListHandler();
+    reg.reveal('gmail');
+    expect(registered[0].config.annotations).toMatchObject({ readOnlyHint: false, idempotentHint: true });
+    const listed = (await getListHandler()!()).tools as { annotations: Record<string, unknown> }[];
+    expect(listed[0].annotations).toMatchObject({ readOnlyHint: false, idempotentHint: true });
+  });
+
+  it('maps service overrides so admin reporting stays under the admin service', () => {
+    const { server } = fakeServer();
+    const reg = new ToolRegistry(server as never, FULL_WRITES);
+    reg.registerTool('reports_activities_list', { description: 'x' }, () => {});
+    reg.registerTool('admin_users_list', { description: 'x' }, () => {});
+    expect(reg.services()).toEqual(['admin']);
+    expect(reg.catalog('admin').map((o) => o.tool)).toEqual(['reports_activities_list', 'admin_users_list']);
+  });
+
+  it('registerMeta marks the entry as meta and skips the catalog', () => {
+    const { server } = fakeServer();
+    const reg = new ToolRegistry(server as never, FULL_WRITES);
+    reg.registerMeta('gmail_discover', { description: 'meta' }, () => {});
+    reg.registerTool('gmail_search', { description: 'op' }, () => {});
+    expect(reg.tools[0].meta).toBe(true);
+    expect(reg.services()).toEqual(['gmail']);
+    expect(reg.catalog('gmail').map((o) => o.tool)).toEqual(['gmail_search']);
+  });
+
+  it('catalog returns summary/args/cud and filters by query', () => {
+    const { server } = fakeServer();
+    const reg = new ToolRegistry(server as never, FULL_WRITES);
+    reg.registerTool(
+      'drive_upload',
+      { description: 'Upload a file to Drive', inputSchema: { account: z.string(), path: z.string() } },
+      () => {},
+    );
+    reg.registerTool('drive_search', { description: 'Search files', inputSchema: { account: z.string() } }, () => {});
+    expect(reg.catalog('drive')).toEqual([
+      { tool: 'drive_upload', summary: 'Upload a file to Drive', args: ['account', 'path'], cud: 'create' },
+      { tool: 'drive_search', summary: 'Search files', args: ['account'], cud: 'read' },
+    ]);
+    expect(reg.catalog('drive', 'upload').map((o) => o.tool)).toEqual(['drive_upload']);
+    expect(reg.catalog('drive', 'nothing-matches')).toEqual([]);
+  });
+
+  it('reveal notifies once per service and flips visibility', () => {
+    const { server } = fakeServer();
+    const reg = new ToolRegistry(server as never, FULL_WRITES);
+    reg.registerTool('drive_search', { description: 'x' }, () => {});
+    const entry = reg.tools[0];
+    expect(reg.isVisible(entry)).toBe(false);
+    expect(reg.reveal('drive')).toBe(true);
+    expect(reg.reveal('drive')).toBe(false);
+    expect(reg.isVisible(entry)).toBe(true);
+    expect(server.sendToolListChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('list handler exposes meta tools at boot, operational tools after reveal', async () => {
+    const { server, getListHandler } = fakeServer();
+    const reg = new ToolRegistry(server as never, FULL_WRITES);
+    reg.registerTool('drive_search', { description: 'Search files', inputSchema: { account: z.string() } }, () => {});
+    reg.registerMeta('drive_discover', { description: 'meta', inputSchema: { query: z.string().optional() } }, () => {});
+    reg.installListHandler();
+    const handler = getListHandler();
+    expect(handler).toBeDefined();
+
+    const before = await handler!();
+    expect(before.tools.map((t) => (t as { name: string }).name)).toEqual(['drive_discover']);
+
+    reg.reveal('drive');
+    const after = await handler!();
+    expect(after.tools.map((t) => (t as { name: string }).name)).toEqual(['drive_search', 'drive_discover']);
+
+    const search = after.tools.find((t) => (t as { name: string }).name === 'drive_search') as {
+      inputSchema: { type: string; properties: Record<string, unknown>; required?: string[] };
+      annotations: Record<string, boolean>;
+    };
+    expect(search.inputSchema.type).toBe('object');
+    expect(Object.keys(search.inputSchema.properties)).toEqual(['account']);
+    expect(search.inputSchema.required).toEqual(['account']);
+    expect(search.annotations).toEqual({ readOnlyHint: true, destructiveHint: false });
+
+    const schemaOf = (r: { tools: unknown[] }, name: string) =>
+      (r.tools.find((t) => (t as { name: string }).name === name) as { inputSchema: unknown }).inputSchema;
+    expect(schemaOf(after, 'drive_discover')).toBe(schemaOf(before, 'drive_discover'));
+  });
+
+  it('installListHandler throws when nothing is registered', () => {
+    const { server } = fakeServer();
+    const reg = new ToolRegistry(server as never, FULL_WRITES);
+    expect(() => reg.installListHandler()).toThrow(/at least one registered tool/);
+  });
+
+  it('visibleCount tracks eager/revealed/hidden', () => {
+    const { server } = fakeServer();
+    const reg = new ToolRegistry(server as never, FULL_WRITES);
+    reg.registerTool('drive_search', { description: 'x' }, () => {});
+    reg.registerTool('gmail_search', { description: 'x' }, () => {});
+    reg.registerMeta('drive_discover', { description: 'meta' }, () => {});
+    expect(reg.visibleCount()).toEqual({ eager: 1, revealed: 0, hidden: 2 });
+    reg.reveal('drive');
+    expect(reg.visibleCount()).toEqual({ eager: 1, revealed: 1, hidden: 1 });
   });
 });

--- a/tests/toolsets.test.ts
+++ b/tests/toolsets.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { getToolsets, toolsetEnabled } from '../src/toolsets.js';
+
+describe('getToolsets', () => {
+  it('defaults to all when unset, empty, or "all"', () => {
+    expect(getToolsets({})).toBe('all');
+    expect(getToolsets({ GOOGLE_TOOLSETS: '' })).toBe('all');
+    expect(getToolsets({ GOOGLE_TOOLSETS: '  ' })).toBe('all');
+    expect(getToolsets({ GOOGLE_TOOLSETS: 'ALL' })).toBe('all');
+  });
+
+  it('parses a CSV list, trimming and lowercasing', () => {
+    const sets = getToolsets({ GOOGLE_TOOLSETS: ' Gmail, drive ,,sheets ' });
+    expect(sets).toEqual(new Set(['gmail', 'drive', 'sheets']));
+  });
+
+  it('treats "all" as the wildcard wherever it appears', () => {
+    expect(getToolsets({ GOOGLE_TOOLSETS: 'all,' })).toBe('all');
+    expect(getToolsets({ GOOGLE_TOOLSETS: 'all,gmail' })).toBe('all');
+    expect(getToolsets({ GOOGLE_TOOLSETS: 'gmail,ALL' })).toBe('all');
+  });
+
+  it('a CSV of only separators falls back to all', () => {
+    expect(getToolsets({ GOOGLE_TOOLSETS: ',' })).toBe('all');
+    expect(getToolsets({ GOOGLE_TOOLSETS: ' , , ' })).toBe('all');
+  });
+});
+
+describe('toolsetEnabled', () => {
+  it('all enables everything', () => {
+    expect(toolsetEnabled('all', 'gmail')).toBe(true);
+  });
+
+  it('a list enables only its members', () => {
+    const sets = new Set(['gmail']);
+    expect(toolsetEnabled(sets, 'gmail')).toBe(true);
+    expect(toolsetEnabled(sets, 'drive')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 1 of the v5 roadmap (milestone "v5 · Phase 1 — Tool architecture").

- **Boot surface**: `tools/list` exposes only `{service}_discover` meta-tools (one per enabled service) — ~1k tokens idle instead of ~40k+ for 173 schemas.
- **Discovery**: `{service}_discover` returns the operation catalog (`tool`, `summary`, `args`, `cud`, write-control posture), reveals the service, emits `notifications/tools/list_changed`; optional `query` filters the catalog.
- **Graceful dispatch**: all operational tools stay registered and callable at all times — hiding is a custom `tools/list` handler, not a call gate. Existing prompts that call tools by name keep working with zero discovery overhead.
- **Annotations**: computed from cud (`readOnlyHint`, `destructiveHint`; updates are destructive per MCP spec semantics — false claims "additive only"), explicit overrides honored on both paths.
- **`GOOGLE_TOOLSETS`** (`all` | CSV): service filter with actionable failure modes (fail-fast on empty selection, stderr hint when a requested service lacks its enabling env, `all` recognized as wildcard anywhere in the CSV).
- `reports_activities_list` mapped under `admin` so the discover/toolset surface is consistent.

Deliberately **not** emitting `tool_reference` content blocks or server-side `defer_loading`: verified against SDK 1.29.0 that strict clients reject unknown content types and strip nonstandard Tool fields. `tools/list_changed` gating is the durable mechanism.

## Review
4-lens adversarial review (correctness, MCP contract, security/conventions, tests/docs) with per-finding verification: 11 findings confirmed, all fixed in this diff (empty-toolset boot crash diagnostics, update-cud destructiveHint, annotation override drop on the list path, `all,` parsing, ghost `reports` service, docs/test gaps).

## Test plan
- [x] typecheck, lint, build clean
- [x] 157/157 unit tests (annotations per cud class on both paths, override passthrough, schema-cache identity, toolset wildcard/empty-CSV edges, service override, discover catalog/reveal/notify)
- [x] Live stdio smoke (real MCP client): 9 discover tools at boot, catalog reveal + exactly one list_changed, 44 tools post-reveal, hidden tool dispatches gracefully, destructive annotation on revealed delete tool
- [x] Failure modes: `GOOGLE_TOOLSETS=forms` without bundle → stderr hint + actionable fatal; `GOOGLE_TOOLSETS=all,` boots normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)