### PR TITLE
fix: retry transfer share without expirationTime on consumer accounts

### DIFF
--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -1495,18 +1495,27 @@ async function shareAndCopy(
   intendedName: string,
   parentFolderId: string | undefined,
 ): Promise<{ data: drive_v3.Schema$File; cleanupFailed: boolean; renameFailed: boolean }> {
-  const perm = await sourceDrive.permissions.create({
-    fileId,
-    requestBody: {
-      type: 'user',
-      role: 'reader',
-      emailAddress: targetEmail,
-      expirationTime: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-    },
-    sendNotificationEmail: false,
-    supportsAllDrives: true,
-    fields: 'id',
-  });
+  const share = (expiration: boolean) =>
+    sourceDrive.permissions.create({
+      fileId,
+      requestBody: {
+        type: 'user',
+        role: 'reader',
+        emailAddress: targetEmail,
+        ...(expiration ? { expirationTime: new Date(Date.now() + 60 * 60 * 1000).toISOString() } : {}),
+      },
+      sendNotificationEmail: false,
+      supportsAllDrives: true,
+      fields: 'id',
+    });
+  let perm;
+  try {
+    perm = await share(true);
+  } catch (err) {
+    // consumer Gmail rejects expirationTime; the finally-revoke still cleans up
+    if (!/expiration/i.test((err as Error).message ?? '')) throw err;
+    perm = await share(false);
+  }
   let cleanupFailed = false;
   let renameFailed = false;
   let data: drive_v3.Schema$File;


### PR DESCRIPTION
## Summary
Live smoke between real accounts caught this: consumer Gmail rejects `expirationTime` on `permissions.create`, so `drive_transfer`'s share+copy primary always fell back to download+upload for consumer sources. Now retries the grant without the expiration on that specific error (the `finally` revoke still cleans up; only the 1h dead-man backstop is skipped).

## Test plan
- [x] 260/260 unit tests, typecheck/lint/build clean
- [x] Real-account smoke against the patched dist (Infisical env): consumer→Workspace = `share_copy` with clean name + revoked share; Workspace→consumer `share_copy` + `move` still green; all smoke files trashed

🤖 Generated with [Claude Code](https://claude.com/claude-code)