### PR TITLE
fix: harden token persistence and toolset filtering

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 import { google } from 'googleapis';
 import { ACCOUNT_CONFIG } from './accounts.js';
 import type { Account } from './accounts.js';
-import { readToken, writeToken } from './token-store.js';
+import { readToken, updateToken } from './token-store.js';
 
 export async function getClient(account: Account) {
   const config = ACCOUNT_CONFIG[account];
@@ -30,8 +30,7 @@ export async function getClient(account: Account) {
   oauth2Client.setCredentials(tokenData);
 
   oauth2Client.on('tokens', (tokens) => {
-    const existing = readToken(account) ?? {};
-    writeToken(account, { ...existing, ...tokens });
+    updateToken(account, tokens);
   });
 
   return oauth2Client;

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -6,6 +6,8 @@ import type { TokenData } from './types.js';
 
 const ENC_VERSION = 1;
 const ALGO = 'aes-256-gcm';
+const LOCK_TIMEOUT_MS = 5_000;
+const LOCK_RETRY_MS = 10;
 
 interface EncFile {
   v: number;
@@ -71,10 +73,92 @@ export function readToken(alias: string): TokenData | null {
   return decryptToken(contents, masterKey());
 }
 
-export function writeToken(alias: string, data: object): void {
+function sleep(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function withTokenLock<T>(alias: string, fn: () => T): T {
   const p = ACCOUNT_CONFIG[alias].encPath;
-  fs.mkdirSync(path.dirname(p), { recursive: true });
-  fs.writeFileSync(p, encryptToken(data, masterKey()), { mode: 0o600 });
+  const dir = path.dirname(p);
+  const lock = path.join(dir, `.${path.basename(p)}.lock`);
+  const ownerFile = `${lock}.${process.pid}.${randomBytes(6).toString('hex')}.owner`;
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(ownerFile, String(process.pid), { mode: 0o600, flag: 'wx' });
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+  try {
+    while (true) {
+      try {
+        fs.linkSync(ownerFile, lock);
+        break;
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code !== 'EEXIST') throw error;
+        try {
+          const observedOwner = fs.readFileSync(lock, 'utf8');
+          const owner = Number(observedOwner);
+          if (Number.isSafeInteger(owner) && owner > 0) {
+            try {
+              process.kill(owner, 0);
+            } catch (ownerError) {
+              if ((ownerError as NodeJS.ErrnoException).code !== 'ESRCH') throw ownerError;
+              if (fs.readFileSync(lock, 'utf8') === observedOwner) fs.rmSync(lock, { force: true });
+              continue;
+            }
+          }
+        } catch (readError) {
+          if ((readError as NodeJS.ErrnoException).code === 'ENOENT') {
+            continue;
+          }
+          throw readError;
+        }
+        if (Date.now() >= deadline) {
+          throw new Error(`Timed out waiting for token lock: ${alias}`, { cause: error });
+        }
+        sleep(LOCK_RETRY_MS);
+      }
+    }
+  } finally {
+    fs.rmSync(ownerFile, { force: true });
+  }
+
+  try {
+    return fn();
+  } finally {
+    fs.rmSync(lock, { force: true });
+  }
+}
+
+function writeTokenAtomic(alias: string, data: object): void {
+  const p = ACCOUNT_CONFIG[alias].encPath;
+  const dir = path.dirname(p);
+  const tmp = path.join(dir, `.${path.basename(p)}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`);
+  try {
+    fs.writeFileSync(tmp, encryptToken(data, masterKey()), { mode: 0o600, flag: 'wx' });
+    const fd = fs.openSync(tmp, 'r');
+    try {
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    fs.renameSync(tmp, p);
+  } finally {
+    fs.rmSync(tmp, { force: true });
+  }
+}
+
+export function writeToken(alias: string, data: object): void {
+  withTokenLock(alias, () => writeTokenAtomic(alias, data));
+}
+
+export function updateToken(alias: string, updates: object): void {
+  withTokenLock(alias, () => {
+    const existing = readToken(alias) ?? {};
+    const definedUpdates = Object.fromEntries(
+      Object.entries(updates).filter(([, value]) => value !== null && value !== undefined),
+    );
+    writeTokenAtomic(alias, { ...existing, ...definedUpdates });
+  });
 }
 
 export function hasToken(alias: string): boolean {

--- a/src/tools/google-api.ts
+++ b/src/tools/google-api.ts
@@ -23,24 +23,24 @@ const MAX_RESPONSE_CHARS = 100_000;
 
 // Policy/toolset namespace for each API alias must match the NAMED tools' service
 // names, or user deny globs and GOOGLE_TOOLSETS silently miss escape-hatch calls.
-const SERVICE_FOR_ALIAS: Record<string, string | null> = {
+const SERVICE_FOR_ALIAS: Record<string, string> = {
   gmail: 'gmail',
   drive: 'drive',
   calendar: 'calendar',
   sheets: 'sheets',
   docs: 'docs',
-  slides: null,
+  slides: 'slides',
   forms: 'forms',
   people: 'contacts',
   searchconsole: 'searchconsole',
   tasks: 'tasks',
   chat: 'chat',
   meet: 'meet',
-  driveactivity: null,
-  drivelabels: null,
+  driveactivity: 'driveactivity',
+  drivelabels: 'drivelabels',
   admin_directory: 'admin',
   admin_reports: 'admin',
-  groupssettings: null,
+  groupssettings: 'groupssettings',
 };
 
 export interface EscapeDeps extends DiscoveryDeps {
@@ -83,9 +83,9 @@ function describeMethod(m: DiscoveryMethod) {
 export function registerEscapeTools(registry: ToolRegistry, policy: Policy, deps: EscapeDeps = {}): void {
   const getClientFn = deps.getClientFn ?? getClient;
   const toolsets = deps.toolsets ?? getToolsets();
+  const serviceForAlias = (alias: string): string => SERVICE_FOR_ALIAS[alias] ?? alias;
   const apiEnabled = (alias: string): boolean => {
-    const service = SERVICE_FOR_ALIAS[alias];
-    return service === null || service === undefined || toolsetEnabled(toolsets, service);
+    return toolsetEnabled(toolsets, serviceForAlias(alias));
   };
   const enabledApis = Object.keys(WORKSPACE_APIS).filter(apiEnabled);
   const apiList = enabledApis.join(', ');
@@ -93,7 +93,7 @@ export function registerEscapeTools(registry: ToolRegistry, policy: Policy, deps
     jsonResult(
       {
         error: 'toolset_disabled',
-        message: `API "${alias}" maps to service "${SERVICE_FOR_ALIAS[alias]}", which is excluded by GOOGLE_TOOLSETS.`,
+        message: `API "${alias}" maps to service "${serviceForAlias(alias)}", which is excluded by GOOGLE_TOOLSETS.`,
         hint: 'Add the service to GOOGLE_TOOLSETS (or unset it) to use this API.',
         retriable: false,
       },
@@ -206,7 +206,7 @@ export function registerEscapeTools(registry: ToolRegistry, policy: Policy, deps
       }
 
       const cud = cudFromMethod(method);
-      const policyService = SERVICE_FOR_ALIAS[api as string] ?? (api as string);
+      const policyService = serviceForAlias(api as string);
       const lastSegment = method.id.split('.').pop() ?? method.id;
       const toolRef = { name: `${policyService}_${lastSegment}`, service: policyService, cud };
       if (cud !== 'read' && !isAllowed(toolRef, policy)) {

--- a/tests/google-api.test.ts
+++ b/tests/google-api.test.ts
@@ -241,11 +241,18 @@ describe('google_api_call', () => {
     expect(JSON.parse(searchBlocked.content[0].text).error).toBe('toolset_disabled');
   });
 
-  it('keeps serviceless APIs available regardless of GOOGLE_TOOLSETS', async () => {
-    const { call, dir } = setup(FULL, { toolsets: new Set(['drive']) });
+  it('requires an explicit toolset for APIs without dedicated named tools', async () => {
+    const { call, search, dir } = setup(FULL, { toolsets: new Set(['drive']) });
     cleanupDirs.push(dir);
-    const res = await call({ account: 'test', api: 'slides', methodId: 'slides.nope' });
-    expect(JSON.parse(res.content[0].text).error).toBe('unknown_method');
+    const blockedCall = await call({ account: 'test', api: 'slides', methodId: 'slides.nope' });
+    expect(JSON.parse(blockedCall.content[0].text).error).toBe('toolset_disabled');
+    const blockedSearch = await search({ query: 'presentation', api: 'slides' });
+    expect(JSON.parse(blockedSearch.content[0].text).error).toBe('toolset_disabled');
+
+    const explicit = setup(FULL, { toolsets: new Set(['slides']) });
+    cleanupDirs.push(explicit.dir);
+    const enabled = await explicit.call({ account: 'test', api: 'slides', methodId: 'slides.nope' });
+    expect(JSON.parse(enabled.content[0].text).error).toBe('unknown_method');
   });
 
   it('refuses to send credentials to non-googleapis hosts (poisoned cache)', async () => {

--- a/tests/token-store.test.ts
+++ b/tests/token-store.test.ts
@@ -1,8 +1,22 @@
-import { describe, it, expect } from 'vitest';
-import { deriveKey, encryptToken, decryptToken } from '../src/token-store.js';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ACCOUNT_CONFIG } from '../src/accounts.js';
+import { deriveKey, encryptToken, decryptToken, readToken, writeToken, updateToken } from '../src/token-store.js';
 
 const KEY = 'test-master-key';
 const sample = { refresh_token: 'r', access_token: 'a', scope: 's', expiry_date: 123 };
+
+const originalPath = ACCOUNT_CONFIG.test.encPath;
+const cleanupDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  ACCOUNT_CONFIG.test.encPath = originalPath;
+  delete process.env.MASTER_KEY;
+  for (const dir of cleanupDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
+});
 
 describe('token-store crypto', () => {
   it('round-trips a token object', () => {
@@ -52,5 +66,50 @@ describe('token-store crypto', () => {
 
   it('derives a 32-byte key from an arbitrary passphrase', () => {
     expect(deriveKey('short')).toHaveLength(32);
+  });
+
+  it('keeps the previous token readable when a replacement write fails', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
+    cleanupDirs.push(dir);
+    ACCOUNT_CONFIG.test.encPath = path.join(dir, 'test.enc');
+    process.env.MASTER_KEY = KEY;
+    writeToken('test', sample);
+
+    const originalWrite = fs.writeFileSync.bind(fs);
+    let interrupted = false;
+    vi.spyOn(fs, 'writeFileSync').mockImplementation((file, data, options) => {
+      if (typeof file === 'number' || interrupted) return originalWrite(file, data, options);
+      interrupted = true;
+      originalWrite(file, String(data).slice(0, 12), options);
+      throw new Error('simulated interrupted write');
+    });
+
+    expect(() => writeToken('test', { ...sample, access_token: 'new' })).toThrow(/interrupted/);
+    expect(interrupted).toBe(true);
+    expect(readToken('test')).toEqual(sample);
+  });
+
+  it('recovers a token lock left by a dead process', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
+    cleanupDirs.push(dir);
+    ACCOUNT_CONFIG.test.encPath = path.join(dir, 'test.enc');
+    process.env.MASTER_KEY = KEY;
+    fs.writeFileSync(path.join(dir, '.test.enc.lock'), '2147483647', { mode: 0o600 });
+
+    writeToken('test', sample);
+
+    expect(readToken('test')).toEqual(sample);
+  });
+
+  it('merges refresh updates with the latest token inside the store boundary', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
+    cleanupDirs.push(dir);
+    ACCOUNT_CONFIG.test.encPath = path.join(dir, 'test.enc');
+    process.env.MASTER_KEY = KEY;
+    writeToken('test', sample);
+
+    updateToken('test', { access_token: 'new', refresh_token: null, expiry_date: 456 });
+
+    expect(readToken('test')).toEqual({ ...sample, access_token: 'new', expiry_date: 456 });
   });
 });


### PR DESCRIPTION
## Summary
- Make encrypted token replacement atomic and serialize cross-process refresh updates.
- Require explicit toolset opt-in for escape-hatch APIs without dedicated named tools.
- Add regression coverage for interrupted writes, stale locks, partial refresh events, and toolset filtering.

## Scope
- Affected areas: auth runtime, Google API escape hatch, tests
- In scope: token persistence and toolset boundary
- Out of scope: OAuth scope selection and named Google tools

## Why
Direct writes can leave an encrypted token unreadable if interrupted, while concurrent refresh events can lose fields after a stale read. APIs mapped to `null` also bypass `GOOGLE_TOOLSETS`, exposing discovery entries outside the configured service set.

## Root Cause
- Token refresh performs read/merge/write outside a shared lock and writes directly to the canonical file.
- Escape-hatch aliases with no named-tool mapping are treated as enabled under every toolset.

## Changes
- Add a per-account process lock, dead-owner recovery, atomic temp-file replacement, and merge-under-lock refresh updates.
- Ignore null/undefined fields from partial Google credential events.
- Give serviceless APIs explicit namespaces and fail closed for future unmapped aliases.
- Add focused regression tests.

## Migrations / Data
- Schema changes: none
- Data migration/backfill required: none
- Roll-forward plan: existing encrypted token files remain compatible
- Rollback impact: revert this commit; no stored-data conversion is required

## Flags / Config
- New or changed env vars: none
- Feature flags added/changed: none
- Default values and safe fallback behavior: configured toolsets now exclude non-matching escape-hatch APIs

## Security / Privacy
- Auth/authz impact: narrows escape-hatch discovery to configured toolsets
- Sensitive data/PII impact: protects encrypted OAuth token files from partial and stale concurrent replacement
- Input validation/error-handling changes: lock acquisition times out after five seconds and recovers locks owned by dead processes
- Secret handling impact: no secret values are logged or migrated

## Performance / Accessibility
- Performance impact: refresh writes add a very short per-account filesystem lock and fsync; normal reads are unchanged
- Accessibility impact: none

## Risks / Rollout
- What could break? Callers that relied on serviceless APIs being implicitly enabled must add that API alias to `GOOGLE_TOOLSETS`.
- Edge cases considered: interrupted write, concurrent processes, dead lock owner, null refresh fields, explicit serviceless API opt-in
- Rollout plan: merge to `dev`, then include in the next release
- Mitigation plan: existing `GOOGLE_TOOLSETS=all` behavior remains unchanged

## How to Test
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`
- Expected: typecheck/lint/build succeed and all 263 tests pass

## Verification
- [x] `npm run typecheck` -> pass
- [x] `npm run lint` -> pass
- [x] `npm test` -> 16 files, 263 tests passed
- [x] `npm run build` -> pass
- [x] Additional check -> `git diff --check` passed

## Rollback
- Revert commit `483e241`; token format is unchanged.

## Follow-ups
- Required follow-up tasks: release the fix and update downstream pins
- Items added to `todo.md`: none; upstream repository does not use the local project ledger
