### PR TITLE
fix: recover corrupt token locks and tolerate unsignalable lock owners

### DIFF
--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -97,14 +97,24 @@ function withTokenLock<T>(alias: string, fn: () => T): T {
         try {
           const observedOwner = fs.readFileSync(lock, 'utf8');
           const owner = Number(observedOwner);
-          if (Number.isSafeInteger(owner) && owner > 0) {
+          // Non-PID content can only come from a corrupt or interrupted lock
+          // write — recover it like a dead owner instead of spinning to timeout.
+          let ownerDead = !(Number.isSafeInteger(owner) && owner > 0);
+          if (!ownerDead) {
             try {
               process.kill(owner, 0);
             } catch (ownerError) {
-              if ((ownerError as NodeJS.ErrnoException).code !== 'ESRCH') throw ownerError;
-              if (fs.readFileSync(lock, 'utf8') === observedOwner) fs.rmSync(lock, { force: true });
-              continue;
+              const code = (ownerError as NodeJS.ErrnoException).code;
+              // EPERM: the PID exists but is not signalable (recycled by another
+              // user) — treat as alive and wait out the timeout rather than
+              // break a lock we cannot verify.
+              if (code === 'ESRCH') ownerDead = true;
+              else if (code !== 'EPERM') throw ownerError;
             }
+          }
+          if (ownerDead) {
+            if (fs.readFileSync(lock, 'utf8') === observedOwner) fs.rmSync(lock, { force: true });
+            continue;
           }
         } catch (readError) {
           if ((readError as NodeJS.ErrnoException).code === 'ENOENT') {

--- a/tests/token-store.test.ts
+++ b/tests/token-store.test.ts
@@ -101,6 +101,38 @@ describe('token-store crypto', () => {
     expect(readToken('test')).toEqual(sample);
   });
 
+  it('recovers a token lock containing non-PID garbage', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
+    cleanupDirs.push(dir);
+    ACCOUNT_CONFIG.test.encPath = path.join(dir, 'test.enc');
+    process.env.MASTER_KEY = KEY;
+    fs.writeFileSync(path.join(dir, '.test.enc.lock'), 'not-a-pid', { mode: 0o600 });
+
+    writeToken('test', sample);
+
+    expect(readToken('test')).toEqual(sample);
+  });
+
+  it('treats an unsignalable lock owner (EPERM) as alive and times out', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
+    cleanupDirs.push(dir);
+    ACCOUNT_CONFIG.test.encPath = path.join(dir, 'test.enc');
+    process.env.MASTER_KEY = KEY;
+    const lock = path.join(dir, '.test.enc.lock');
+    fs.writeFileSync(lock, '12345', { mode: 0o600 });
+
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('EPERM') as NodeJS.ErrnoException;
+      err.code = 'EPERM';
+      throw err;
+    });
+    let now = 0;
+    vi.spyOn(Date, 'now').mockImplementation(() => (now += 6_000));
+
+    expect(() => writeToken('test', sample)).toThrow(/Timed out waiting for token lock/);
+    expect(fs.readFileSync(lock, 'utf8')).toBe('12345');
+  });
+
   it('merges refresh updates with the latest token inside the store boundary', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
     cleanupDirs.push(dir);


### PR DESCRIPTION
## Summary
Follow-up to #67 addressing the two lock-recovery edge cases noted in review.

## Changes
- A lock file whose content is not a positive PID (corrupt or interrupted lock write) is now recovered like a dead owner instead of stalling every write to the 5s timeout until removed by hand.
- `EPERM` from the liveness probe (PID recycled by a process we cannot signal) no longer crashes the write; the owner is treated as alive and the writer waits out the timeout rather than breaking a lock it cannot verify.
- Regression tests for both paths (garbage lock recovery; EPERM -> timeout with the lock left intact).

## Verification
- `npm run typecheck` / `npm run lint` / `npm run build` pass
- `npm test`: 16 files, 265 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)