### PR TITLE
fix: open temp token file read-write so fsync succeeds on Windows

### DIFF
--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -145,7 +145,9 @@ function writeTokenAtomic(alias: string, data: object): void {
   const tmp = path.join(dir, `.${path.basename(p)}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`);
   try {
     fs.writeFileSync(tmp, encryptToken(data, masterKey()), { mode: 0o600, flag: 'wx' });
-    const fd = fs.openSync(tmp, 'r');
+    // Open read-write, not read-only: on Windows fsync maps to FlushFileBuffers,
+    // which returns EPERM on a read-only handle.
+    const fd = fs.openSync(tmp, 'r+');
     try {
       fs.fsyncSync(fd);
     } finally {


### PR DESCRIPTION
## Problem

On Windows, `mcp-google-multi auth --account <alias>` fails immediately after the browser consent step:

```
Opening browser for authorization...
Fatal error: EPERM: operation not permitted, fsync
```

No token is ever written, so authenticating any account is impossible on Windows.

## Root cause

`writeTokenAtomic` in `src/token-store.ts` opens the freshly written temp file **read-only** before flushing it:

```js
fs.writeFileSync(tmp, encryptToken(data, masterKey()), { mode: 0o600, flag: 'wx' });
const fd = fs.openSync(tmp, 'r');   // read-only handle
try {
  fs.fsyncSync(fd);
} finally {
  fs.closeSync(fd);
}
```

On Windows, `fsync` maps to `FlushFileBuffers`, which requires a handle opened with write access and returns `EPERM` on a read-only handle. POSIX permits `fsync` on a read-only descriptor, so this passes on Linux/macOS but breaks every Windows user.

## Fix

Open the descriptor read-write (`'r+'`). The file already exists (it was just written), so `'r+'` succeeds, and the durability guarantee is unchanged. Behavior on POSIX is identical.

```js
const fd = fs.openSync(tmp, 'r+');
```

## Testing

- **Before:** `auth` fails on Windows 10 (Node 24) with the `EPERM` error above; no token file is written.
- **After:** the encrypted token is written and `auth` completes ("Token saved (encrypted)"); subsequent reads decrypt correctly.
- Unaffected on macOS/Linux, where `fsync` on a read-only fd was already permitted.

One-line change; no API or behavior change on existing platforms.
