### PR TITLE
chore: promote dev to staging (Windows fsync fix)

### DIFF
--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -145,7 +145,9 @@ function writeTokenAtomic(alias: string, data: object): void {
   const tmp = path.join(dir, `.${path.basename(p)}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`);
   try {
     fs.writeFileSync(tmp, encryptToken(data, masterKey()), { mode: 0o600, flag: 'wx' });
-    const fd = fs.openSync(tmp, 'r');
+    // Open read-write, not read-only: on Windows fsync maps to FlushFileBuffers,
+    // which returns EPERM on a read-only handle.
+    const fd = fs.openSync(tmp, 'r+');
     try {
       fs.fsyncSync(fd);
     } finally {


### PR DESCRIPTION
Promotes the Windows token-write fix (#73, thanks @mjreddy) to the beta channel.

v5.1.1 regressed Windows: `writeTokenAtomic` reopened the temp token file read-only before `fsyncSync`, and on Windows fsync maps to `FlushFileBuffers`, which requires a writable handle (EPERM otherwise). Auth and token refresh were broken for all Windows users on stable. Fix verified against libuv source, MSDN, and nodejs/node#3879; 265/265 tests green.

Will be promoted to stable immediately after the beta cut, since stable is the broken channel.