### PR TITLE
chore: promote staging to main (5.1.2 — Windows fsync fix)

### DIFF
--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -145,7 +145,9 @@ function writeTokenAtomic(alias: string, data: object): void {
   const tmp = path.join(dir, `.${path.basename(p)}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`);
   try {
     fs.writeFileSync(tmp, encryptToken(data, masterKey()), { mode: 0o600, flag: 'wx' });
-    const fd = fs.openSync(tmp, 'r');
+    // Open read-write, not read-only: on Windows fsync maps to FlushFileBuffers,
+    // which returns EPERM on a read-only handle.
+    const fd = fs.openSync(tmp, 'r+');
     try {
       fs.fsyncSync(fd);
     } finally {


### PR DESCRIPTION
Promotes 5.1.2-beta.1 to stable.

Contains the Windows token-write fix (#73, thanks @mjreddy): `writeTokenAtomic` reopened the temp token file read-only before `fsyncSync`; on Windows fsync maps to `FlushFileBuffers`, which requires a writable handle, so 5.1.1 broke auth and token refresh for all Windows users. Verified against libuv source, MSDN, and nodejs/node#3879; 265/265 tests green; published beta tarball confirmed to contain the `'r+'` change.

Fast-tracked because stable is the affected channel.