### PR TITLE
fix: retry token rename through transient Windows sharing violations

### DIFF
--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -8,6 +8,8 @@ const ENC_VERSION = 1;
 const ALGO = 'aes-256-gcm';
 const LOCK_TIMEOUT_MS = 5_000;
 const LOCK_RETRY_MS = 10;
+const RENAME_ATTEMPTS = 5;
+const RENAME_RETRY_MS = 20;
 
 interface EncFile {
   v: number;
@@ -153,9 +155,33 @@ function writeTokenAtomic(alias: string, data: object): void {
     } finally {
       fs.closeSync(fd);
     }
-    fs.renameSync(tmp, p);
+    renameWithRetry(tmp, p);
   } finally {
-    fs.rmSync(tmp, { force: true });
+    try {
+      fs.rmSync(tmp, { force: true });
+    } catch {
+      // force only suppresses ENOENT; a Windows handle-holder can make this
+      // throw and mask the real write error. The orphan tmp is harmless.
+    }
+  }
+}
+
+// Windows uses classic rename semantics (MoveFileExW without POSIX semantics),
+// so replacing a token file that another process momentarily holds open — a
+// concurrent readToken, antivirus, an indexer — fails with a transient
+// EPERM/EACCES/EBUSY. Reads take no lock, so the token lock cannot prevent
+// this; a short bounded retry absorbs it. POSIX rename never fails this way.
+function renameWithRetry(from: string, to: string): void {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      fs.renameSync(from, to);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      const transient = code === 'EPERM' || code === 'EACCES' || code === 'EBUSY';
+      if (!transient || attempt >= RENAME_ATTEMPTS) throw error;
+      sleep(RENAME_RETRY_MS * attempt);
+    }
   }
 }
 

--- a/tests/token-store.test.ts
+++ b/tests/token-store.test.ts
@@ -133,6 +133,87 @@ describe('token-store crypto', () => {
     expect(fs.readFileSync(lock, 'utf8')).toBe('12345');
   });
 
+  it('retries the token rename through transient sharing violations', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
+    cleanupDirs.push(dir);
+    ACCOUNT_CONFIG.test.encPath = path.join(dir, 'test.enc');
+    process.env.MASTER_KEY = KEY;
+
+    const originalRename = fs.renameSync.bind(fs);
+    let failures = 0;
+    const spy = vi.spyOn(fs, 'renameSync').mockImplementation((from, to) => {
+      if (failures < 2) {
+        failures++;
+        const err = new Error('EPERM: operation not permitted, rename') as NodeJS.ErrnoException;
+        err.code = 'EPERM';
+        throw err;
+      }
+      return originalRename(from, to);
+    });
+
+    writeToken('test', sample);
+
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(readToken('test')).toEqual(sample);
+  });
+
+  it('gives up on the rename after bounded attempts', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
+    cleanupDirs.push(dir);
+    ACCOUNT_CONFIG.test.encPath = path.join(dir, 'test.enc');
+    process.env.MASTER_KEY = KEY;
+
+    const spy = vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      const err = new Error('EBUSY: resource busy or locked, rename') as NodeJS.ErrnoException;
+      err.code = 'EBUSY';
+      throw err;
+    });
+
+    expect(() => writeToken('test', sample)).toThrow(/EBUSY/);
+    expect(spy).toHaveBeenCalledTimes(5);
+    expect(readToken('test')).toBeNull();
+  });
+
+  it('does not retry the rename on non-transient errors', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
+    cleanupDirs.push(dir);
+    ACCOUNT_CONFIG.test.encPath = path.join(dir, 'test.enc');
+    process.env.MASTER_KEY = KEY;
+
+    const spy = vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      const err = new Error('ENOENT: no such file or directory, rename') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    expect(() => writeToken('test', sample)).toThrow(/ENOENT/);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let tmp cleanup failures mask the rename error', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
+    cleanupDirs.push(dir);
+    ACCOUNT_CONFIG.test.encPath = path.join(dir, 'test.enc');
+    process.env.MASTER_KEY = KEY;
+
+    vi.spyOn(fs, 'renameSync').mockImplementation(() => {
+      const err = new Error('EBUSY: resource busy or locked, rename') as NodeJS.ErrnoException;
+      err.code = 'EBUSY';
+      throw err;
+    });
+    const originalRm = fs.rmSync.bind(fs);
+    vi.spyOn(fs, 'rmSync').mockImplementation((target, options) => {
+      if (String(target).endsWith('.tmp')) {
+        const err = new Error('EPERM: operation not permitted, unlink') as NodeJS.ErrnoException;
+        err.code = 'EPERM';
+        throw err;
+      }
+      return originalRm(target, options);
+    });
+
+    expect(() => writeToken('test', sample)).toThrow(/EBUSY/);
+  });
+
   it('merges refresh updates with the latest token inside the store boundary', () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-store-'));
     cleanupDirs.push(dir);


### PR DESCRIPTION
Follow-up to #73, closing the main remaining Windows finding from its verification sweep.

## Problem

Windows uses classic rename semantics (`MoveFileExW` with `MOVEFILE_REPLACE_EXISTING`, not `FILE_RENAME_POSIX_SEMANTICS`), so `writeTokenAtomic`'s final `renameSync(tmp, dest)` fails with a transient `EPERM`/`EACCES`/`EBUSY` if any process momentarily holds the destination open: a concurrent `readToken` from another server instance (reads take no lock, by design), an antivirus on-access scan, an indexer. The token lock only serializes writers, so it cannot prevent this. POSIX rename replaces open targets silently, which is why this never fires on Linux/macOS.

## Fix

- Bounded retry around the rename: 5 attempts, linear backoff (20/40/60/80ms, ~200ms worst case), only for `EPERM`/`EACCES`/`EBUSY`; other codes rethrow immediately. Runs under the token lock, so the budget is kept deliberately small relative to the 5s lock deadline concurrent writers spin against.
- The `finally` tmp-file cleanup no longer masks the real write error: `rmSync(force)` only suppresses `ENOENT`, so the same handle-holder that defeated the rename could throw from cleanup and replace the informative error. Cleanup failures are now swallowed; an orphan `.tmp` is harmless.

## Testing

Three new regression tests (transient failures then success; bounded give-up preserving the error; non-transient codes fail fast) plus one for the error-masking path. 269/269 green, typecheck/lint/build pass. Diff adversarially reviewed by two independent lenses (correctness/concurrency + Windows rename semantics vs libuv error mappings); both verdicts: ship.

Stays at alpha: no promotion planned with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)