### PR TITLE
chore: add discovery snapshot fetcher (gen:discovery)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/server-destroy": "^1.0.3",
         "eslint": "^10.2.1",
         "semantic-release": "^25.0.3",
+        "tsx": "^4.23.1",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.1",
         "vitest": "^3.2.6"
@@ -9107,6 +9108,25 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/tunnel": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-google-multi",
   "version": "0.0.0-semantically-released",
-  "description": "Local MCP server for Google Workspace (Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console, +Forms/Chat/Admin) across multiple accounts — OAuth-only, encrypted token storage, deny-by-default writes.",
+  "description": "Local MCP server for Google Workspace (Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console, +Forms/Chat/Admin) across multiple accounts \u2014 OAuth-only, encrypted token storage, deny-by-default writes.",
   "type": "module",
   "license": "MIT",
   "bin": {
@@ -52,9 +52,10 @@
     "auth": "node dist/index.js auth --account",
     "migrate-tokens": "node dist/index.js migrate-tokens",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.scripts.json",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "gen:discovery": "tsx scripts/fetch-discovery.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -72,6 +73,7 @@
     "@types/server-destroy": "^1.0.3",
     "eslint": "^10.2.1",
     "semantic-release": "^25.0.3",
+    "tsx": "^4.23.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1",
     "vitest": "^3.2.6"

--- a/scripts/fetch-discovery.ts
+++ b/scripts/fetch-discovery.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Google Workspace API Discovery snapshot fetcher.
+// Usage: npm run gen:discovery
+// Writes discovery/<id>.<version>.json + discovery/MANIFEST.md (directory is gitignored;
+// the snapshot feeds gen:tools and is refreshed on Google API revisions).
+
+interface Api {
+  id: string;
+  version: string;
+}
+
+const APIS: Api[] = [
+  { id: 'admin', version: 'datatransfer_v1' },
+  { id: 'admin', version: 'directory_v1' },
+  { id: 'admin', version: 'reports_v1' },
+  { id: 'alertcenter', version: 'v1beta1' },
+  { id: 'appsmarket', version: 'v2' },
+  { id: 'calendar', version: 'v3' },
+  { id: 'chat', version: 'v1' },
+  { id: 'classroom', version: 'v1' },
+  { id: 'cloudidentity', version: 'v1' },
+  { id: 'cloudsearch', version: 'v1' },
+  { id: 'docs', version: 'v1' },
+  { id: 'drive', version: 'v2' },
+  { id: 'drive', version: 'v3' },
+  { id: 'driveactivity', version: 'v2' },
+  { id: 'drivelabels', version: 'v2' },
+  { id: 'forms', version: 'v1' },
+  { id: 'gmail', version: 'v1' },
+  { id: 'gmailpostmastertools', version: 'v1' },
+  { id: 'groupsmigration', version: 'v1' },
+  { id: 'groupssettings', version: 'v1' },
+  { id: 'keep', version: 'v1' },
+  { id: 'licensing', version: 'v1' },
+  { id: 'meet', version: 'v2' },
+  { id: 'people', version: 'v1' },
+  { id: 'reseller', version: 'v1' },
+  { id: 'script', version: 'v1' },
+  { id: 'searchconsole', version: 'v1' },
+  { id: 'sheets', version: 'v4' },
+  { id: 'slides', version: 'v1' },
+  { id: 'tasks', version: 'v1' },
+  { id: 'vault', version: 'v1' },
+  { id: 'workspaceevents', version: 'v1' },
+];
+
+// Not fetchable: gsuiteaddons v1 (discovery endpoint requires auth), Marketplace SDK
+// (Cloud Console config, not a REST API), CalDAV (IETF protocol). Tracked in MANIFEST.md.
+const NO_DISCOVERY: Array<{ name: string; reason: string }> = [
+  { name: 'gsuiteaddons v1', reason: 'discovery endpoint requires an authenticated, API-enabled project' },
+  { name: 'Workspace Marketplace SDK', reason: 'configured in Cloud Console; not a discovery-backed REST API' },
+  { name: 'CalDAV', reason: 'IETF protocol (RFC 4791); no Google discovery document' },
+];
+
+const OUT_DIR = path.join(process.cwd(), 'discovery');
+const TIMEOUT_MS = 15_000;
+
+function countMethods(node: unknown): number {
+  if (typeof node !== 'object' || node === null) return 0;
+  const record = node as Record<string, unknown>;
+  let count = 'httpMethod' in record ? 1 : 0;
+  for (const value of Object.values(record)) count += countMethods(value);
+  return count;
+}
+
+async function fetchDoc(api: Api): Promise<Record<string, unknown>> {
+  const urls = [
+    `https://www.googleapis.com/discovery/v1/apis/${api.id}/${api.version}/rest`,
+    `https://${api.id}.googleapis.com/$discovery/rest?version=${api.version}`,
+  ];
+  let lastError = '';
+  for (const url of urls) {
+    const res = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+    if (res.ok) return (await res.json()) as Record<string, unknown>;
+    lastError = `${url} -> HTTP ${res.status}`;
+  }
+  throw new Error(`No discovery document for ${api.id}:${api.version} (${lastError})`);
+}
+
+async function main(): Promise<void> {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  const rows: Array<{ api: Api; file: string; methods: number; schemas: number; revision: string }> = [];
+  const failures: string[] = [];
+
+  for (const api of APIS) {
+    const label = `${api.id}:${api.version}`;
+    try {
+      const doc = await fetchDoc(api);
+      const file = `${api.id}.${api.version}.json`;
+      fs.writeFileSync(path.join(OUT_DIR, file), `${JSON.stringify(doc, null, 2)}\n`);
+      rows.push({
+        api,
+        file,
+        methods: countMethods(doc.resources) + countMethods(doc.methods),
+        schemas: Object.keys((doc.schemas as object | undefined) ?? {}).length,
+        revision: String(doc.revision ?? 'unknown'),
+      });
+      console.log(`ok       ${label} (${rows[rows.length - 1].methods} methods, rev ${rows[rows.length - 1].revision})`);
+    } catch (error) {
+      failures.push(`${label}: ${(error as Error).message}`);
+      console.error(`FAILED   ${label}: ${(error as Error).message}`);
+    }
+  }
+
+  const totalMethods = rows.reduce((sum, r) => sum + r.methods, 0);
+  const date = new Date().toISOString().slice(0, 10);
+  const manifest = [
+    '# Google Workspace API Discovery — Snapshot Manifest',
+    '',
+    `Generated: ${date} by \`npm run gen:discovery\`.`,
+    'Source: Google API Discovery Service (central endpoint, per-service `$discovery` fallback).',
+    '',
+    '| Discovery id + version | #methods | #schemas | Revision | File |',
+    '|---|---:|---:|---|---|',
+    ...rows.map((r) => `| ${r.api.id}:${r.api.version} | ${r.methods} | ${r.schemas} | ${r.revision} | \`${r.file}\` |`),
+    '',
+    `Total: ${rows.length} documents, ${totalMethods} methods.`,
+    '',
+    '## No discovery document',
+    '',
+    ...NO_DISCOVERY.map((n) => `- ${n.name} — ${n.reason}`),
+    '',
+  ];
+  if (failures.length > 0) manifest.push('## Failures', '', ...failures.map((f) => `- ${f}`), '');
+  fs.writeFileSync(path.join(OUT_DIR, 'MANIFEST.md'), `${manifest.join('\n')}`);
+
+  console.log(`\n${rows.length}/${APIS.length} documents, ${totalMethods} methods total.`);
+  if (failures.length > 0) {
+    console.error(`${failures.length} failure(s) — see above.`);
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["scripts"]
+}


### PR DESCRIPTION
First slice of the exhaustive-coverage milestone (#5).

Adds `npm run gen:discovery`: fetches all 32 Google Workspace API discovery documents (909 methods) into the gitignored `discovery/` snapshot with a regenerated `MANIFEST.md`. Several APIs (forms, meet, drivelabels, keep, workspaceevents, gmailpostmastertools, appsmarket) no longer serve from the central `www.googleapis.com` discovery URL, so the fetcher falls back to each service's `$discovery/rest` endpoint. Adds `searchconsole:v1` to the set. Three known non-discovery items (Workspace Add-ons, Marketplace SDK, CalDAV) are recorded in the manifest.

`tsx` devDependency + `tsconfig.scripts.json` bring `scripts/` under the `typecheck` gate without including them in the published build (`files: ["dist"]` unchanged).

No runtime changes; `chore:` so no release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)