### PR TITLE
feat: add Slides tools and Forms write tools

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -2,7 +2,7 @@
 
 Every tool takes an `account` argument matching one of your `GOOGLE_ACCOUNTS` aliases — and on read tools (except the three that save files locally: `drive_download`, `drive_export`, `gmail_download_attachment`) it also accepts `"*"` or a CSV subset for **[cross-account fan-out](./README.md#multi-account-fan-out-one-call-across-accounts)**. **Create / update / delete tools are gated by [write-control](./README.md#write-control-deny-by-default)** — deny-by-default; reads are always available. Run `mcp-google-multi config check` to see exactly which CUD tools your current profile enables. `account_list` (always visible) reports each alias's email, token health, and scopes.
 
-~170 tools across the services below. Tools load **[discover-first](./README.md#discover-first-tools-tiny-idle-context)**: each service also exposes a `{service}_discover` meta-tool, and only those appear in `tools/list` until discovered (everything stays directly callable). `GOOGLE_TOOLSETS` can switch whole services off. Anything not listed below is reachable through the **[escape hatch](./README.md#escape-hatch-any-workspace-rest-method)** (`google_api_search` + `google_api_call`). (Codegen'd dedicated tools for the long tail are on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones).)
+~175 tools across the services below. Tools load **[discover-first](./README.md#discover-first-tools-tiny-idle-context)**: each service also exposes a `{service}_discover` meta-tool, and only those appear in `tools/list` until discovered (everything stays directly callable). `GOOGLE_TOOLSETS` can switch whole services off. Anything not listed below is reachable through the **[escape hatch](./README.md#escape-hatch-any-workspace-rest-method)** (`google_api_search` + `google_api_call`). (Codegen'd dedicated tools for the long tail are on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones).)
 
 ## Gmail
 
@@ -134,11 +134,24 @@ Every tool takes an `account` argument matching one of your `GOOGLE_ACCOUNTS` al
 | `meet_conference_records_list` / `meet_conference_record_get` | Past Meet sessions |
 | `meet_recordings_list` / `meet_transcripts_list` / `meet_transcript_entries_list` | Recordings & transcripts |
 
+## Google Slides — optional bundle (`GOOGLE_OPTIONAL_SCOPES=slides`)
+
+| Tool | Description |
+|------|-------------|
+| `slides_create` | Create a presentation |
+| `slides_get` | Compact summary (per-slide objectId + text digest); `full: true` for raw JSON |
+| `slides_page_get` | Full JSON of one slide/page |
+| `slides_page_thumbnail` | Rendered thumbnail URL for one slide |
+| `slides_batch_update` | Generic batchUpdate escape hatch |
+
 ## Google Forms — optional bundle (`GOOGLE_OPTIONAL_SCOPES=forms`)
 
 | Tool | Description |
 |------|-------------|
 | `forms_get` / `forms_responses_list` / `forms_response_get` / `forms_watches_list` | Form + responses (read) |
+| `forms_create` | Create a form (add questions with `forms_batch_update`) |
+| `forms_batch_update` | Generic batchUpdate escape hatch (questions, info, settings) |
+| `forms_set_publish_settings` | Publish/unpublish, toggle accepting responses |
 
 ## Google Chat — optional bundle (`GOOGLE_OPTIONAL_SCOPES=chat`)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-google-multi
 
-A **local** [MCP](https://modelcontextprotocol.io) server that gives Claude Code (and any MCP client) access to your **Google Workspace** — Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console (plus optional Forms, Chat, and Workspace Admin) — across **multiple Google accounts** at once.
+A **local** [MCP](https://modelcontextprotocol.io) server that gives Claude Code (and any MCP client) access to your **Google Workspace** — Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console (plus optional Slides, Forms, Chat, and Workspace Admin) — across **multiple Google accounts** at once.
 
 [![npm](https://img.shields.io/npm/v/mcp-google-multi?label=npm&color=cb3837)](https://www.npmjs.com/package/mcp-google-multi)
 
@@ -9,7 +9,7 @@ A **local** [MCP](https://modelcontextprotocol.io) server that gives Claude Code
 - 🔑 **Multi-account** — drive any number of your Google accounts from one server, each by a short alias.
 - 🔒 **Secure by default** — refresh tokens **encrypted at rest** (AES-256-GCM); **writes are deny-by-default**; no telemetry — it talks only to Google.
 - 📦 **npm-first** — install and run with `npx`; everything configured through env vars.
-- 🧰 **~170 tools** across 12 services → full list in **[COVERAGE.md](./COVERAGE.md)**.
+- 🧰 **~175 tools** across 13 services → full list in **[COVERAGE.md](./COVERAGE.md)**.
 
 > v5 is **local + user-OAuth only**. Service accounts and hosting (and the APIs they unlock) are on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones). **Upgrading from v4?** Jump to [Upgrading](#upgrading-from-v4).
 
@@ -67,9 +67,9 @@ Now the only thing on disk is the **encrypted** token store. Pass the token via 
 | `GOOGLE_PROFILE` | — | write policy: `read-only` (default) · `safe-writes` · `full-writes` |
 | `GOOGLE_READ_ONLY` | — | `true` = hard kill-switch for all writes |
 | `GOOGLE_WRITE_ALLOW` / `GOOGLE_WRITE_DENY` | — | glob overrides, e.g. `calendar:*`, `*:delete*` |
-| `GOOGLE_OPTIONAL_SCOPES` | — | extra bundles: `forms`, `chat` |
+| `GOOGLE_OPTIONAL_SCOPES` | — | extra bundles: `slides`, `forms`, `chat` |
 | `GOOGLE_ADMIN_ACCOUNTS` | — | aliases granted Workspace-admin scopes (the account's own super-admin OAuth) |
-| `GOOGLE_TOOLSETS` | — | `all` (default) or a CSV filter of: `gmail`, `drive`, `calendar`, `sheets`, `docs`, `contacts`, `searchconsole`, `tasks`, `meet`, `forms`, `chat`, `admin` |
+| `GOOGLE_TOOLSETS` | — | `all` (default) or a CSV filter of: `gmail`, `drive`, `calendar`, `sheets`, `docs`, `contacts`, `searchconsole`, `tasks`, `meet`, `slides`, `forms`, `chat`, `admin` |
 | `TOKEN_STORE_PATH` | — | override the encrypted token dir (default: `~/.config/mcp-google-multi/tokens`) |
 | `DISCOVERY_CACHE_PATH` | — | override the Discovery-doc cache dir (default: `~/.config/mcp-google-multi/discovery`) |
 | `GOOGLE_TRIM` | — | `off` (or `0`/`false`/`no`) disables compact JSON serialization of tool responses |
@@ -80,7 +80,7 @@ Inspect the resolved setup any time: `mcp-google-multi config check`.
 
 The server does **not** dump ~170 tool schemas into your model's context. At boot, `tools/list` exposes only one small `{service}_discover` tool per service (plus nothing else). Calling e.g. `drive_discover` returns that service's operation catalog (name, one-line summary, arguments, read/write class), reveals the operational tools, and emits `notifications/tools/list_changed` so the client re-fetches the list. An optional `query` argument filters the catalog.
 
-Hidden is a listing concept, not a security boundary: operational tools stay callable at all times (existing prompts that call tools directly keep working), and write-control + OAuth scopes remain the real enforcement. Use `GOOGLE_TOOLSETS` to switch entire services off — it is a filter only: listing `forms`/`chat`/`admin` does not enable them without their `GOOGLE_OPTIONAL_SCOPES` / `GOOGLE_ADMIN_ACCOUNTS` gates.
+Hidden is a listing concept, not a security boundary: operational tools stay callable at all times (existing prompts that call tools directly keep working), and write-control + OAuth scopes remain the real enforcement. Use `GOOGLE_TOOLSETS` to switch entire services off — it is a filter only: listing `slides`/`forms`/`chat`/`admin` does not enable them without their `GOOGLE_OPTIONAL_SCOPES` / `GOOGLE_ADMIN_ACCOUNTS` gates.
 
 ## Multi-account: fan out one call across accounts
 
@@ -100,7 +100,7 @@ Fan-out is **read-only by design** (write tools take exactly one account), and t
 
 ## Escape hatch: any Workspace REST method
 
-Two eager tools cover everything the curated set doesn't: `google_api_search` finds any method in Google's API Discovery index (including APIs with no dedicated tools here, like Slides), and `google_api_call` invokes a method by its Discovery id (`drive.revisions.list`, `slides.presentations.create`, …) with path/query params and a JSON body. Calls run through your account's OAuth client and the **same write-control policy** as named tools: the read/create/update/delete class is derived from the method's HTTP verb and name (POST deletes like `batchDelete`/`clear` count as deletes), and policy globs/`GOOGLE_TOOLSETS` match the same service names as named tools (`people` counts as `contacts`, `admin_*` as `admin`; `slides`/`driveactivity`/`drivelabels`/`groupssettings` have no named service and are always available).
+Two eager tools cover everything the curated set doesn't: `google_api_search` finds any method in Google's API Discovery index (including APIs with no dedicated tools here, like Drive Activity), and `google_api_call` invokes a method by its Discovery id (`drive.revisions.list`, `slides.presentations.create`, …) with path/query params and a JSON body. Calls run through your account's OAuth client and the **same write-control policy** as named tools: the read/create/update/delete class is derived from the method's HTTP verb and name (POST deletes like `batchDelete`/`clear` count as deletes), and policy globs/`GOOGLE_TOOLSETS` match the same service names as named tools (`people` counts as `contacts`, `admin_*` as `admin`; `driveactivity`/`drivelabels`/`groupssettings` have no named service and are always available).
 
 Discovery documents are fetched from Google on first use and cached on disk for 7 days (`DISCOVERY_CACHE_PATH`, default `~/.config/mcp-google-multi/discovery`); a stale cache is used when offline.
 
@@ -126,12 +126,12 @@ Reads are never gated. **Every create/update/delete is off until you opt in** �
 
 ## What's covered
 
-~170 tools across Gmail, Drive, Calendar, Sheets, Docs, Contacts, Search Console, Tasks, Meet, and (optional) Forms, Chat, Workspace Admin. **Full per-tool list → [COVERAGE.md](./COVERAGE.md).** Every tool takes an `account` argument matching one of your aliases.
+~175 tools across Gmail, Drive, Calendar, Sheets, Docs, Contacts, Search Console, Tasks, Meet, and (optional) Slides, Forms, Chat, Workspace Admin. **Full per-tool list → [COVERAGE.md](./COVERAGE.md).** Every tool takes an `account` argument matching one of your aliases.
 
 ## Google Cloud setup
 
 1. [Google Cloud Console](https://console.cloud.google.com) → create or select a project.
-2. Enable the APIs you'll use: Gmail, Drive, Calendar, Sheets, Docs, People, Search Console, Tasks, Meet (+ Forms / Chat / Admin SDK if you enable those bundles).
+2. Enable the APIs you'll use: Gmail, Drive, Calendar, Sheets, Docs, People, Search Console, Tasks, Meet (+ Slides / Forms / Chat / Admin SDK if you enable those bundles).
 3. **APIs & Services → Credentials → Create Credentials → OAuth client ID → Desktop app**.
 4. Add the redirect URI `http://localhost:4242/oauth2callback`.
 5. Copy the **Client ID** + **Client Secret** into your environment.

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -10,7 +10,7 @@ import { writeToken } from './token-store.js';
 // ─── Scope tiers ────────────────────────────────────────────────────────
 //
 // BASE: always granted. Existing v3 surface + Tasks + Meet (added in v4.0.0).
-// OPTIONAL: per-account opt-in via env GOOGLE_OPTIONAL_SCOPES="forms,chat".
+// OPTIONAL: per-account opt-in via env GOOGLE_OPTIONAL_SCOPES="slides,forms,chat".
 // ADMIN: per-account opt-in via env GOOGLE_ADMIN_ACCOUNTS="alias1,alias2".
 //
 // Personal Gmail accounts will 403 on admin scopes — never grant by default.
@@ -30,6 +30,9 @@ export const BASE_SCOPES = [
 ];
 
 export const OPTIONAL_SCOPE_BUNDLES: Record<string, string[]> = {
+  slides: [
+    'https://www.googleapis.com/auth/presentations',
+  ],
   forms: [
     'https://www.googleapis.com/auth/forms.body',
     'https://www.googleapis.com/auth/forms.responses.readonly',

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { registerContactsTools } from './tools/contacts.js';
 import { registerSearchConsoleTools } from './tools/searchconsole.js';
 import { registerTasksTools } from './tools/tasks.js';
 import { registerMeetTools } from './tools/meet.js';
+import { registerSlidesTools } from './tools/slides.js';
 import { registerFormsTools } from './tools/forms.js';
 import { registerChatTools } from './tools/chat.js';
 import { registerAdminTools } from './tools/admin.js';
@@ -43,6 +44,7 @@ const SERVICES: Array<{
   { name: 'searchconsole', register: registerSearchConsoleTools },
   { name: 'tasks', register: registerTasksTools },
   { name: 'meet', register: registerMeetTools },
+  { name: 'slides', register: registerSlidesTools, enabled: () => new Set(getOptionalBundles()).has('slides') },
   { name: 'forms', register: registerFormsTools, enabled: () => new Set(getOptionalBundles()).has('forms') },
   { name: 'chat', register: registerChatTools, enabled: () => new Set(getOptionalBundles()).has('chat') },
   { name: 'admin', register: registerAdminTools, enabled: () => getAdminAccounts().length > 0 },
@@ -74,7 +76,7 @@ function buildRegistry(server: McpServer, policy: Policy): ToolRegistry {
     throw new Error(
       `GOOGLE_TOOLSETS="${process.env.GOOGLE_TOOLSETS ?? ''}" selected no enabled services. ` +
         `Known services: ${SERVICES.map((s) => s.name).join(', ')}. ` +
-        `Note: forms/chat require GOOGLE_OPTIONAL_SCOPES, admin requires GOOGLE_ADMIN_ACCOUNTS.`,
+        `Note: slides/forms/chat require GOOGLE_OPTIONAL_SCOPES, admin requires GOOGLE_ADMIN_ACCOUNTS.`,
     );
   }
   registerDiscoverTools(registry, policy);

--- a/src/tools/forms.ts
+++ b/src/tools/forms.ts
@@ -5,6 +5,7 @@ import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
+import { coerceArray, coerceBoolean, coerceJson } from './_coerce.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
@@ -101,6 +102,109 @@ export function registerFormsTools(server: ToolRegistry): void {
         const auth = await getClient(account as Account);
         const forms = google.forms({ version: 'v1', auth });
         const res = await forms.forms.watches.list({ formId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleFormsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'forms_create',
+    {
+      description: 'Create a new Google Form with a title (add questions with forms_batch_update)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        title: z.string().describe('Form title shown to responders'),
+        documentTitle: z.string().optional().describe('Drive file name (default: the title)'),
+      },
+    },
+    async ({ account, title, documentTitle }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const forms = google.forms({ version: 'v1', auth });
+        const res = await forms.forms.create({
+          requestBody: { info: { title, documentTitle } },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({
+            formId: res.data.formId,
+            title: res.data.info?.title,
+            responderUri: res.data.responderUri,
+            revisionId: res.data.revisionId,
+          }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleFormsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'forms_batch_update',
+    {
+      description: 'Generic forms.batchUpdate pass-through: add/edit/delete questions, update form info and settings. See https://developers.google.com/workspace/forms/api/reference/rest/v1/forms/request',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        formId: z.string().describe('Form ID'),
+        requests: coerceArray(coerceJson(z.record(z.string(), z.unknown())))
+          .describe('Array of Request objects, each with one request-type key like {createItem: {...}}'),
+        includeFormInResponse: coerceBoolean.optional().describe('Return the updated form in the response'),
+        writeControl: coerceJson(z.object({
+          requiredRevisionId: z.string().optional(),
+          targetRevisionId: z.string().optional(),
+        }).optional()).describe('Optional optimistic concurrency control'),
+      },
+    },
+    async ({ account, formId, requests, includeFormInResponse, writeControl }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const forms = google.forms({ version: 'v1', auth });
+        const res = await forms.forms.batchUpdate({
+          formId,
+          requestBody: {
+            requests: requests as any,
+            includeFormInResponse,
+            writeControl,
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleFormsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'forms_set_publish_settings',
+    {
+      description: 'Publish/unpublish a form and toggle whether it accepts responses (legacy forms without publish state are not supported)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        formId: z.string().describe('Form ID'),
+        isPublished: coerceBoolean.describe('Form is published and reachable by responders'),
+        isAcceptingResponses: coerceBoolean.optional().describe('Form accepts responses (requires published; default: follows isPublished)'),
+      },
+    },
+    async ({ account, formId, isPublished, isAcceptingResponses }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const forms = google.forms({ version: 'v1', auth });
+        const updateMask = ['publishState.isPublished'];
+        if (isAcceptingResponses !== undefined) updateMask.push('publishState.isAcceptingResponses');
+        const res = await forms.forms.setPublishSettings({
+          formId,
+          requestBody: {
+            publishSettings: {
+              publishState: { isPublished, isAcceptingResponses },
+            },
+            updateMask: updateMask.join(','),
+          },
+        });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
         };

--- a/src/tools/slides.ts
+++ b/src/tools/slides.ts
@@ -1,0 +1,209 @@
+import type { ToolRegistry } from '../registry.js';
+import { z } from 'zod';
+import { google } from 'googleapis';
+import { ACCOUNTS } from '../accounts.js';
+import type { Account } from '../accounts.js';
+import { getClient } from '../client.js';
+import { handleGoogleApiError } from './_errors.js';
+import { coerceArray, coerceBoolean, coerceJson } from './_coerce.js';
+import { sliceClean } from '../trim.js';
+
+const accountEnum = z.enum(ACCOUNTS);
+
+const SLIDE_TEXT_DIGEST_CHARS = 200;
+
+export function registerSlidesTools(server: ToolRegistry): void {
+  server.registerTool(
+    'slides_create',
+    {
+      description: 'Create a new Google Slides presentation (starts with one blank slide)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        title: z.string().describe('Presentation title'),
+      },
+    },
+    async ({ account, title }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const slides = google.slides({ version: 'v1', auth });
+        const res = await slides.presentations.create({ requestBody: { title } });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({
+            presentationId: res.data.presentationId,
+            title: res.data.title,
+            url: `https://docs.google.com/presentation/d/${res.data.presentationId}/edit`,
+            firstSlideObjectId: res.data.slides?.[0]?.objectId,
+          }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSlidesError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'slides_get',
+    {
+      description: 'Get a presentation as a compact summary (title, per-slide objectId + text digest). Pass full:true for the raw Presentation JSON (can be very large).',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        presentationId: z.string().describe('Presentation ID'),
+        full: coerceBoolean.optional().describe('Return the untrimmed Presentation resource'),
+      },
+    },
+    async ({ account, presentationId, full }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const slides = google.slides({ version: 'v1', auth });
+        const res = await slides.presentations.get({ presentationId });
+        const payload = full ? res.data : summarizePresentation(res.data as Record<string, any>);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSlidesError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'slides_page_get',
+    {
+      description: 'Get the full JSON of one slide/page (all page elements with geometry and text)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        presentationId: z.string().describe('Presentation ID'),
+        pageObjectId: z.string().describe('Page object ID (from slides_get)'),
+      },
+    },
+    async ({ account, presentationId, pageObjectId }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const slides = google.slides({ version: 'v1', auth });
+        const res = await slides.presentations.pages.get({ presentationId, pageObjectId });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSlidesError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'slides_page_thumbnail',
+    {
+      description: 'Get a rendered thumbnail image URL for one slide (the contentUrl expires after ~30 minutes)',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        presentationId: z.string().describe('Presentation ID'),
+        pageObjectId: z.string().describe('Page object ID (from slides_get)'),
+        mimeType: z.enum(['PNG']).optional().describe('Thumbnail mime type (default: PNG)'),
+        thumbnailSize: z.enum(['LARGE', 'MEDIUM', 'SMALL', 'WIDTH2000_PX']).optional()
+          .describe('LARGE=1600px, MEDIUM=800px, SMALL=200px, WIDTH2000_PX=2000px wide (default: server-chosen)'),
+      },
+    },
+    async ({ account, presentationId, pageObjectId, mimeType, thumbnailSize }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const slides = google.slides({ version: 'v1', auth });
+        const res = await slides.presentations.pages.getThumbnail({
+          presentationId,
+          pageObjectId,
+          'thumbnailProperties.mimeType': mimeType,
+          'thumbnailProperties.thumbnailSize': thumbnailSize,
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(res.data, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSlidesError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'slides_batch_update',
+    {
+      description: 'Generic presentations.batchUpdate pass-through. Accepts the full Request union (create/move/delete slides, insert text/shapes/images/tables, styling, replaceAllText, …). See https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        presentationId: z.string().describe('Presentation ID'),
+        requests: coerceArray(coerceJson(z.record(z.string(), z.unknown())))
+          .describe('Array of Request objects, each with one request-type key like {createSlide: {...}}'),
+        writeControl: coerceJson(z.object({
+          requiredRevisionId: z.string().optional(),
+        }).optional()).describe('Optional optimistic concurrency control'),
+      },
+    },
+    async ({ account, presentationId, requests, writeControl }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const slides = google.slides({ version: 'v1', auth });
+        const res = await slides.presentations.batchUpdate({
+          presentationId,
+          requestBody: {
+            requests: requests as any,
+            writeControl,
+          },
+        });
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify({
+            presentationId: res.data.presentationId,
+            replies: res.data.replies ?? [],
+          }, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleSlidesError(error, account as Account);
+      }
+    },
+  );
+}
+
+// ─── Helpers (exported for unit tests) ───────────────────────────────────
+
+export function extractPageText(elements: Array<Record<string, any>> | undefined): string {
+  const parts: string[] = [];
+  const visit = (els: Array<Record<string, any>> | undefined): void => {
+    for (const el of els ?? []) {
+      for (const te of el.shape?.text?.textElements ?? []) {
+        const content = te.textRun?.content ?? te.autoText?.content;
+        if (content) parts.push(content);
+      }
+      for (const row of el.table?.tableRows ?? []) {
+        for (const cell of row.tableCells ?? []) {
+          for (const te of cell.text?.textElements ?? []) {
+            if (te.textRun?.content) parts.push(te.textRun.content);
+          }
+        }
+      }
+      visit(el.elementGroup?.children);
+    }
+  };
+  visit(elements);
+  return parts.join('').replace(/\s+/g, ' ').trim();
+}
+
+export function summarizePresentation(p: Record<string, any>): Record<string, unknown> {
+  const slides = ((p.slides ?? []) as Array<Record<string, any>>).map((s, index) => {
+    const text = extractPageText(s.pageElements);
+    return {
+      index,
+      objectId: s.objectId,
+      elementCount: (s.pageElements ?? []).length,
+      ...(text ? { text: sliceClean(text, SLIDE_TEXT_DIGEST_CHARS) } : {}),
+    };
+  });
+  return {
+    presentationId: p.presentationId,
+    title: p.title,
+    revisionId: p.revisionId,
+    slideCount: slides.length,
+    slides,
+    hint: 'Pass full:true for the raw Presentation JSON, or slides_page_get for one slide.',
+  };
+}
+
+function handleSlidesError(error: any, account: Account) {
+  return handleGoogleApiError(error, account, "Slides tools require the optional \"slides\" scope bundle. Add GOOGLE_OPTIONAL_SCOPES=slides (or include \"slides\" in the list) and re-auth.");
+}

--- a/tests/optional-bundles.test.ts
+++ b/tests/optional-bundles.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getOptionalBundles, resolveScopesForAccount, OPTIONAL_SCOPE_BUNDLES } from '../src/auth.js';
+
+const PRESENTATIONS_SCOPE = 'https://www.googleapis.com/auth/presentations';
+
+describe('optional scope bundles', () => {
+  const saved = process.env.GOOGLE_OPTIONAL_SCOPES;
+
+  beforeEach(() => {
+    delete process.env.GOOGLE_OPTIONAL_SCOPES;
+  });
+
+  afterEach(() => {
+    if (saved === undefined) delete process.env.GOOGLE_OPTIONAL_SCOPES;
+    else process.env.GOOGLE_OPTIONAL_SCOPES = saved;
+  });
+
+  it('slides bundle grants exactly the presentations scope (read + write + thumbnails)', () => {
+    expect(OPTIONAL_SCOPE_BUNDLES.slides).toEqual([PRESENTATIONS_SCOPE]);
+  });
+
+  it('forms bundle includes the forms.body write scope', () => {
+    expect(OPTIONAL_SCOPE_BUNDLES.forms).toContain('https://www.googleapis.com/auth/forms.body');
+  });
+
+  it('GOOGLE_OPTIONAL_SCOPES=slides enables the slides bundle', () => {
+    process.env.GOOGLE_OPTIONAL_SCOPES = 'slides';
+    expect(getOptionalBundles()).toContain('slides');
+    expect(resolveScopesForAccount('test')).toContain(PRESENTATIONS_SCOPE);
+  });
+
+  it('slides is disabled when GOOGLE_OPTIONAL_SCOPES is unset or lists other bundles', () => {
+    expect(getOptionalBundles()).not.toContain('slides');
+    expect(resolveScopesForAccount('test')).not.toContain(PRESENTATIONS_SCOPE);
+
+    process.env.GOOGLE_OPTIONAL_SCOPES = 'forms,chat';
+    expect(getOptionalBundles()).toEqual(['forms', 'chat']);
+    expect(resolveScopesForAccount('test')).not.toContain(PRESENTATIONS_SCOPE);
+  });
+
+  it('parses CSV with whitespace and drops unknown bundle names', () => {
+    process.env.GOOGLE_OPTIONAL_SCOPES = ' slides , forms ,bogus';
+    expect(getOptionalBundles()).toEqual(['slides', 'forms']);
+  });
+});

--- a/tests/slides.test.ts
+++ b/tests/slides.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { ToolRegistry } from '../src/registry.js';
+import type { Policy } from '../src/write-control.js';
+import { registerSlidesTools, extractPageText, summarizePresentation } from '../src/tools/slides.js';
+
+const POLICY: Policy = { profile: 'safe-writes', readOnly: false, allow: [], deny: [] };
+
+function buildRegistry(): ToolRegistry {
+  const server = {
+    registerTool: () => 'ok',
+    sendToolListChanged: () => {},
+    server: { setRequestHandler: () => {} },
+  };
+  return new ToolRegistry(server as never, POLICY);
+}
+
+describe('registerSlidesTools', () => {
+  it('registers the five slides tools with the expected cud classes', () => {
+    const registry = buildRegistry();
+    registerSlidesTools(registry);
+    const byName = Object.fromEntries(registry.tools.map((t) => [t.name, t]));
+    expect(Object.keys(byName).sort()).toEqual([
+      'slides_batch_update',
+      'slides_create',
+      'slides_get',
+      'slides_page_get',
+      'slides_page_thumbnail',
+    ]);
+    expect(byName.slides_create.cud).toBe('create');
+    expect(byName.slides_get.cud).toBe('read');
+    expect(byName.slides_page_get.cud).toBe('read');
+    expect(byName.slides_page_thumbnail.cud).toBe('read');
+    expect(byName.slides_batch_update.cud).toBe('update');
+    for (const tool of registry.tools) expect(tool.service).toBe('slides');
+  });
+});
+
+describe('extractPageText', () => {
+  it('collects shape text runs and normalizes whitespace', () => {
+    const text = extractPageText([
+      { shape: { text: { textElements: [{ textRun: { content: 'Hello\n' } }, { textRun: { content: ' world ' } }] } } },
+    ]);
+    expect(text).toBe('Hello world');
+  });
+
+  it('collects table cell text and nested group children', () => {
+    const text = extractPageText([
+      {
+        table: {
+          tableRows: [
+            { tableCells: [{ text: { textElements: [{ textRun: { content: 'A1 ' } }] } }] },
+          ],
+        },
+      },
+      {
+        elementGroup: {
+          children: [
+            { shape: { text: { textElements: [{ textRun: { content: 'grouped' } }] } } },
+          ],
+        },
+      },
+    ]);
+    expect(text).toBe('A1 grouped');
+  });
+
+  it('handles autoText and elements with no text', () => {
+    expect(extractPageText([{ image: {} }, { shape: { text: { textElements: [{ autoText: { content: '3' } }] } } }])).toBe('3');
+    expect(extractPageText(undefined)).toBe('');
+  });
+});
+
+describe('summarizePresentation', () => {
+  const presentation = {
+    presentationId: 'p1',
+    title: 'Deck',
+    revisionId: 'r9',
+    pageSize: { width: {}, height: {} },
+    masters: [{ objectId: 'm1' }],
+    slides: [
+      {
+        objectId: 's1',
+        pageElements: [
+          { shape: { text: { textElements: [{ textRun: { content: 'Title slide' } }] } } },
+        ],
+      },
+      { objectId: 's2' },
+    ],
+  };
+
+  it('produces a compact per-slide digest instead of the raw payload', () => {
+    const summary = summarizePresentation(presentation) as any;
+    expect(summary.presentationId).toBe('p1');
+    expect(summary.title).toBe('Deck');
+    expect(summary.revisionId).toBe('r9');
+    expect(summary.slideCount).toBe(2);
+    expect(summary.slides).toEqual([
+      { index: 0, objectId: 's1', elementCount: 1, text: 'Title slide' },
+      { index: 1, objectId: 's2', elementCount: 0 },
+    ]);
+    expect(summary.masters).toBeUndefined();
+    expect(summary.pageSize).toBeUndefined();
+    expect(summary.hint).toContain('full:true');
+  });
+
+  it('caps each slide digest at 200 chars', () => {
+    const long = 'x'.repeat(500);
+    const summary = summarizePresentation({
+      presentationId: 'p2',
+      slides: [{ objectId: 's1', pageElements: [{ shape: { text: { textElements: [{ textRun: { content: long } }] } } }] }],
+    }) as any;
+    expect(summary.slides[0].text).toHaveLength(200);
+  });
+
+  it('handles a presentation with no slides', () => {
+    const summary = summarizePresentation({ presentationId: 'p3', title: 'Empty' }) as any;
+    expect(summary.slideCount).toBe(0);
+    expect(summary.slides).toEqual([]);
+  });
+});


### PR DESCRIPTION
Second slice of the exhaustive-coverage milestone (#5): the two CORE-tier service gaps get curated tools.

- **Slides (new service, opt-in)**: `slides_create`, `slides_get` (compact per-slide digest by default, `full:true` for raw), `slides_page_get`, `slides_page_thumbnail`, `slides_batch_update` (loose `requests` array per the no-mega-union rule). Covers all 5 methods of slides:v1. Enabled via `GOOGLE_OPTIONAL_SCOPES=slides` — new optional bundle with the `presentations` scope; nothing changes for existing users until they opt in.
- **Forms (write tools, same bundle)**: `forms_create`, `forms_batch_update`, `forms_set_publish_settings` (updateMask computed from provided keys). The `forms.body` write scope was already in the bundle; watches excluded (need Pub/Sub).

12 new tests incl. both-ways bundle gating; 281/281 green, typecheck/lint/build pass. COVERAGE.md + README service enumerations updated (~175 tools, 13 services).

🤖 Generated with [Claude Code](https://claude.com/claude-code)