### PR TITLE
docs: rewrite README as a landing page, split reference into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,167 +1,60 @@
 # mcp-google-multi
 
-A **local** [MCP](https://modelcontextprotocol.io) server that gives Claude Code (and any MCP client) access to your **Google Workspace** — Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console (plus optional Slides, Forms, Chat, and Workspace Admin) — across **multiple Google accounts** at once.
+The most complete **local Google Workspace MCP server**: Gmail, Drive, Calendar, Sheets, Docs, Slides, Forms, Contacts, Tasks, Chat, Meet, Classroom, Vault, Admin and more — **every OAuth-reachable Workspace API method** as a tool, across **multiple Google accounts** at once, from Claude Code or any MCP client.
 
 [![npm](https://img.shields.io/npm/v/mcp-google-multi?label=npm&color=cb3837)](https://www.npmjs.com/package/mcp-google-multi)
 
-> Open-source and **funded by [IdeaCrafters](https://github.com/IdeaCraftersHQ)** — the studio that pays for its development and upkeep.
+- 🧰 **Exhaustive** — 871 tools across 28 services + an escape hatch for anything else → [COVERAGE.md](./COVERAGE.md)
+- 🔑 **Multi-account** — drive any number of Google accounts by alias, or fan one call out across all of them
+- 🔒 **Private by design** — your own OAuth app, tokens encrypted at rest (AES-256-GCM), writes deny-by-default, no telemetry, no metering — it talks only to Google
 
-- 🔑 **Multi-account** — drive any number of your Google accounts from one server, each by a short alias.
-- 🔒 **Secure by default** — refresh tokens **encrypted at rest** (AES-256-GCM); **writes are deny-by-default**; no telemetry — it talks only to Google.
-- 📦 **npm-first** — install and run with `npx`; everything configured through env vars.
-- 🧰 **Exhaustive coverage** — every OAuth-reachable Workspace API method is a named tool: **871 tools across 28 services** (182 hand-curated + 689 generated from Google's API Discovery), plus an escape hatch for anything else → full list in **[COVERAGE.md](./COVERAGE.md)**.
+## Quick setup
 
-> v5 is **local + user-OAuth only**. Service accounts and hosting (and the APIs they unlock) are on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones). **Upgrading from v4?** Jump to [Upgrading](#upgrading-from-v4).
+You don't need to know anything about MCP or OAuth — five steps, all copy-paste:
 
-## Quick start
+1. **Install [Node.js](https://nodejs.org) 20 or newer**, then install the server:
 
-You need **Node 20+**, a Google Cloud OAuth client (~2 min — [setup below](#google-cloud-setup)), and a random 32-byte key.
+   ```bash
+   npm install -g mcp-google-multi
+   ```
 
-```bash
-# 1) install
-npm i -g mcp-google-multi
+2. **Create your (free) Google app** so the server can sign in as you — one-time, ~2 minutes: follow [Google Cloud setup](./docs/google-cloud-setup.md). You come back with a **Client ID** and **Client Secret**.
 
-# 2) put your config + creds in the environment (see "Configuration").
-#    Easiest for a quick try — export them, or drop a .env in your working dir:
-#    GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_ACCOUNTS, MASTER_KEY, GOOGLE_PROFILE
+3. **Create a file named `.env`** in the folder you'll run from, and fill in your values:
 
-# 3) authenticate each account (opens a browser; one-time per account)
-mcp-google-multi auth --account work
-mcp-google-multi auth --account personal
+   ```bash
+   GOOGLE_CLIENT_ID=paste-your-client-id
+   GOOGLE_CLIENT_SECRET=paste-your-client-secret
+   # name each Google account with a short alias:
+   GOOGLE_ACCOUNTS=work:you@company.com,personal:you@gmail.com
+   # encryption key for stored tokens — generate one with: openssl rand -base64 32
+   MASTER_KEY=paste-the-generated-key
+   ```
 
-# 4) register with Claude Code
-claude mcp add google-multi -s user -- npx -y mcp-google-multi
-```
+4. **Sign in each account** (a browser window opens; approve the permissions):
 
-Restart your MCP client and the tools appear. Tokens are written **encrypted** to `~/.config/mcp-google-multi/tokens/` (override with `TOKEN_STORE_PATH`) — useless to anyone without your `MASTER_KEY`.
+   ```bash
+   mcp-google-multi auth --account work
+   mcp-google-multi auth --account personal
+   ```
 
-Generate a key: `openssl rand -base64 32`.
+5. **Connect it to Claude Code** (any MCP client works the same way):
 
-## Recommended: keep secrets in a vault (Infisical)
+   ```bash
+   claude mcp add google-multi -s user -- npx -y mcp-google-multi
+   ```
 
-A plaintext `.env` is fine to try it out, but for a daily driver, **don't leave `GOOGLE_CLIENT_SECRET` + `MASTER_KEY` on disk** — inject them at launch from a secrets manager. The server just reads `process.env` (it has no idea where the values come from), so wrap it with [Infisical](https://infisical.com):
+Restart your client and the tools appear. Check everything with `mcp-google-multi config check`.
 
-```bash
-#!/usr/bin/env bash
-# ~/.local/bin/mcp-google-multi-run  — chmod +x, then register this as the MCP command
-set -euo pipefail
-export INFISICAL_TOKEN="$(infisical login --method=universal-auth \
-  --client-id "$YOUR_CLIENT_ID" --client-secret "$YOUR_CLIENT_SECRET" --plain --silent)"
-exec infisical run --projectId <project> --env prod --path /mcp-google-multi \
-  -- npx -y mcp-google-multi
-```
+**Go deeper:** [Configuration reference](./docs/configuration.md) · [What's covered](./COVERAGE.md) · [Features tour](./docs/features.md) · [Secrets in a vault](./docs/secrets.md) · [Upgrading from v4](./docs/upgrading-v4.md) · [Security policy](./SECURITY.md) · [Roadmap](https://github.com/bakissation/mcp-google-multi/milestones)
 
-```bash
-claude mcp add google-multi -s user -- ~/.local/bin/mcp-google-multi-run
-```
-
-Now the only thing on disk is the **encrypted** token store. Pass the token via the `INFISICAL_TOKEN` env var (as above), **not** a `--token` flag, so it never shows up in `ps`. (Any secrets manager works — Doppler, Vault, 1Password CLI, etc. — the pattern is the same.)
-
-## Configuration
-
-| Env var | Required | Description |
-|---|---|---|
-| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | ✓ | OAuth **Desktop** client from Google Cloud |
-| `GOOGLE_ACCOUNTS` | ✓ | `alias:email,…` — e.g. `work:you@co.com,personal:you@gmail.com` |
-| `MASTER_KEY` | ✓ | base64 32-byte key that encrypts the token store (`openssl rand -base64 32`) |
-| `GOOGLE_PROFILE` | — | write policy: `read-only` (default) · `safe-writes` · `full-writes` |
-| `GOOGLE_READ_ONLY` | — | `true` = hard kill-switch for all writes |
-| `GOOGLE_WRITE_ALLOW` / `GOOGLE_WRITE_DENY` | — | glob overrides, e.g. `calendar:*`, `*:delete*` |
-| `GOOGLE_OPTIONAL_SCOPES` | — | extra bundles: `slides`, `forms`, `chat` |
-| `GOOGLE_ADMIN_ACCOUNTS` | — | aliases granted Workspace-admin scopes (the account's own super-admin OAuth) |
-| `GOOGLE_TOOLSETS` | — | `all` (default) or a CSV filter of: `gmail`, `drive`, `calendar`, `sheets`, `docs`, `contacts`, `searchconsole`, `tasks`, `meet`, `slides`, `forms`, `chat`, `admin` |
-| `TOKEN_STORE_PATH` | — | override the encrypted token dir (default: `~/.config/mcp-google-multi/tokens`) |
-| `DISCOVERY_CACHE_PATH` | — | override the Discovery-doc cache dir (default: `~/.config/mcp-google-multi/discovery`) |
-| `GOOGLE_TRIM` | — | `off` (or `0`/`false`/`no`) disables compact JSON serialization of tool responses |
-
-Inspect the resolved setup any time: `mcp-google-multi config check`.
-
-## Discover-first tools (tiny idle context)
-
-The server does **not** dump ~170 tool schemas into your model's context. At boot, `tools/list` exposes only one small `{service}_discover` tool per service (plus nothing else). Calling e.g. `drive_discover` returns that service's operation catalog (name, one-line summary, arguments, read/write class), reveals the operational tools, and emits `notifications/tools/list_changed` so the client re-fetches the list. An optional `query` argument filters the catalog.
-
-Hidden is a listing concept, not a security boundary: operational tools stay callable at all times (existing prompts that call tools directly keep working), and write-control + OAuth scopes remain the real enforcement. Use `GOOGLE_TOOLSETS` to switch entire services off — it is a filter only: listing `slides`/`forms`/`chat`/`admin` does not enable them without their `GOOGLE_OPTIONAL_SCOPES` / `GOOGLE_ADMIN_ACCOUNTS` gates.
-
-## Multi-account: fan out one call across accounts
-
-Every read tool's `account` argument also accepts `"*"` (all configured accounts) or a CSV subset (`"work,personal"`). The server runs the call once per account (bounded concurrency) and returns per-account results — one account failing never hides the others:
-
-```jsonc
-{ "results": [
-    { "account": "work", "ok": true, "data": { /* … */ } },
-    { "account": "personal", "ok": false, "error": { "error": "auth_required", /* … */ } }
-  ],
-  "partial": true }
-```
-
-Fan-out is **read-only by design** (write tools take exactly one account), and the three read tools that save files to disk (`drive_download`, `drive_export`, `gmail_download_attachment`) are excluded so parallel accounts can't clobber the same path. `account_list` shows what's configured: alias, email, token health (`ok` / `expired_refreshable` / `needs_reauth` / `missing` / `decrypt_error`), and granted-vs-configured scopes — without ever touching token values.
-
-`drive_transfer` copies or moves a file between two of your accounts: server-side share+copy when possible (the temporary read grant on the source is revoked right after; the copy gets a clean name, never "Copy of"), download+upload as the fallback. `move: true` trashes the source after a successful copy — that part is **delete-gated by write-control**, so `safe-writes` can copy but never move. Comments, revision history, and permissions don't transfer; if the fallback has to change the format (Drawings export as PNG), the result is flagged `lossy` and a requested move keeps the source intact. Native files over Google's 10MB export cap and binaries over 1GB can't take the fallback path.
-
-## Escape hatch: any Workspace REST method
-
-Two eager tools cover everything the curated set doesn't: `google_api_search` finds any method in Google's API Discovery index (including APIs with no dedicated tools here, like Drive Activity), and `google_api_call` invokes a method by its Discovery id (`drive.revisions.list`, `slides.presentations.create`, …) with path/query params and a JSON body. Calls run through your account's OAuth client and the **same write-control policy** as named tools: the read/create/update/delete class is derived from the method's HTTP verb and name (POST deletes like `batchDelete`/`clear` count as deletes), and policy globs/`GOOGLE_TOOLSETS` match the same service names as named tools (`people` counts as `contacts`, `admin_*` as `admin`; `driveactivity`/`drivelabels`/`groupssettings` have no named service and are always available).
-
-Discovery documents are fetched from Google on first use and cached on disk for 7 days (`DISCOVERY_CACHE_PATH`, default `~/.config/mcp-google-multi/discovery`); a stale cache is used when offline.
-
-## Lean responses by default
-
-Tool responses are serialized compactly (no pretty-print token tax; set `GOOGLE_TRIM=off` to restore pretty JSON), and the fat readers ship sensible caps with per-call escape valves. The caps are per-call controls (`full` / `maxChars`) and are NOT affected by `GOOGLE_TRIM`:
-
-- `drive_read` returns up to `maxChars` characters (default 100k) with `truncated`/`totalChars`/`offset` for paging — this also bounds Google Doc exports, which can reach 10MB. (Non-Google-native files over 2MB are still rejected with `too_large`, not paged.)
-- `gmail_read` / `gmail_read_thread` cap each message body at 50k chars (`bodyTruncated` + `bodyTotalChars` flags); pass `full: true` for the whole body.
-- `calendar_list_events` / `calendar_list_instances` trim descriptions to ~300 chars and drop empty/audit fields (`created`/`updated`) in list view; `calendar_get_event` always returns the full event.
-
-## Write-control (deny-by-default)
-
-Reads are never gated. **Every create/update/delete is off until you opt in** — pick a profile:
-
-| `GOOGLE_PROFILE` | Allows |
-|---|---|
-| `read-only` (default) | reads only |
-| `safe-writes` | create + update (deletes still blocked) |
-| `full-writes` | everything |
-
-`GOOGLE_READ_ONLY=true` overrides all. For fine control: `GOOGLE_WRITE_ALLOW="calendar:*, sheets:update*"` and `GOOGLE_WRITE_DENY="*:delete*"` (deny wins). `mcp-google-multi config check` prints the resolved policy and exactly which tools are enabled.
-
-## What's covered
-
-Every OAuth-reachable Workspace API method is a named tool — 871 across 28 services. Core services (Gmail, Drive, Calendar, Sheets, Docs, Contacts, Search Console, Tasks, Meet) are on by default; Slides, Forms, Chat, Classroom, Vault, Keep, Apps Script, Cloud Search, Drive Labels and more enable via `GOOGLE_OPTIONAL_SCOPES` bundles, and Workspace Admin APIs via `GOOGLE_ADMIN_ACCOUNTS`. Curated tools give shaped, token-lean responses for everyday operations; generated tools (from Google's API Discovery documents) cover the long tail with the same write-control and account fan-out. **Full per-tool list → [COVERAGE.md](./COVERAGE.md).** Every tool takes an `account` argument matching one of your aliases.
-
-## Google Cloud setup
-
-1. [Google Cloud Console](https://console.cloud.google.com) → create or select a project.
-2. Enable the APIs you'll use: Gmail, Drive, Calendar, Sheets, Docs, People, Search Console, Tasks, Meet (+ Slides / Forms / Chat / Admin SDK if you enable those bundles).
-3. **APIs & Services → Credentials → Create Credentials → OAuth client ID → Desktop app**.
-4. Add the redirect URI `http://localhost:4242/oauth2callback`.
-5. Copy the **Client ID** + **Client Secret** into your environment.
-
-## Upgrading from v4
-
-v5 is a breaking change, but the migration is a one-time, ~2-minute step:
-
-1. Update: `npm i -g mcp-google-multi@latest` (or update your client config).
-2. Add **`MASTER_KEY`** to your environment (`openssl rand -base64 32`) — now required.
-3. Encrypt existing tokens: `mcp-google-multi migrate-tokens` (reads your old `tokens/<alias>/token.json` and encrypts them) — or just re-auth each account.
-4. Writes are now **deny-by-default** — set `GOOGLE_PROFILE=safe-writes` (or `full-writes`) to keep writing. (`GOOGLE_ALLOW_ADMIN_WRITES` is gone — replaced by write-control profiles.)
-
-## Security
-
-Your OAuth, your machine. Refresh tokens are **AES-256-GCM encrypted at rest** (decryptable only with your `MASTER_KEY`), writes are deny-by-default, and the server has **no telemetry** — it connects only to Google's APIs. Found a vulnerability? Report it privately — see [SECURITY.md](./SECURITY.md), never a public issue.
-
-## Roadmap
-
-Maintainer-led. Direction is tracked publicly as **[GitHub Milestones](https://github.com/bakissation/mcp-google-multi/milestones)** (exhaustive API coverage → service accounts + hosting in v6). Not accepting unsolicited feature PRs; bug reports are welcome.
-
-## Contributing
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md). Security issues go to [SECURITY.md](./SECURITY.md), never a public issue.
-
-## Credits
+## Maintainer & credits
 
 Built and maintained by **Abdelbaki Berkati** — [berkati.xyz](https://berkati.xyz) · [@bakissation](https://github.com/bakissation). [Read the case study →](https://berkati.xyz/case-studies/mcp-google-multi/)
 
 Development is **funded by [IdeaCrafters](https://ideacrafters.com)** ([@IdeaCraftersHQ](https://github.com/IdeaCraftersHQ)) — the studio that pays for this OSS to exist.
+
+Thanks to contributors [@obatried](https://github.com/obatried), [@trevor-commits](https://github.com/trevor-commits), and [@mjreddy](https://github.com/mjreddy). The project is maintainer-led (roadmap on [Milestones](https://github.com/bakissation/mcp-google-multi/milestones); bug reports welcome, feature PRs by prior agreement — see [CONTRIBUTING.md](./CONTRIBUTING.md)). Security reports go to [SECURITY.md](./SECURITY.md), never a public issue.
 
 ## License
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,54 @@
+# Configuration reference
+
+Everything is configured through environment variables (a `.env` in the working directory is loaded automatically). Back to the [README](../README.md).
+
+## Environment variables
+
+| Env var | Required | Description |
+|---|---|---|
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | ✓ | OAuth **Desktop** client from Google Cloud — see [Google Cloud setup](./google-cloud-setup.md) |
+| `GOOGLE_ACCOUNTS` | ✓ | `alias:email,…` — e.g. `work:you@co.com,personal:you@gmail.com` |
+| `MASTER_KEY` | ✓ | base64 32-byte key that encrypts the token store (`openssl rand -base64 32`) |
+| `GOOGLE_PROFILE` | — | write policy: `read-only` (default) · `safe-writes` · `full-writes` |
+| `GOOGLE_READ_ONLY` | — | `true` = hard kill-switch for all writes |
+| `GOOGLE_WRITE_ALLOW` / `GOOGLE_WRITE_DENY` | — | glob overrides, e.g. `calendar:*`, `*:delete*` (deny wins) |
+| `GOOGLE_OPTIONAL_SCOPES` | — | opt-in scope bundles, CSV — see [bundles](#optional-scope-bundles) |
+| `GOOGLE_ADMIN_ACCOUNTS` | — | aliases granted Workspace-admin scopes (the account's own super-admin OAuth) |
+| `GOOGLE_TOOLSETS` | — | `all` (default) or a CSV filter of service names — see [services](#services) |
+| `TOKEN_STORE_PATH` | — | override the encrypted token dir (default: `~/.config/mcp-google-multi/tokens`) |
+| `DISCOVERY_CACHE_PATH` | — | override the Discovery-doc cache dir (default: `~/.config/mcp-google-multi/discovery`) |
+| `GOOGLE_TRIM` | — | `off` (or `0`/`false`/`no`) disables compact JSON serialization of tool responses |
+
+Inspect the resolved setup any time: `mcp-google-multi config check`.
+
+## Write-control (deny-by-default)
+
+Reads are never gated. **Every create/update/delete is off until you opt in** — pick a profile:
+
+| `GOOGLE_PROFILE` | Allows |
+|---|---|
+| `read-only` (default) | reads only |
+| `safe-writes` | create + update (deletes still blocked) |
+| `full-writes` | everything |
+
+`GOOGLE_READ_ONLY=true` overrides all. For fine control: `GOOGLE_WRITE_ALLOW="calendar:*, sheets:update*"` and `GOOGLE_WRITE_DENY="*:delete*"` (deny wins). The policy applies identically to curated tools, generated tools, and the escape hatch.
+
+## Services
+
+Core services register by default: `gmail`, `drive`, `calendar`, `sheets`, `docs`, `contacts`, `searchconsole`, `tasks`, `meet`, `workspaceevents`.
+
+Optional services register when their bundle is enabled (below): `slides`, `forms`, `chat`, `classroom`, `cloudidentity`, `cloudsearch`, `vault`, `keep`, `driveactivity`, `drivelabels`, `script`, `postmaster`, `groupssettings`, `groupsmigration`, `licensing`, `reseller`, `appsmarket` — plus `admin`, which requires `GOOGLE_ADMIN_ACCOUNTS`.
+
+`GOOGLE_TOOLSETS` is a filter only: listing an optional service does not enable it without its bundle/admin gate.
+
+## Optional scope bundles
+
+Add bundle names to `GOOGLE_OPTIONAL_SCOPES` (CSV), then re-run `auth` for each account so the new scopes are granted:
+
+`slides`, `forms`, `chat`, `classroom`, `cloudidentity`, `cloudsearch`, `vault`, `keep`, `driveactivity`, `drivelabels`, `script`, `postmaster`, `groupssettings`, `groupsmigration`, `licensing`, `reseller`, `appsmarket`.
+
+A tool whose scope was never granted returns a typed `insufficient_scope` error with a re-auth hint instead of failing silently.
+
+## Secrets management
+
+Don't leave `GOOGLE_CLIENT_SECRET` + `MASTER_KEY` in a plaintext `.env` for daily use — inject them at launch from a secrets manager. See [Secrets in a vault](./secrets.md).

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,43 @@
+# Features tour
+
+How the server keeps 871 tools usable, fast, and safe. Back to the [README](../README.md).
+
+## Discover-first tools (tiny idle context)
+
+The server does **not** dump hundreds of tool schemas into your model's context. At boot, `tools/list` exposes only one small `{service}_discover` tool per service (plus the escape hatch and `account_list`). Calling e.g. `drive_discover` returns that service's operation catalog (name, one-line summary, arguments, read/write class), reveals the operational tools, and emits `notifications/tools/list_changed` so the client re-fetches the list. An optional `query` argument filters the catalog.
+
+Hidden is a listing concept, not a security boundary: operational tools stay callable at all times (existing prompts that call tools directly keep working), and write-control + OAuth scopes remain the real enforcement. Use `GOOGLE_TOOLSETS` to switch entire services off — it is a filter only: listing an optional service does not enable it without its `GOOGLE_OPTIONAL_SCOPES` / `GOOGLE_ADMIN_ACCOUNTS` gate.
+
+## Curated + generated tiers
+
+Everyday operations are **curated** tools: hand-written, response-shaped, token-lean. The long tail is **generated** from Google's API Discovery documents — one tool per method, same write-control, same account fan-out, regenerated when Google revises an API. Together they cover every OAuth-reachable Workspace API method; the split per service is in [COVERAGE.md](../COVERAGE.md).
+
+## Multi-account: fan out one call across accounts
+
+Every read tool's `account` argument also accepts `"*"` (all configured accounts) or a CSV subset (`"work,personal"`). The server runs the call once per account (bounded concurrency) and returns per-account results — one account failing never hides the others:
+
+```jsonc
+{ "results": [
+    { "account": "work", "ok": true, "data": { /* … */ } },
+    { "account": "personal", "ok": false, "error": { "error": "auth_required", /* … */ } }
+  ],
+  "partial": true }
+```
+
+Fan-out is **read-only by design** (write tools take exactly one account), and the three read tools that save files to disk (`drive_download`, `drive_export`, `gmail_download_attachment`) are excluded so parallel accounts can't clobber the same path. `account_list` shows what's configured: alias, email, token health (`ok` / `expired_refreshable` / `needs_reauth` / `missing` / `decrypt_error`), and granted-vs-configured scopes — without ever touching token values.
+
+`drive_transfer` copies or moves a file between two of your accounts: server-side share+copy when possible (the temporary read grant on the source is revoked right after; the copy gets a clean name, never "Copy of"), download+upload as the fallback. `move: true` trashes the source after a successful copy — that part is **delete-gated by write-control**, so `safe-writes` can copy but never move. Comments, revision history, and permissions don't transfer; if the fallback has to change the format (Drawings export as PNG), the result is flagged `lossy` and a requested move keeps the source intact. Native files over Google's 10MB export cap and binaries over 1GB can't take the fallback path.
+
+## Escape hatch: any Workspace REST method
+
+Two eager tools cover anything outside the snapshot: `google_api_search` finds any method in Google's API Discovery index, and `google_api_call` invokes a method by its Discovery id (`drive.revisions.list`, `slides.presentations.create`, …) with path/query params and a JSON body. Calls run through your account's OAuth client and the **same write-control policy** as named tools: the read/create/update/delete class is derived from the method's HTTP verb and name (POST deletes like `batchDelete`/`clear` count as deletes), and policy globs/`GOOGLE_TOOLSETS` match the same service names as named tools (`people` counts as `contacts`, `admin_*` as `admin`).
+
+Discovery documents are fetched from Google on first use and cached on disk for 7 days (`DISCOVERY_CACHE_PATH`); a stale cache is used when offline.
+
+## Lean responses by default
+
+Tool responses are serialized compactly (no pretty-print token tax; set `GOOGLE_TRIM=off` to restore pretty JSON), and the fat readers ship sensible caps with per-call escape valves. The caps are per-call controls (`full` / `maxChars`) and are NOT affected by `GOOGLE_TRIM`:
+
+- `drive_read` returns up to `maxChars` characters (default 100k) with `truncated`/`totalChars`/`offset` for paging — this also bounds Google Doc exports, which can reach 10MB. (Non-Google-native files over 2MB are still rejected with `too_large`, not paged.)
+- `gmail_read` / `gmail_read_thread` cap each message body at 50k chars (`bodyTruncated` + `bodyTotalChars` flags); pass `full: true` for the whole body.
+- `calendar_list_events` / `calendar_list_instances` trim descriptions to ~300 chars and drop empty/audit fields in list view; `calendar_get_event` always returns the full event.

--- a/docs/google-cloud-setup.md
+++ b/docs/google-cloud-setup.md
@@ -1,0 +1,11 @@
+# Google Cloud setup (one-time, ~2 minutes)
+
+The server signs in to Google **as you**, through an OAuth app that you own. Creating it is free and needs no billing account. Back to the [README](../README.md).
+
+1. Open the [Google Cloud Console](https://console.cloud.google.com) and sign in with any Google account. Create a project (top bar → project picker → **New project**) or pick an existing one.
+2. Enable the APIs you'll use: **APIs & Services → Library**, search and enable Gmail, Google Drive, Google Calendar, Google Sheets, Google Docs, People, Search Console, Tasks, and Google Meet. (Enable Slides / Forms / Chat / Admin SDK / Classroom / Vault / etc. later if you turn on those [bundles](./configuration.md#optional-scope-bundles).)
+3. Create the OAuth client: **APIs & Services → Credentials → Create Credentials → OAuth client ID**. If asked to configure the consent screen first: choose **External**, fill in the app name and your email, and add your own Google account(s) as **Test users** — nothing needs to be verified for personal use.
+4. Choose application type **Desktop app**, any name. After creating it, add the redirect URI `http://localhost:4242/oauth2callback` if the console offers the field (Desktop clients often accept loopback redirects automatically).
+5. Copy the **Client ID** and **Client Secret** — these become `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` in your configuration.
+
+Because the app is yours and unverified, Google shows an "unverified app" warning during sign-in — click **Advanced → Continue**. That's expected: you are the only user of your own OAuth app.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,21 @@
+# Keep secrets in a vault
+
+A plaintext `.env` is fine to try things out, but for a daily driver, **don't leave `GOOGLE_CLIENT_SECRET` + `MASTER_KEY` on disk** — inject them at launch from a secrets manager. The server just reads `process.env` (it has no idea where the values come from), so wrap it. Back to the [README](../README.md).
+
+Example with [Infisical](https://infisical.com):
+
+```bash
+#!/usr/bin/env bash
+# ~/.local/bin/mcp-google-multi-run  — chmod +x, then register this as the MCP command
+set -euo pipefail
+export INFISICAL_TOKEN="$(infisical login --method=universal-auth \
+  --client-id "$YOUR_CLIENT_ID" --client-secret "$YOUR_CLIENT_SECRET" --plain --silent)"
+exec infisical run --projectId <project> --env prod --path /mcp-google-multi \
+  -- npx -y mcp-google-multi
+```
+
+```bash
+claude mcp add google-multi -s user -- ~/.local/bin/mcp-google-multi-run
+```
+
+Now the only thing on disk is the **encrypted** token store. Pass the token via the `INFISICAL_TOKEN` env var (as above), **not** a `--token` flag, so it never shows up in `ps`. Any secrets manager works — Doppler, Vault, 1Password CLI, etc. — the pattern is the same.

--- a/docs/upgrading-v4.md
+++ b/docs/upgrading-v4.md
@@ -1,0 +1,10 @@
+# Upgrading from v4
+
+v5 is a breaking change, but the migration is a one-time, ~2-minute step. Back to the [README](../README.md).
+
+1. Update: `npm i -g mcp-google-multi@latest` (or update your client config).
+2. Add **`MASTER_KEY`** to your environment (`openssl rand -base64 32`) — now required.
+3. Encrypt existing tokens: `mcp-google-multi migrate-tokens` (reads your old `tokens/<alias>/token.json` and encrypts them) — or just re-auth each account.
+4. Writes are now **deny-by-default** — set `GOOGLE_PROFILE=safe-writes` (or `full-writes`) to keep writing. (`GOOGLE_ALLOW_ADMIN_WRITES` is gone — replaced by [write-control profiles](./configuration.md#write-control-deny-by-default).)
+
+v5 is **local + user-OAuth only**. Service accounts and hosting (and the APIs they unlock) are tracked for v6 on the [roadmap](https://github.com/bakissation/mcp-google-multi/milestones).


### PR DESCRIPTION
Part of the Fidelity & DX milestone (#7): the README becomes a slim landing page — what it is (badges + three "why" bullets), a quick setup written for someone who has never touched MCP or OAuth (five copy-paste steps, plain language), and the maintainer/credits block. Everything else moves to dedicated pages:

- `docs/configuration.md` — full env reference, write-control profiles/globs, service list, the 17 optional scope bundles
- `docs/google-cloud-setup.md` — novice-expanded OAuth app creation (consent screen, test users, the unverified-app warning)
- `docs/secrets.md` — the vault/launch-injection pattern
- `docs/features.md` — discover-first, curated+generated tiers, fan-out + drive_transfer, escape hatch, lean responses
- `docs/upgrading-v4.md` — the v4→v5 migration

Nothing was deleted — every section of the old README lives in one of the linked pages, refreshed to the current surface. Contributor credits (@obatried, @trevor-commits, @mjreddy) added to the maintainer block.

`docs:` commit — no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)