### PR TITLE
feat: summary-first Docs reads with heading-addressable sections

### DIFF
--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -6,28 +6,134 @@ import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
+import { capText } from '../trim.js';
 
 const accountEnum = z.enum(ACCOUNTS);
 
 function extractPlainText(body: any): string {
+  return extractPlainTextInRange(body, 0, Infinity);
+}
+
+export function extractPlainTextInRange(body: any, start: number, end: number): string {
   if (!body?.content) return '';
   let text = '';
   for (const element of body.content) {
+    const es = element.startIndex ?? 0;
+    const ee = element.endIndex ?? Infinity;
+    if (ee <= start || es >= end) continue;
     if (element.paragraph) {
       for (const pe of element.paragraph.elements ?? []) {
-        if (pe.textRun?.content) {
-          text += pe.textRun.content;
-        }
+        const run = pe.textRun?.content;
+        if (!run) continue;
+        const ps = pe.startIndex ?? es;
+        const from = Math.max(0, start - ps);
+        const to = Math.min(run.length, end - ps);
+        if (to > from) text += run.slice(from, to);
       }
     } else if (element.table) {
       for (const row of element.table.tableRows ?? []) {
         for (const cell of row.tableCells ?? []) {
-          text += extractPlainText(cell);
+          text += extractPlainTextInRange(cell, start, end);
         }
       }
     }
   }
   return text;
+}
+
+const HEADING_RANKS: Record<string, number> = {
+  TITLE: 0,
+  HEADING_1: 1,
+  HEADING_2: 2,
+  HEADING_3: 3,
+  HEADING_4: 4,
+  HEADING_5: 5,
+  HEADING_6: 6,
+};
+
+export type HeadingLevel = 'title' | 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface HeadingEntry {
+  i: number;
+  level: HeadingLevel;
+  text: string;
+  startIndex: number;
+  endIndex: number;
+}
+
+export function buildHeadingIndex(body: any): HeadingEntry[] {
+  const found: { rank: number; text: string; startIndex: number }[] = [];
+  let docEnd = 0;
+  const walk = (b: any) => {
+    if (!b?.content) return;
+    for (const element of b.content) {
+      if (typeof element.endIndex === 'number' && element.endIndex > docEnd) docEnd = element.endIndex;
+      if (element.paragraph) {
+        const rank = HEADING_RANKS[element.paragraph.paragraphStyle?.namedStyleType ?? ''];
+        if (rank !== undefined) {
+          let text = '';
+          for (const pe of element.paragraph.elements ?? []) {
+            if (pe.textRun?.content) text += pe.textRun.content;
+          }
+          found.push({ rank, text: text.trim(), startIndex: element.startIndex ?? 0 });
+        }
+      } else if (element.table) {
+        for (const row of element.table.tableRows ?? []) {
+          for (const cell of row.tableCells ?? []) walk(cell);
+        }
+      }
+    }
+  };
+  walk(body);
+  return found.map((h, i) => {
+    let endIndex = docEnd;
+    for (let j = i + 1; j < found.length; j++) {
+      if (found[j].rank <= h.rank) {
+        endIndex = found[j].startIndex;
+        break;
+      }
+    }
+    return {
+      i,
+      level: (h.rank === 0 ? 'title' : h.rank) as HeadingLevel,
+      text: h.text,
+      startIndex: h.startIndex,
+      endIndex,
+    };
+  });
+}
+
+export type HeadingResolution =
+  | { match: HeadingEntry }
+  | { error: 'not_found' | 'ambiguous'; candidates: HeadingEntry[] };
+
+export function resolveHeading(headings: HeadingEntry[], query: string): HeadingResolution {
+  const q = query.trim().toLowerCase();
+  const exact = headings.filter((h) => h.text.toLowerCase() === q);
+  if (exact.length === 1) return { match: exact[0] };
+  if (exact.length > 1) return { error: 'ambiguous', candidates: exact };
+  const partial = headings.filter((h) => h.text.toLowerCase().includes(q));
+  if (partial.length === 1) return { match: partial[0] };
+  if (partial.length > 1) return { error: 'ambiguous', candidates: partial };
+  return { error: 'not_found', candidates: headings };
+}
+
+export function findTab(tabs: any[] | undefined, tabId: string): any | undefined {
+  for (const tab of tabs ?? []) {
+    if (tab.tabProperties?.tabId === tabId) return tab;
+    const nested = findTab(tab.childTabs, tabId);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+export function listTabs(tabs: any[] | undefined): { tabId: string; title: string }[] {
+  const out: { tabId: string; title: string }[] = [];
+  for (const tab of tabs ?? []) {
+    out.push({ tabId: tab.tabProperties?.tabId ?? '', title: tab.tabProperties?.title ?? '' });
+    out.push(...listTabs(tab.childTabs));
+  }
+  return out;
 }
 
 export function registerDocsTools(server: ToolRegistry): void {
@@ -103,23 +209,105 @@ export function registerDocsTools(server: ToolRegistry): void {
   server.registerTool(
     'docs_read',
     {
-      description: 'Read document content as plain text',
+      description: 'Read document content as plain text with a heading index (returns up to maxChars characters per call). Pass heading or headingIndex to read one section, tabId to read a specific tab.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         documentId: z.string().describe('Google Docs document ID'),
+        heading: z.string().optional()
+          .describe('Read only the section under this heading (case-insensitive; exact match first, then substring)'),
+        headingIndex: z.number().int().min(0).optional()
+          .describe('Read only the section at this position in the headings array (the `i` field)'),
+        tabId: z.string().optional()
+          .describe('Read a specific tab instead of the first tab'),
+        maxChars: z.number().min(1).max(2_000_000).default(50_000).optional()
+          .describe('Max characters of text to return (default: 50000)'),
+        offset: z.number().min(0).default(0).optional()
+          .describe('Character offset to continue a truncated read'),
       },
     },
-    async ({ account, documentId }) => {
+    async ({ account, documentId, heading, headingIndex, tabId, maxChars, offset }) => {
       try {
+        if (heading !== undefined && headingIndex !== undefined) {
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify({
+              error: 'invalid_params',
+              message: 'Provide either heading or headingIndex, not both',
+            }, null, 2) }],
+            isError: true,
+          };
+        }
         const auth = await getClient(account as Account);
         const docs = google.docs({ version: 'v1', auth });
-        const res = await docs.documents.get({ documentId });
-        const text = extractPlainText(res.data.body);
+        const res = await docs.documents.get({
+          documentId,
+          ...(tabId !== undefined ? { includeTabsContent: true } : {}),
+        });
+
+        let body = res.data.body;
+        if (tabId !== undefined) {
+          const tab = findTab(res.data.tabs as any[], tabId);
+          if (!tab) {
+            return {
+              content: [{ type: 'text' as const, text: JSON.stringify({
+                error: 'not_found',
+                message: `Tab "${tabId}" not found in document ${documentId}`,
+                availableTabs: listTabs(res.data.tabs as any[]),
+              }, null, 2) }],
+              isError: true,
+            };
+          }
+          body = tab.documentTab?.body;
+        }
+
+        const headings = buildHeadingIndex(body);
+
+        let section: HeadingEntry | undefined;
+        if (headingIndex !== undefined) {
+          section = headings[headingIndex];
+          if (!section) {
+            return {
+              content: [{ type: 'text' as const, text: JSON.stringify({
+                error: 'invalid_params',
+                message: `headingIndex ${headingIndex} is out of range (document has ${headings.length} headings)`,
+                headings: headings.map(({ i, level, text }) => ({ i, level, text })),
+              }, null, 2) }],
+              isError: true,
+            };
+          }
+        } else if (heading !== undefined) {
+          const resolved = resolveHeading(headings, heading);
+          if ('error' in resolved) {
+            return {
+              content: [{ type: 'text' as const, text: JSON.stringify({
+                error: resolved.error === 'ambiguous' ? 'ambiguous_heading' : 'not_found',
+                message: resolved.error === 'ambiguous'
+                  ? `Heading "${heading}" matches multiple headings; use headingIndex to disambiguate`
+                  : `Heading "${heading}" not found in document ${documentId}`,
+                candidates: resolved.candidates.map(({ i, level, text }) => ({ i, level, text })),
+              }, null, 2) }],
+              isError: true,
+            };
+          }
+          section = resolved.match;
+        }
+
+        const text = section
+          ? extractPlainTextInRange(body, section.startIndex, section.endIndex)
+          : extractPlainText(body);
+        const from = offset ?? 0;
+        const capped = capText(text, maxChars ?? 50_000, from);
+
         return {
           content: [{ type: 'text' as const, text: JSON.stringify({
             documentId: res.data.documentId,
             title: res.data.title,
-            text,
+            ...(tabId !== undefined ? { tabId } : {}),
+            headings: headings.map(({ i, level, text: t }) => ({ i, level, text: t })),
+            ...(section ? { section: { i: section.i, level: section.level, text: section.text } } : {}),
+            text: capped.text,
+            ...(capped.truncated || from > 0
+              ? { truncated: capped.truncated, totalChars: capped.totalChars, offset: from }
+              : {}),
           }, null, 2) }],
         };
       } catch (error: any) {

--- a/tests/docs-read.test.ts
+++ b/tests/docs-read.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildHeadingIndex,
+  extractPlainTextInRange,
+  resolveHeading,
+  findTab,
+  listTabs,
+} from '../src/tools/docs.js';
+import { capText } from '../src/trim.js';
+
+function para(text: string, start: number, namedStyleType?: string) {
+  const end = start + text.length;
+  return {
+    startIndex: start,
+    endIndex: end,
+    paragraph: {
+      ...(namedStyleType ? { paragraphStyle: { namedStyleType } } : {}),
+      elements: [{ startIndex: start, endIndex: end, textRun: { content: text } }],
+    },
+  };
+}
+
+function docBody(specs: [style: string | null, text: string][]) {
+  let cursor = 1;
+  const content: any[] = [];
+  for (const [style, text] of specs) {
+    content.push(para(text, cursor, style ?? undefined));
+    cursor += text.length;
+  }
+  return { content };
+}
+
+const BODY = docBody([
+  ['TITLE', 'My Doc\n'],        // 1..8
+  [null, 'intro text\n'],       // 8..19
+  ['HEADING_1', 'Alpha\n'],     // 19..25
+  [null, 'alpha body\n'],       // 25..36
+  ['HEADING_2', 'Alpha One\n'], // 36..46
+  [null, 'nested body\n'],      // 46..58
+  ['HEADING_1', 'Beta\n'],      // 58..63
+  [null, 'beta body\n'],        // 63..73
+]);
+
+function tableBody() {
+  const cellContent = [
+    para('In Cell\n', 9, 'HEADING_2'),  // 9..17
+    para('cell body\n', 17),            // 17..27
+  ];
+  return {
+    content: [
+      para('before\n', 1),              // 1..8
+      {
+        startIndex: 8,
+        endIndex: 40,
+        table: { tableRows: [{ tableCells: [{ content: cellContent }] }] },
+      },
+      para('after\n', 40),              // 40..46
+      para('Next\n', 46, 'HEADING_2'),  // 46..51
+      para('tail\n', 51),               // 51..56
+    ],
+  };
+}
+
+describe('buildHeadingIndex', () => {
+  it('collects title and heading levels with spans to the next same-or-higher heading', () => {
+    expect(buildHeadingIndex(BODY)).toEqual([
+      { i: 0, level: 'title', text: 'My Doc', startIndex: 1, endIndex: 73 },
+      { i: 1, level: 1, text: 'Alpha', startIndex: 19, endIndex: 58 },
+      { i: 2, level: 2, text: 'Alpha One', startIndex: 36, endIndex: 58 },
+      { i: 3, level: 1, text: 'Beta', startIndex: 58, endIndex: 73 },
+    ]);
+  });
+
+  it('ends a section at the next heading of the same level', () => {
+    const body = docBody([
+      ['HEADING_1', 'First\n'],  // 1..7
+      [null, 'one\n'],           // 7..11
+      ['HEADING_1', 'Second\n'], // 11..18
+      [null, 'two\n'],           // 18..22
+    ]);
+    expect(buildHeadingIndex(body)).toEqual([
+      { i: 0, level: 1, text: 'First', startIndex: 1, endIndex: 11 },
+      { i: 1, level: 1, text: 'Second', startIndex: 11, endIndex: 22 },
+    ]);
+  });
+
+  it('includes table-nested headings in document order', () => {
+    expect(buildHeadingIndex(tableBody())).toEqual([
+      { i: 0, level: 2, text: 'In Cell', startIndex: 9, endIndex: 46 },
+      { i: 1, level: 2, text: 'Next', startIndex: 46, endIndex: 56 },
+    ]);
+  });
+
+  it('returns an empty index for empty or missing bodies', () => {
+    expect(buildHeadingIndex({ content: [] })).toEqual([]);
+    expect(buildHeadingIndex(undefined)).toEqual([]);
+    expect(buildHeadingIndex(docBody([[null, 'no headings\n']]))).toEqual([]);
+  });
+});
+
+describe('extractPlainTextInRange', () => {
+  it('extracts a mid-document section including nested subheadings', () => {
+    expect(extractPlainTextInRange(BODY, 19, 58)).toBe('Alpha\nalpha body\nAlpha One\nnested body\n');
+  });
+
+  it('extracts the last section through to the document end', () => {
+    expect(extractPlainTextInRange(BODY, 58, 73)).toBe('Beta\nbeta body\n');
+  });
+
+  it('extracts a section whose heading sits inside a table', () => {
+    expect(extractPlainTextInRange(tableBody(), 9, 46)).toBe('In Cell\ncell body\nafter\n');
+  });
+
+  it('slices partially-overlapping paragraphs at the range edges', () => {
+    expect(extractPlainTextInRange(BODY, 21, 27)).toBe('pha\nal');
+  });
+
+  it('returns empty for missing bodies and empty ranges', () => {
+    expect(extractPlainTextInRange(undefined, 0, 100)).toBe('');
+    expect(extractPlainTextInRange(BODY, 19, 19)).toBe('');
+  });
+
+  it('full range matches the unbounded walk', () => {
+    expect(extractPlainTextInRange(BODY, 0, Infinity))
+      .toBe('My Doc\nintro text\nAlpha\nalpha body\nAlpha One\nnested body\nBeta\nbeta body\n');
+  });
+});
+
+describe('resolveHeading', () => {
+  const headings = buildHeadingIndex(docBody([
+    ['HEADING_1', 'Overview\n'],
+    ['HEADING_2', 'Overview of Costs\n'],
+    ['HEADING_1', 'Details\n'],
+  ]));
+
+  it('prefers a case-insensitive exact match over substring matches', () => {
+    const res = resolveHeading(headings, 'overview');
+    expect(res).toHaveProperty('match');
+    expect((res as any).match.i).toBe(0);
+  });
+
+  it('falls back to a unique substring match', () => {
+    const res = resolveHeading(headings, 'costs');
+    expect((res as any).match.i).toBe(1);
+  });
+
+  it('errors on an ambiguous substring, listing candidates', () => {
+    const res = resolveHeading(headings, 'over');
+    expect(res).toEqual({ error: 'ambiguous', candidates: [headings[0], headings[1]] });
+  });
+
+  it('errors on duplicate exact matches', () => {
+    const dup = buildHeadingIndex(docBody([
+      ['HEADING_1', 'Notes\n'],
+      [null, 'x\n'],
+      ['HEADING_1', 'Notes\n'],
+    ]));
+    const res = resolveHeading(dup, 'Notes');
+    expect(res).toEqual({ error: 'ambiguous', candidates: dup });
+  });
+
+  it('errors not_found with all headings as candidates', () => {
+    expect(resolveHeading(headings, 'zzz')).toEqual({ error: 'not_found', candidates: headings });
+  });
+});
+
+describe('section paging', () => {
+  it('applies maxChars/offset within an extracted section', () => {
+    const section = extractPlainTextInRange(BODY, 58, 73);
+    expect(capText(section, 5, 0)).toEqual({ text: 'Beta\n', truncated: true, totalChars: 15 });
+    expect(capText(section, 100, 5)).toEqual({ text: 'beta body\n', truncated: false, totalChars: 15 });
+  });
+});
+
+describe('tab helpers', () => {
+  const tabs = [
+    {
+      tabProperties: { tabId: 't1', title: 'First' },
+      childTabs: [{ tabProperties: { tabId: 't1a', title: 'Nested' } }],
+    },
+    { tabProperties: { tabId: 't2', title: 'Second' } },
+  ];
+
+  it('finds tabs recursively through childTabs', () => {
+    expect(findTab(tabs, 't1a')?.tabProperties.title).toBe('Nested');
+    expect(findTab(tabs, 't2')?.tabProperties.title).toBe('Second');
+    expect(findTab(tabs, 'missing')).toBeUndefined();
+    expect(findTab(undefined, 't1')).toBeUndefined();
+  });
+
+  it('lists all tabs flat', () => {
+    expect(listTabs(tabs)).toEqual([
+      { tabId: 't1', title: 'First' },
+      { tabId: 't1a', title: 'Nested' },
+      { tabId: 't2', title: 'Second' },
+    ]);
+  });
+});


### PR DESCRIPTION
Part of the Fidelity & DX milestone (#7).

`docs_read` becomes summary-first and pageable:

- Default response now includes a **headings index** (`[{i, level, text}]` from the named styles already on the wire — no extra API call) alongside the text.
- **Paging**: `maxChars` (default 50k) / `offset` with `truncated`/`totalChars` — the drive_read precedent; large docs no longer land whole in context.
- **Section reads**: `heading` (case-insensitive exact-then-substring, typed `ambiguous_heading` envelope listing candidates on ambiguity) or `headingIndex` reads just that section's span (to the next same-or-higher heading).
- **Tabs**: optional `tabId` runs the same logic against any tab (recursive child-tab lookup; unknown id returns the available tabs).

Pure helpers (`buildHeadingIndex`, range extraction, tab lookup) are exported and unit-tested on synthetic Document fixtures — 18 new tests, 318 total green first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)