### PR TITLE
feat: gmail read fidelity — HTML extraction, threading headers, richer attachments

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -759,7 +759,7 @@ Optional scope bundles: `appsmarket`, `chat`, `classroom`, `cloudidentity`, `clo
 | `gmail_list_labels` | curated | read | List all Gmail labels (system and user-defined). Use to get label IDs for gmail_modify_labels. |
 | `gmail_modify_labels` | curated | update | Add or remove labels on a Gmail message. Use system label IDs like STARRED, UNREAD, INBOX, TRASH, or custom label IDs fr |
 | `gmail_read` | curated | read | Read a full Gmail message by ID (body capped at 50k chars unless full=true) |
-| `gmail_read_thread` | curated | read | Read all messages in a Gmail thread (bodies capped at 50k chars each unless full=true) |
+| `gmail_read_thread` | curated | read | Read all messages in a Gmail thread (bodies capped at 50k chars each unless full=true). mode=summary returns headers + s |
 | `gmail_search` | curated | read | Search messages in a Gmail account |
 | `gmail_send` | curated | create | Send an email from a Gmail account |
 | `gmail_send_draft` | curated | create | Send an existing Gmail draft by its draft ID |

--- a/src/tools/gmail-mime.ts
+++ b/src/tools/gmail-mime.ts
@@ -64,6 +64,111 @@ export function normalizeBodyLineEndings(body: string): string {
   return body.replace(/\r\n|\r|\n/g, '\r\n');
 }
 
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+function codePointToChar(code: number, fallback: string): string {
+  if (Number.isNaN(code) || code > 0x10ffff || (code >= 0xd800 && code <= 0xdfff)) return fallback;
+  return String.fromCodePoint(code);
+}
+
+function decodeEntities(text: string): string {
+  return text.replace(
+    /&(?:#(\d+)|#[xX]([0-9a-fA-F]+)|([a-zA-Z][a-zA-Z0-9]*));/g,
+    (match, dec, hex, named) => {
+      if (dec) return codePointToChar(parseInt(dec, 10), match);
+      if (hex) return codePointToChar(parseInt(hex, 16), match);
+      return NAMED_ENTITIES[named.toLowerCase()] ?? match;
+    },
+  );
+}
+
+// Fixpoint tag strip: one pass can reassemble a tag from a removed span's
+// edges (<scr<b>ipt> -> <script>).
+function stripTags(input: string, replacement = ''): string {
+  let out = input;
+  for (let previous = ''; previous !== out; ) {
+    previous = out;
+    out = out.replace(/<[^>]*>/g, replacement);
+  }
+  return out;
+}
+
+/**
+ * Best-effort HTML→plain-text for reading HTML-only emails. Regex-based on
+ * purpose — no HTML parser dependency, and mail HTML is flat enough for it.
+ */
+export function htmlToText(html: string): string {
+  // Repeat until stable: single-pass removal can leave behind sequences
+  // reassembled from the removed span's edges (<scr<script>ipt>).
+  let text = html;
+  for (let previous = ''; previous !== text; ) {
+    previous = text;
+    text = text
+      // --!> is a valid comment terminator per WHATWG
+      .replace(/<!--[\s\S]*?--!?>/g, '')
+      // an unterminated comment consumes the rest of the document per spec
+      .replace(/<!--[\s\S]*$/, '')
+      .replace(/<(style|script|head)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
+  }
+  // All comment content is gone; drop any stray bare delimiters too.
+  text = text.replace(/<!--|--!?>/g, '');
+  // Source whitespace (incl. newlines) is insignificant in HTML; real line
+  // structure is reintroduced from block tags below.
+  text = text.replace(/\s+/g, ' ');
+
+  text = text.replace(
+    /<a\b[^>]*?href\s*=\s*(?:"([^"]*)"|'([^']*)')[^>]*>([\s\S]*?)<\/a\s*>/gi,
+    (_match, dq, sq, inner) => {
+      const href = (dq ?? sq ?? '').trim();
+      const innerText = stripTags(inner, ' ').replace(/\s+/g, ' ').trim();
+      const redundant =
+        href === '' ||
+        href.startsWith('#') ||
+        href === innerText ||
+        href === `mailto:${innerText}`;
+      return redundant ? inner : `${inner} (${href})`;
+    },
+  );
+
+  text = text
+    .replace(/<(?:br|hr)\b[^>]*>/gi, '\n')
+    .replace(/<\/t[dh]\s*>/gi, ' ')
+    .replace(/<(?:p|h[1-6])\b[^>]*>/gi, '\n')
+    .replace(/<\/(?:p|div|h[1-6]|li|tr|table|ul|ol|blockquote|pre|section|article|header|footer|address|figure|dl|dt|dd)\s*>/gi, '\n');
+  text = stripTags(text);
+
+  return decodeEntities(text)
+    .replace(/[ \t]*\n[ \t]*/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+/**
+ * RFC 5322 threading: In-Reply-To/References must carry the parent's real
+ * Message-ID header, not the Gmail API id. Falls back to the API id when the
+ * header is missing so replies still thread inside Gmail.
+ */
+export function buildReplyHeaders(
+  fallbackId: string,
+  parentMessageIdHeader: string,
+  parentReferences: string,
+): { inReplyTo: string; references: string } {
+  const parentId = parentMessageIdHeader.trim();
+  if (parentId === '') return { inReplyTo: fallbackId, references: fallbackId };
+  const refs = parentReferences.trim().replace(/\s+/g, ' ');
+  return {
+    inReplyTo: parentId,
+    references: refs === '' ? parentId : `${refs} ${parentId}`,
+  };
+}
+
 /**
  * RFC 2046 §5.1.1 boundary token: 1-70 chars from a restricted set, no trailing space.
  * randomBytes hex output is only [0-9a-f], all of which are bcharsnospace.

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -6,7 +6,7 @@ import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
-import { buildMultipartAlternative, encodeAddressHeader, encodeHeaderValue, normalizeBodyLineEndings } from './gmail-mime.js';
+import { buildMultipartAlternative, buildReplyHeaders, encodeAddressHeader, encodeHeaderValue, htmlToText, normalizeBodyLineEndings } from './gmail-mime.js';
 import { sliceClean } from '../trim.js';
 import type { GmailMessageHeader, GmailMessageFull, GmailAttachment } from '../types.js';
 import * as path from 'path';
@@ -21,41 +21,51 @@ function getHeader(
   return headers?.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value ?? '';
 }
 
+function collectTextParts(part: any, plain: string[], html: string[], topLevel = false): void {
+  if (!part) return;
+  const isAttachment = Boolean(part.filename) || Boolean(part.body?.attachmentId);
+  if (!isAttachment && part.body?.data) {
+    const decoded = Buffer.from(part.body.data, 'base64url').toString('utf-8');
+    if (part.mimeType === 'text/html') html.push(decoded);
+    // Simple (non-multipart) messages can carry any mimeType at the top level;
+    // returning their raw body preserves pre-collect behavior.
+    else if (part.mimeType === 'text/plain' || !part.mimeType || topLevel) plain.push(decoded);
+  }
+  for (const child of part.parts ?? []) {
+    collectTextParts(child, plain, html);
+  }
+}
+
 function decodeBody(
   payload: any,
-): string {
-  if (payload.body?.data) {
-    return Buffer.from(payload.body.data, 'base64url').toString('utf-8');
+  rawHtml = false,
+): { body: string; bodyOrigin?: 'text/plain' | 'text/html' } {
+  const plain: string[] = [];
+  const html: string[] = [];
+  collectTextParts(payload, plain, html, true);
+  // Concatenating every plain leaf keeps forwarded/mixed messages whole;
+  // any plain content beats HTML because alternatives duplicate the same body.
+  if (plain.length > 0) return { body: plain.join('\n\n'), bodyOrigin: 'text/plain' };
+  if (html.length > 0) {
+    const joined = html.join('\n\n');
+    return { body: rawHtml ? joined : htmlToText(joined), bodyOrigin: 'text/html' };
   }
-  if (payload.parts) {
-    for (const part of payload.parts) {
-      if (part.mimeType === 'text/plain' && part.body?.data) {
-        return Buffer.from(part.body.data, 'base64url').toString('utf-8');
-      }
-    }
-    for (const part of payload.parts) {
-      if (part.mimeType === 'text/html' && part.body?.data) {
-        return Buffer.from(part.body.data, 'base64url').toString('utf-8');
-      }
-    }
-    for (const part of payload.parts) {
-      if (part.parts) {
-        const result = decodeBody(part);
-        if (result) return result;
-      }
-    }
-  }
-
-  return '';
+  return { body: '' };
 }
 
 function getAttachments(payload: any): GmailAttachment[] {
   const attachments: GmailAttachment[] = [];
   if (payload.filename && payload.body?.attachmentId) {
+    const disposition = getHeader(payload.headers, 'Content-Disposition');
+    const inline = disposition.toLowerCase().startsWith('inline')
+      || getHeader(payload.headers, 'Content-ID') !== '';
     attachments.push({
       filename: payload.filename,
       attachmentId: payload.body.attachmentId,
       mimeType: payload.mimeType ?? 'application/octet-stream',
+      ...(typeof payload.body.size === 'number' ? { sizeBytes: payload.body.size } : {}),
+      ...(payload.partId ? { partId: payload.partId } : {}),
+      ...(inline ? { inline: true } : {}),
     });
   }
   if (payload.parts) {
@@ -66,12 +76,42 @@ function getAttachments(payload: any): GmailAttachment[] {
   return attachments;
 }
 
+async function resolveReplyHeaders(
+  gmail: any,
+  replyToMessageId: string,
+): Promise<{ inReplyTo: string; references: string }> {
+  try {
+    const meta = await gmail.users.messages.get({
+      userId: 'me',
+      id: replyToMessageId,
+      format: 'metadata',
+      metadataHeaders: ['Message-ID', 'References'],
+    });
+    const headers = meta.data.payload?.headers;
+    return buildReplyHeaders(
+      replyToMessageId,
+      getHeader(headers, 'Message-ID'),
+      getHeader(headers, 'References'),
+    );
+  } catch {
+    // Degrade to the API id (pre-lookup behavior) rather than blocking the send.
+    return { inReplyTo: replyToMessageId, references: replyToMessageId };
+  }
+}
+
 const BODY_CAP_CHARS = 50_000;
 
-export function parseMessage(msg: any, bodyCap?: number): GmailMessageFull {
+export function parseMessage(
+  msg: any,
+  bodyCap?: number,
+  opts?: { rawHtml?: boolean },
+): GmailMessageFull {
   const headers = msg.payload?.headers ?? [];
-  const body = decodeBody(msg.payload);
+  const { body, bodyOrigin } = decodeBody(msg.payload, opts?.rawHtml === true);
   const capped = bodyCap !== undefined && body.length > bodyCap;
+  const messageIdHeader = getHeader(headers, 'Message-ID');
+  const inReplyTo = getHeader(headers, 'In-Reply-To');
+  const references = getHeader(headers, 'References');
   return {
     id: msg.id ?? '',
     threadId: msg.threadId ?? '',
@@ -81,7 +121,13 @@ export function parseMessage(msg: any, bodyCap?: number): GmailMessageFull {
     cc: getHeader(headers, 'Cc'),
     date: getHeader(headers, 'Date'),
     body: capped ? sliceClean(body, bodyCap) : body,
+    ...(bodyOrigin ? { bodyOrigin } : {}),
     ...(capped ? { bodyTruncated: true, bodyTotalChars: body.length } : {}),
+    ...(messageIdHeader ? { messageIdHeader } : {}),
+    ...(inReplyTo ? { inReplyTo } : {}),
+    ...(references ? { references } : {}),
+    ...(msg.labelIds ? { labelIds: msg.labelIds } : {}),
+    ...(msg.internalDate ? { internalDate: msg.internalDate } : {}),
     attachments: getAttachments(msg.payload),
   };
 }
@@ -112,21 +158,30 @@ export function registerGmailTools(server: ToolRegistry): void {
         const messages = listRes.data.messages ?? [];
         const results: GmailMessageHeader[] = [];
 
-        for (const m of messages) {
-          const detail = await gmail.users.messages.get({
-            userId: 'me',
-            id: m.id!,
-            format: 'metadata',
-            metadataHeaders: ['From', 'Subject', 'Date'],
-          });
-          results.push({
-            id: detail.data.id ?? '',
-            threadId: detail.data.threadId ?? '',
-            subject: getHeader(detail.data.payload?.headers, 'Subject'),
-            from: getHeader(detail.data.payload?.headers, 'From'),
-            date: getHeader(detail.data.payload?.headers, 'Date'),
-            snippet: detail.data.snippet ?? '',
-          });
+        // Bounded parallelism: chunked Promise.all keeps order and avoids
+        // hammering the per-user quota with an unbounded fan-out.
+        const CHUNK_SIZE = 10;
+        for (let i = 0; i < messages.length; i += CHUNK_SIZE) {
+          const details = await Promise.all(
+            messages.slice(i, i + CHUNK_SIZE).map((m) => gmail.users.messages.get({
+              userId: 'me',
+              id: m.id!,
+              format: 'metadata',
+              metadataHeaders: ['From', 'To', 'Subject', 'Date'],
+            })),
+          );
+          for (const detail of details) {
+            results.push({
+              id: detail.data.id ?? '',
+              threadId: detail.data.threadId ?? '',
+              subject: getHeader(detail.data.payload?.headers, 'Subject'),
+              from: getHeader(detail.data.payload?.headers, 'From'),
+              to: getHeader(detail.data.payload?.headers, 'To'),
+              date: getHeader(detail.data.payload?.headers, 'Date'),
+              snippet: detail.data.snippet ?? '',
+              labelIds: detail.data.labelIds ?? [],
+            });
+          }
         }
 
         return {
@@ -145,9 +200,11 @@ export function registerGmailTools(server: ToolRegistry): void {
         account: accountEnum.describe('Google account alias'),
         messageId: z.string().describe('Gmail message ID'),
         full: coerceBoolean.optional().describe('Return the entire body without the character cap'),
+        rawHtml: coerceBoolean.optional()
+          .describe('Return the HTML body unconverted instead of the plain-text rendering (HTML-only messages)'),
       },
     },
-    async ({ account, messageId, full }) => {
+    async ({ account, messageId, full, rawHtml }) => {
       try {
         const auth = await getClient(account as Account);
         const gmail = google.gmail({ version: 'v1', auth });
@@ -158,7 +215,7 @@ export function registerGmailTools(server: ToolRegistry): void {
           format: 'full',
         });
 
-        const result = parseMessage(res.data, full ? undefined : BODY_CAP_CHARS);
+        const result = parseMessage(res.data, full ? undefined : BODY_CAP_CHARS, { rawHtml });
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
         };
@@ -170,17 +227,42 @@ export function registerGmailTools(server: ToolRegistry): void {
   server.registerTool(
     'gmail_read_thread',
     {
-      description: 'Read all messages in a Gmail thread (bodies capped at 50k chars each unless full=true)',
+      description: 'Read all messages in a Gmail thread (bodies capped at 50k chars each unless full=true). mode=summary returns headers + snippets only.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         threadId: z.string().describe('Gmail thread ID'),
         full: coerceBoolean.optional().describe('Return entire bodies without the character cap'),
+        rawHtml: coerceBoolean.optional()
+          .describe('Return HTML bodies unconverted instead of the plain-text rendering (HTML-only messages)'),
+        mode: z.enum(['full', 'summary']).default('full')
+          .describe('full = complete bodies; summary = per-message headers and snippet only'),
       },
     },
-    async ({ account, threadId, full }) => {
+    async ({ account, threadId, full, rawHtml, mode }) => {
       try {
         const auth = await getClient(account as Account);
         const gmail = google.gmail({ version: 'v1', auth });
+
+        if (mode === 'summary') {
+          const res = await gmail.users.threads.get({
+            userId: 'me',
+            id: threadId,
+            format: 'metadata',
+            metadataHeaders: ['From', 'To', 'Subject', 'Date', 'Message-ID'],
+          });
+          const summaries = (res.data.messages ?? []).map((m) => ({
+            id: m.id ?? '',
+            from: getHeader(m.payload?.headers, 'From'),
+            to: getHeader(m.payload?.headers, 'To'),
+            subject: getHeader(m.payload?.headers, 'Subject'),
+            date: getHeader(m.payload?.headers, 'Date'),
+            snippet: m.snippet ?? '',
+            labelIds: m.labelIds ?? [],
+          }));
+          return {
+            content: [{ type: 'text' as const, text: JSON.stringify(summaries, null, 2) }],
+          };
+        }
 
         const res = await gmail.users.threads.get({
           userId: 'me',
@@ -188,7 +270,7 @@ export function registerGmailTools(server: ToolRegistry): void {
           format: 'full',
         });
 
-        const messages = (res.data.messages ?? []).map((m) => parseMessage(m, full ? undefined : BODY_CAP_CHARS));
+        const messages = (res.data.messages ?? []).map((m) => parseMessage(m, full ? undefined : BODY_CAP_CHARS, { rawHtml }));
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(messages, null, 2) }],
         };
@@ -241,8 +323,9 @@ export function registerGmailTools(server: ToolRegistry): void {
 
         if (cc) headers.push(`Cc: ${encodeAddressHeader(cc)}`);
         if (replyToMessageId) {
-          headers.push(`In-Reply-To: ${replyToMessageId}`);
-          headers.push(`References: ${replyToMessageId}`);
+          const { inReplyTo, references } = await resolveReplyHeaders(gmail, replyToMessageId);
+          headers.push(`In-Reply-To: ${inReplyTo}`);
+          headers.push(`References: ${references}`);
         }
 
         const rawMessage = [...headers, '', bodyText].join('\r\n');
@@ -321,11 +404,13 @@ export function registerGmailTools(server: ToolRegistry): void {
         htmlBody: z.string().optional()
           .describe('Optional HTML body. When set, drafts as multipart/alternative so HTML-capable clients render the rich version. Use bare tags only: <p>, <a>, <br>, <strong>, <em>, <ul><li>.'),
         cc: z.string().optional().describe('CC recipients, comma-separated'),
+        replyToMessageId: z.string().optional()
+          .describe('Message ID to reply to (sets In-Reply-To and References headers)'),
         replyToThreadId: z.string().optional()
           .describe('Thread ID to associate the draft with'),
       },
     },
-    async ({ account, to, subject, body, htmlBody, cc, replyToThreadId }) => {
+    async ({ account, to, subject, body, htmlBody, cc, replyToMessageId, replyToThreadId }) => {
       try {
         const auth = await getClient(account as Account);
         const gmail = google.gmail({ version: 'v1', auth });
@@ -350,6 +435,11 @@ export function registerGmailTools(server: ToolRegistry): void {
         }
 
         if (cc) headers.push(`Cc: ${encodeAddressHeader(cc)}`);
+        if (replyToMessageId) {
+          const { inReplyTo, references } = await resolveReplyHeaders(gmail, replyToMessageId);
+          headers.push(`In-Reply-To: ${inReplyTo}`);
+          headers.push(`References: ${references}`);
+        }
 
         const rawMessage = [...headers, '', bodyText].join('\r\n');
         const encoded = Buffer.from(rawMessage, 'utf-8').toString('base64url');

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,14 +11,19 @@ export interface GmailMessageHeader {
   threadId: string;
   subject: string;
   from: string;
+  to: string;
   date: string;
   snippet: string;
+  labelIds: string[];
 }
 
 export interface GmailAttachment {
   filename: string;
   attachmentId: string;
   mimeType: string;
+  sizeBytes?: number;
+  partId?: string;
+  inline?: boolean;
 }
 
 export interface GmailMessageFull {
@@ -30,8 +35,14 @@ export interface GmailMessageFull {
   cc: string;
   date: string;
   body: string;
+  bodyOrigin?: 'text/plain' | 'text/html';
   bodyTruncated?: boolean;
   bodyTotalChars?: number;
+  messageIdHeader?: string;
+  inReplyTo?: string;
+  references?: string;
+  labelIds?: string[];
+  internalDate?: string;
   attachments: GmailAttachment[];
 }
 

--- a/tests/gmail-mime.test.ts
+++ b/tests/gmail-mime.test.ts
@@ -4,6 +4,8 @@ import {
   encodeAddressHeader,
   normalizeBodyLineEndings,
   buildMultipartAlternative,
+  buildReplyHeaders,
+  htmlToText,
 } from '../src/tools/gmail-mime.js';
 
 describe('encodeHeaderValue', () => {
@@ -215,6 +217,99 @@ describe('buildMultipartAlternative', () => {
     const a = buildMultipartAlternative('p', 'h').contentType;
     const b = buildMultipartAlternative('p', 'h').contentType;
     expect(a).not.toBe(b);
+  });
+});
+
+describe('htmlToText', () => {
+  it('strips style, script, and head blocks including their content', () => {
+    const html = '<head><title>T</title></head><style>body { color: red; }</style>'
+      + '<script>if (1 < 2) { alert("x"); }</script><p>Content</p>';
+    expect(htmlToText(html)).toBe('Content');
+  });
+
+  it('strips HTML comments', () => {
+    expect(htmlToText('before<!-- secret note -->after')).toBe('beforeafter');
+  });
+
+  it('maps paragraphs to blank-line-separated blocks', () => {
+    expect(htmlToText('<p>Hello</p><p>World</p>')).toBe('Hello\n\nWorld');
+  });
+
+  it('maps br, headings, list items, and table rows to newlines', () => {
+    expect(htmlToText('one<br>two')).toBe('one\ntwo');
+    expect(htmlToText('<h1>Title</h1>Body')).toBe('Title\nBody');
+    expect(htmlToText('<ul><li>One</li><li>Two</li></ul>')).toBe('One\nTwo');
+    expect(htmlToText('<table><tr><td>a</td><td>b</td></tr><tr><td>c</td></tr></table>'))
+      .toBe('a b\nc');
+  });
+
+  it('collapses HTML source newlines inside a paragraph to spaces', () => {
+    expect(htmlToText('<p>line one\n   line two</p>')).toBe('line one line two');
+  });
+
+  it('renders links as "text (href)"', () => {
+    expect(htmlToText('<a href="https://example.com/page">Read more</a>'))
+      .toBe('Read more (https://example.com/page)');
+    expect(htmlToText('<a class="btn" href=\'https://y.io\' target="_blank">Click</a>'))
+      .toBe('Click (https://y.io)');
+  });
+
+  it('omits the href when it duplicates the text or is an anchor', () => {
+    expect(htmlToText('<a href="https://example.com">https://example.com</a>'))
+      .toBe('https://example.com');
+    expect(htmlToText('<a href="#section">Jump</a>')).toBe('Jump');
+    expect(htmlToText('<a href="mailto:a@b.co">a@b.co</a>')).toBe('a@b.co');
+  });
+
+  it('strips remaining inline tags without adding whitespace', () => {
+    expect(htmlToText('<p>Hello <strong>bold</strong> and <em>italic</em></p>'))
+      .toBe('Hello bold and italic');
+  });
+
+  it('decodes named entities', () => {
+    expect(htmlToText('Fish &amp; Chips &lt;tag&gt; &quot;q&quot; &apos;a&apos; &#39;b&#39; A&nbsp;B'))
+      .toBe('Fish & Chips <tag> "q" \'a\' \'b\' A B');
+  });
+
+  it('decodes decimal and hex numeric entities', () => {
+    expect(htmlToText('caf&#233; caf&#xE9; &#x1F600;')).toBe('café café 😀');
+  });
+
+  it('decodes double-encoded entities exactly once', () => {
+    expect(htmlToText('&amp;lt;')).toBe('&lt;');
+  });
+
+  it('leaves unknown and invalid entities untouched', () => {
+    expect(htmlToText('&bogus; &#xDFFF; &#1114112;')).toBe('&bogus; &#xDFFF; &#1114112;');
+  });
+
+  it('collapses 3+ newlines to 2 and trims line-edge whitespace', () => {
+    expect(htmlToText('<p>a</p><br><br><br><p>b</p>')).toBe('a\n\nb');
+    expect(htmlToText('<p>text &nbsp; </p><p>next</p>')).toBe('text\n\nnext');
+  });
+});
+
+describe('buildReplyHeaders', () => {
+  it('uses the parent Message-ID for both headers when there are no prior references', () => {
+    expect(buildReplyHeaders('gmailid123', '<abc@mail.example.com>', ''))
+      .toEqual({ inReplyTo: '<abc@mail.example.com>', references: '<abc@mail.example.com>' });
+  });
+
+  it('appends the parent Message-ID to the existing references chain', () => {
+    expect(buildReplyHeaders('gmailid123', '<c@x.com>', '<a@x.com> <b@x.com>'))
+      .toEqual({ inReplyTo: '<c@x.com>', references: '<a@x.com> <b@x.com> <c@x.com>' });
+  });
+
+  it('unfolds folded references whitespace into single spaces', () => {
+    expect(buildReplyHeaders('g', '<c@x.com>', '<a@x.com>\r\n <b@x.com>').references)
+      .toBe('<a@x.com> <b@x.com> <c@x.com>');
+  });
+
+  it('falls back to the Gmail API id when the Message-ID header is absent', () => {
+    expect(buildReplyHeaders('gmailid123', '', ''))
+      .toEqual({ inReplyTo: 'gmailid123', references: 'gmailid123' });
+    expect(buildReplyHeaders('gmailid123', '   ', '<a@x.com>'))
+      .toEqual({ inReplyTo: 'gmailid123', references: 'gmailid123' });
   });
 });
 

--- a/tests/gmail-read.test.ts
+++ b/tests/gmail-read.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest';
+import { parseMessage } from '../src/tools/gmail.js';
+
+const b64 = (s: string) => Buffer.from(s, 'utf-8').toString('base64url');
+
+const textPart = (mimeType: string, text: string) => ({
+  mimeType,
+  filename: '',
+  body: { data: b64(text) },
+});
+
+const msg = (payload: unknown, extra: Record<string, unknown> = {}) => ({
+  id: 'm1',
+  threadId: 't1',
+  payload,
+  ...extra,
+});
+
+describe('parseMessage body selection', () => {
+  it('prefers nested text/plain over a sibling text/html part', () => {
+    const payload = {
+      mimeType: 'multipart/mixed',
+      parts: [
+        textPart('text/html', '<p>html version</p>'),
+        {
+          mimeType: 'multipart/alternative',
+          parts: [textPart('text/plain', 'plain version')],
+        },
+      ],
+    };
+    const out = parseMessage(msg(payload));
+    expect(out.body).toBe('plain version');
+    expect(out.bodyOrigin).toBe('text/plain');
+  });
+
+  it('prefers text/plain in a classic multipart/alternative', () => {
+    const payload = {
+      mimeType: 'multipart/alternative',
+      parts: [
+        textPart('text/plain', 'plain'),
+        textPart('text/html', '<p>html</p>'),
+      ],
+    };
+    const out = parseMessage(msg(payload));
+    expect(out.body).toBe('plain');
+    expect(out.bodyOrigin).toBe('text/plain');
+  });
+
+  it('concatenates sequential text/plain parts of the same container', () => {
+    const payload = {
+      mimeType: 'multipart/mixed',
+      parts: [
+        textPart('text/plain', 'intro'),
+        textPart('text/plain', 'forwarded body'),
+      ],
+    };
+    const out = parseMessage(msg(payload));
+    expect(out.body).toBe('intro\n\nforwarded body');
+    expect(out.bodyOrigin).toBe('text/plain');
+  });
+
+  it('converts an HTML-only message to plain text', () => {
+    const out = parseMessage(msg(textPart('text/html', '<p>Hello <strong>world</strong></p>')));
+    expect(out.body).toBe('Hello world');
+    expect(out.bodyOrigin).toBe('text/html');
+  });
+
+  it('concatenates multiple HTML parts before converting', () => {
+    const payload = {
+      mimeType: 'multipart/mixed',
+      parts: [
+        textPart('text/html', '<p>one</p>'),
+        textPart('text/html', '<p>two</p>'),
+      ],
+    };
+    const out = parseMessage(msg(payload));
+    expect(out.body).toBe('one\n\ntwo');
+    expect(out.bodyOrigin).toBe('text/html');
+  });
+
+  it('returns the raw HTML body when rawHtml is set', () => {
+    const out = parseMessage(msg(textPart('text/html', '<p>Hi</p>')), undefined, { rawHtml: true });
+    expect(out.body).toBe('<p>Hi</p>');
+    expect(out.bodyOrigin).toBe('text/html');
+  });
+
+  it('still prefers text/plain when rawHtml is set', () => {
+    const payload = {
+      mimeType: 'multipart/alternative',
+      parts: [
+        textPart('text/plain', 'plain'),
+        textPart('text/html', '<p>html</p>'),
+      ],
+    };
+    const out = parseMessage(msg(payload), undefined, { rawHtml: true });
+    expect(out.body).toBe('plain');
+    expect(out.bodyOrigin).toBe('text/plain');
+  });
+
+  it('applies the body cap to the converted text, not the raw HTML', () => {
+    const html = `<p>${'a'.repeat(40)}</p>`.repeat(3);
+    const converted = [`${'a'.repeat(40)}`, `${'a'.repeat(40)}`, `${'a'.repeat(40)}`].join('\n\n');
+    expect(html.length).toBeGreaterThan(130);
+
+    const uncapped = parseMessage(msg(textPart('text/html', html)), 130);
+    expect(uncapped.body).toBe(converted);
+    expect(uncapped.bodyTruncated).toBeUndefined();
+
+    const capped = parseMessage(msg(textPart('text/html', html)), 100);
+    expect(capped.body).toBe(converted.slice(0, 100));
+    expect(capped.bodyTruncated).toBe(true);
+    expect(capped.bodyTotalChars).toBe(converted.length);
+  });
+
+  it('omits bodyOrigin when the message has no body', () => {
+    const out = parseMessage(msg({ mimeType: 'multipart/mixed', parts: [] }));
+    expect(out.body).toBe('');
+    expect(out.bodyOrigin).toBeUndefined();
+  });
+});
+
+describe('parseMessage header and resource fields', () => {
+  it('surfaces Message-ID, In-Reply-To, References, labelIds, and internalDate', () => {
+    const headers = [
+      { name: 'Subject', value: 'S' },
+      { name: 'Message-ID', value: '<mid@example.com>' },
+      { name: 'In-Reply-To', value: '<parent@example.com>' },
+      { name: 'References', value: '<a@x.com> <parent@example.com>' },
+    ];
+    const out = parseMessage(msg(
+      { headers, body: { data: b64('hi') } },
+      { labelIds: ['INBOX', 'UNREAD'], internalDate: '1720000000000' },
+    ));
+    expect(out.messageIdHeader).toBe('<mid@example.com>');
+    expect(out.inReplyTo).toBe('<parent@example.com>');
+    expect(out.references).toBe('<a@x.com> <parent@example.com>');
+    expect(out.labelIds).toEqual(['INBOX', 'UNREAD']);
+    expect(out.internalDate).toBe('1720000000000');
+  });
+
+  it('omits the additive fields when absent from the message', () => {
+    const out = parseMessage(msg({ headers: [], body: { data: b64('x') } }));
+    expect(out.messageIdHeader).toBeUndefined();
+    expect(out.inReplyTo).toBeUndefined();
+    expect(out.references).toBeUndefined();
+    expect(out.labelIds).toBeUndefined();
+    expect(out.internalDate).toBeUndefined();
+  });
+});
+
+describe('parseMessage attachments', () => {
+  it('surfaces sizeBytes, partId, and inline detection', () => {
+    const payload = {
+      mimeType: 'multipart/mixed',
+      parts: [
+        textPart('text/plain', 'body'),
+        {
+          partId: '1',
+          mimeType: 'application/pdf',
+          filename: 'report.pdf',
+          headers: [{ name: 'Content-Disposition', value: 'attachment; filename="report.pdf"' }],
+          body: { attachmentId: 'att-1', size: 12345 },
+        },
+        {
+          partId: '2',
+          mimeType: 'image/png',
+          filename: 'logo.png',
+          headers: [{ name: 'Content-Disposition', value: 'inline; filename="logo.png"' }],
+          body: { attachmentId: 'att-2', size: 999 },
+        },
+        {
+          partId: '3',
+          mimeType: 'image/gif',
+          filename: 'sig.gif',
+          headers: [{ name: 'Content-ID', value: '<sig@cid>' }],
+          body: { attachmentId: 'att-3', size: 111 },
+        },
+      ],
+    };
+    const out = parseMessage(msg(payload));
+    expect(out.body).toBe('body');
+    expect(out.attachments).toEqual([
+      { filename: 'report.pdf', attachmentId: 'att-1', mimeType: 'application/pdf', sizeBytes: 12345, partId: '1' },
+      { filename: 'logo.png', attachmentId: 'att-2', mimeType: 'image/png', sizeBytes: 999, partId: '2', inline: true },
+      { filename: 'sig.gif', attachmentId: 'att-3', mimeType: 'image/gif', sizeBytes: 111, partId: '3', inline: true },
+    ]);
+  });
+
+  it('keeps the legacy shape for attachments without size or partId', () => {
+    const payload = {
+      mimeType: 'multipart/mixed',
+      parts: [{ filename: 'f.bin', body: { attachmentId: 'a1' } }],
+    };
+    expect(parseMessage(msg(payload)).attachments).toEqual([
+      { filename: 'f.bin', attachmentId: 'a1', mimeType: 'application/octet-stream' },
+    ]);
+  });
+});


### PR DESCRIPTION
Part of the Fidelity & DX milestone (#7). The Gmail read path finally treats HTML-only mail (most newsletters and transactional email) as first-class:

- **HTML→text extraction**: new dependency-free `htmlToText` (style/script/comment stripping, block-level newlines, links as `text (url)`, named + numeric entity decoding). `decodeBody` is now collect-then-choose: any `text/plain` anywhere beats HTML (fixes the sibling-HTML-over-nested-plain bug), sequential plain parts concatenate (forwarded messages), HTML-only bodies convert. The 50k cap applies **after** conversion, so the window holds content, not `<style>` junk. `bodyOrigin` tells you what happened; `rawHtml: true` returns the markup when you actually want it.
- **Real reply threading**: `gmail_send`/`gmail_create_draft` with `replyToMessageId` now fetch the parent's actual RFC `Message-ID`/`References` chain and build correct `In-Reply-To`/`References` — replies thread properly in non-Gmail clients. Reads expose `messageIdHeader`/`inReplyTo`/`references`/`labelIds`/`internalDate`.
- **Attachments**: `sizeBytes`, `partId`, and `inline` (cid images distinguishable from real attachments).
- **Threads**: optional `mode: 'summary'` returns per-message metadata without bodies (long threads stop blowing the context window); `full` unchanged.
- **Search**: metadata fetches now run in bounded parallel chunks (was N sequential round trips); `to` + `labelIds` added.

All additive — existing consumers keep working; the only content change is HTML-only bodies returning readable text instead of raw markup (escape hatch: `rawHtml`). 30 new tests on pure logic, 330 total green first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)