### PR TITLE
docs: invite v6 feedback issues in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest! This is an MCP server exposing Gmail, Drive, Calendar, Sheets, Docs, Contacts, Search Console, Tasks, Meet, Forms, Chat, and Admin SDK tools with multi-account OAuth.
 
-> **This project is maintainer-led.** The roadmap is published as **[GitHub Milestones](https://github.com/bakissation/mcp-google-multi/milestones)** — there is no code-ready issue backlog, and **unsolicited feature PRs aren't being accepted** right now. **Bug reports and security reports are very welcome** (open an issue for bugs; see [SECURITY.md](./SECURITY.md) for vulnerabilities). If you'd like to contribute a fix, please **open an issue first** so we can confirm it fits the roadmap. The branching/PR mechanics below apply to changes that have been agreed.
+> **This project is maintainer-led.** The roadmap is published as **[GitHub Milestones](https://github.com/bakissation/mcp-google-multi/milestones)** — there is no code-ready issue backlog, and **unsolicited feature PRs aren't being accepted** right now. **Bug reports and security reports are very welcome** (open an issue for bugs; see [SECURITY.md](./SECURITY.md) for vulnerabilities). If you'd like to contribute a fix, please **open an issue first** so we can confirm it fits the roadmap. v5 is complete and in a feedback period — issues describing pain points and missing capabilities directly shape the v6 roadmap. The branching/PR mechanics below apply to changes that have been agreed.
 
 ## Branching model
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Built and maintained by **Abdelbaki Berkati** — [berkati.xyz](https://berkati.
 
 Development is **funded by [IdeaCrafters](https://ideacrafters.com)** ([@IdeaCraftersHQ](https://github.com/IdeaCraftersHQ)) — the studio that pays for this OSS to exist.
 
-Thanks to contributors [@obatried](https://github.com/obatried), [@trevor-commits](https://github.com/trevor-commits), and [@mjreddy](https://github.com/mjreddy). The project is maintainer-led (roadmap on [Milestones](https://github.com/bakissation/mcp-google-multi/milestones); bug reports welcome, feature PRs by prior agreement — see [CONTRIBUTING.md](./CONTRIBUTING.md)). Security reports go to [SECURITY.md](./SECURITY.md), never a public issue.
+Thanks to contributors [@obatried](https://github.com/obatried), [@trevor-commits](https://github.com/trevor-commits), and [@mjreddy](https://github.com/mjreddy). The project is maintainer-led (roadmap on [Milestones](https://github.com/bakissation/mcp-google-multi/milestones); bug reports welcome, feature PRs by prior agreement — see [CONTRIBUTING.md](./CONTRIBUTING.md)). **v5 is complete and in a feedback period: [open an issue](https://github.com/bakissation/mcp-google-multi/issues/new/choose) with bugs, pain points, or what you wish it did — it directly shapes the v6 roadmap.** Security reports go to [SECURITY.md](./SECURITY.md), never a public issue.
 
 ## License
 


### PR DESCRIPTION
One-line addition to the README ownership block and CONTRIBUTING's maintainer-led note: v5 is complete and in a feedback period — issues with bugs, pain points, or missing capabilities directly shape the v6 roadmap. Matches the note already on the v6 milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)