### PR TITLE
release: promote v5.2.1 to stable (staging → main)

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -59,6 +59,21 @@ export async function executeApiMethod(method: ApiMethodRef, args: ExecuteArgs, 
     );
   }
 
+  // drive.files.export streams binary and, without alt=media, Google returns a confusing
+  // "Export requires alt=media" — either way the escape hatch can't surface the content.
+  if (method.id === 'drive.files.export') {
+    return jsonResult(
+      {
+        error: 'binary_unsupported',
+        message: 'drive.files.export returns binary content, not JSON, through this tool.',
+        hint: 'Use drive_export to export a Google Workspace file to disk.',
+        retriable: false,
+        account: args.account,
+      },
+      true,
+    );
+  }
+
   let url: string;
   try {
     url = method.baseUrl + expandPath(method.path, (args.pathParams as Record<string, string> | undefined) ?? {});

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -35,6 +35,28 @@ const COMMENT_LIST_FIELDS = `nextPageToken,comments(${COMMENT_BASE_FIELDS},repli
 const REPLY_FIELDS = `kind,htmlContent,${REPLY_SUBFIELDS}`;
 const REPLY_LIST_FIELDS = `nextPageToken,replies(${REPLY_FIELDS})`;
 
+// basename-sanitize the caller filename (never escapes savePath), create the destination
+// directory if missing (callers otherwise hit ENOENT on a non-existent savePath), and
+// return the absolute path to write.
+export function prepareLocalDest(savePath: string, filename: string): string {
+  const dest = path.join(savePath, path.basename(filename));
+  fs.mkdirSync(savePath, { recursive: true });
+  return dest;
+}
+
+// sendNotificationEmail is only valid for user/group permissions, and Google forbids
+// disabling it on an ownership transfer. Returns undefined to omit the param entirely.
+export function resolveShareNotification(opts: {
+  type: string;
+  role: string;
+  transferOwnership?: boolean;
+  sendNotification?: boolean;
+}): boolean | undefined {
+  if (opts.type !== 'user' && opts.type !== 'group') return undefined;
+  if (opts.transferOwnership || opts.role === 'owner') return true;
+  return opts.sendNotification ?? true;
+}
+
 export function registerDriveTools(server: ToolRegistry): void {
   // ─── Read / search / list ──────────────────────────────────────────────
 
@@ -290,7 +312,7 @@ export function registerDriveTools(server: ToolRegistry): void {
         const auth = await getClient(account as Account);
         const drive = google.drive({ version: 'v3', auth });
 
-        const dest = path.join(savePath, path.basename(filename));
+        const dest = prepareLocalDest(savePath, filename);
         const res = await drive.files.get(
           { fileId, alt: 'media', supportsAllDrives: true },
           { responseType: 'stream' },
@@ -326,7 +348,7 @@ export function registerDriveTools(server: ToolRegistry): void {
         const auth = await getClient(account as Account);
         const drive = google.drive({ version: 'v3', auth });
 
-        const dest = path.join(savePath, path.basename(filename));
+        const dest = prepareLocalDest(savePath, filename);
         const res = await drive.files.export(
           { fileId, mimeType: exportMime },
           { responseType: 'stream' },
@@ -629,9 +651,10 @@ export function registerDriveTools(server: ToolRegistry): void {
         const requestBody: any = { type, role, emailAddress, domain };
         if (expirationTime) requestBody.expirationTime = expirationTime;
 
+        const notify = resolveShareNotification({ type, role, transferOwnership, sendNotification });
         const res = await drive.permissions.create({
           fileId,
-          sendNotificationEmail: sendNotification ?? true,
+          ...(notify === undefined ? {} : { sendNotificationEmail: notify }),
           emailMessage,
           transferOwnership: transferOwnership ?? false,
           supportsAllDrives: true,

--- a/src/tools/google-api.ts
+++ b/src/tools/google-api.ts
@@ -123,7 +123,8 @@ export function registerEscapeTools(registry: ToolRegistry, policy: Policy, deps
       description:
         'Invoke any Google Workspace REST method by Discovery id (escape hatch for operations without a ' +
         'dedicated tool). Find methods with google_api_search first. Subject to the same write-control ' +
-        'policy as named tools.',
+        'policy as named tools. Returns JSON only — for binary/file content (media downloads, ' +
+        'drive.files.export) use drive_download / drive_export instead.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
         api: z.string().describe(`API alias: ${apiList}`),

--- a/tests/drive-dx.test.ts
+++ b/tests/drive-dx.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { prepareLocalDest, resolveShareNotification } from '../src/tools/drive.js';
+import { executeApiMethod, type ApiMethodRef } from '../src/executor.js';
+
+describe('prepareLocalDest', () => {
+  const created: string[] = [];
+  afterEach(() => {
+    for (const p of created.splice(0)) fs.rmSync(p, { recursive: true, force: true });
+  });
+
+  it('creates a missing destination directory (recursively)', () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-gm-dx-'));
+    created.push(parent);
+    const savePath = path.join(parent, 'a', 'b', 'c');
+    expect(fs.existsSync(savePath)).toBe(false);
+
+    const dest = prepareLocalDest(savePath, 'report.pdf');
+
+    expect(fs.existsSync(savePath)).toBe(true);
+    expect(dest).toBe(path.join(savePath, 'report.pdf'));
+  });
+
+  it('basename-sanitizes the filename so it never escapes savePath', () => {
+    const parent = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-gm-dx-'));
+    created.push(parent);
+    const savePath = path.join(parent, 'out');
+
+    for (const malicious of ['../../etc/passwd', '/tmp/evil.sh', 'a/b/c.txt']) {
+      const dest = prepareLocalDest(savePath, malicious);
+      expect(path.resolve(dest).startsWith(path.resolve(savePath) + path.sep)).toBe(true);
+    }
+  });
+});
+
+describe('resolveShareNotification', () => {
+  it('omits the param for anyone/domain permissions', () => {
+    expect(resolveShareNotification({ type: 'anyone', role: 'reader' })).toBeUndefined();
+    expect(resolveShareNotification({ type: 'domain', role: 'writer', sendNotification: false })).toBeUndefined();
+  });
+
+  it('forces notification on ownership transfers (cannot be disabled)', () => {
+    expect(resolveShareNotification({ type: 'user', role: 'owner', sendNotification: false })).toBe(true);
+    expect(resolveShareNotification({ type: 'user', role: 'writer', transferOwnership: true, sendNotification: false })).toBe(true);
+  });
+
+  it('honors the caller flag for regular user/group shares, defaulting to true', () => {
+    expect(resolveShareNotification({ type: 'user', role: 'writer' })).toBe(true);
+    expect(resolveShareNotification({ type: 'user', role: 'writer', sendNotification: false })).toBe(false);
+    expect(resolveShareNotification({ type: 'group', role: 'reader', sendNotification: true })).toBe(true);
+  });
+});
+
+describe('executeApiMethod binary/export steering', () => {
+  const exportMethod: ApiMethodRef = {
+    id: 'drive.files.export',
+    httpMethod: 'GET',
+    path: 'drive/v3/files/{fileId}/export',
+    baseUrl: 'https://www.googleapis.com/',
+    requiredParams: ['fileId', 'mimeType'],
+  };
+
+  async function payload(method: ApiMethodRef, args: Parameters<typeof executeApiMethod>[1]) {
+    const res: any = await executeApiMethod(method, args);
+    expect(res.isError).toBe(true);
+    return JSON.parse(res.content[0].text);
+  }
+
+  it('steers drive.files.export to drive_export before any network call', async () => {
+    const p = await payload(exportMethod, { account: 'test' });
+    expect(p.error).toBe('binary_unsupported');
+    expect(p.hint).toContain('drive_export');
+  });
+
+  it('still blocks alt=media downloads', async () => {
+    const getMethod: ApiMethodRef = {
+      id: 'drive.files.get',
+      httpMethod: 'GET',
+      path: 'drive/v3/files/{fileId}',
+      baseUrl: 'https://www.googleapis.com/',
+      requiredParams: ['fileId'],
+    };
+    const p = await payload(getMethod, { account: 'test', queryParams: { alt: 'media' } });
+    expect(p.error).toBe('binary_unsupported');
+    expect(p.hint).toContain('drive_download');
+  });
+});


### PR DESCRIPTION
## Promote v5.2.1 to stable (staging → main)

Merging triggers `release.yml` on `main` → `semantic-release` publishes stable **`v5.2.1`** to npm `latest` + GitHub release + tag, then `backmerge.yml` resyncs.

### Version
`v5.2.0 → v5.2.1` (patch). **2 `fix:`, zero breaking changes.**

### What ships (DX fixes from the 5.2.0 soak)
- `drive_download`/`drive_export` create the destination dir (`mkdir -p`) instead of `ENOENT` — the largest error class in the 5.2.0 soak.
- Escape hatch steers `drive.files.export` + `alt=media` to `drive_export`/`drive_download` up front.
- `drive_share` omits `sendNotificationEmail` for `anyone`/`domain` and forces it on ownership transfers (fixes the Google 400s).

### Verification
Full gate green through #95 and #96: **355 tests + 7 new**, typecheck/lint/build, CodeQL, Socket Security.

> ⚠️ **Soak note:** `5.2.1-beta` was just published — this promotion has ~no beta bake time. The changes are small, self-contained `fix:` commits with unit coverage, so fast-tracking is low-risk, but flagging it explicitly since it differs from the 2-week soak that preceded 5.2.0.
