### PR TITLE
fix: never send a request body on GET/HEAD in google_api_call

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -45,6 +45,17 @@ export function buildQueryString(queryParams: QueryParams | undefined): string {
   return usp.toString();
 }
 
+// GET/HEAD must never carry a request body: no Google Discovery GET/HEAD method
+// declares a request schema, and undici/fetch throw ("Request with GET/HEAD method
+// cannot have body") if one is attached. gaxios stringifies any object `data`
+// without checking the verb, so a caller-supplied `{}` on a read would otherwise
+// crash the request. Write verbs keep prior semantics: null/undefined -> no body.
+export function resolveRequestBody(httpMethod: string, body: unknown): unknown {
+  const verb = httpMethod.toUpperCase();
+  if (verb === 'GET' || verb === 'HEAD') return undefined;
+  return body ?? undefined;
+}
+
 export async function executeApiMethod(method: ApiMethodRef, args: ExecuteArgs, deps: ExecuteDeps = {}) {
   if (args.queryParams?.alt === 'media') {
     return jsonResult(
@@ -110,7 +121,7 @@ export async function executeApiMethod(method: ApiMethodRef, args: ExecuteArgs, 
       // query string built by hand: gaxios comma-joins arrays, Google needs repeated keys
       url: `${url}?${buildQueryString(args.queryParams)}`,
       method: method.httpMethod as 'GET',
-      data: args.body ?? undefined,
+      data: resolveRequestBody(method.httpMethod, args.body),
     });
     const text = JSON.stringify(res.data ?? null);
     if (text.length > MAX_RESPONSE_CHARS) {

--- a/tests/google-api.test.ts
+++ b/tests/google-api.test.ts
@@ -158,6 +158,33 @@ describe('google_api_call', () => {
     });
   });
 
+  it('drops a caller-supplied empty body on GET reads (undici rejects a GET body)', async () => {
+    const { call, request, dir } = setup(READ_ONLY);
+    cleanupDirs.push(dir);
+    const res = await call({
+      account: 'test',
+      api: 'gmail',
+      methodId: 'gmail.users.messages.list',
+      pathParams: { userId: 'me' },
+      body: {},
+    });
+    expect(res.isError).toBeUndefined();
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({ method: 'GET', data: undefined }));
+  });
+
+  it('forwards a real body on write verbs unchanged', async () => {
+    const { call, request, dir } = setup(FULL);
+    cleanupDirs.push(dir);
+    await call({
+      account: 'test',
+      api: 'gmail',
+      methodId: 'gmail.users.messages.batchDelete',
+      pathParams: { userId: 'me' },
+      body: { ids: ['a', 'b'] },
+    });
+    expect(request).toHaveBeenCalledWith(expect.objectContaining({ method: 'POST', data: { ids: ['a', 'b'] } }));
+  });
+
   it('serializes repeated query params as repeated keys', async () => {
     const { call, request, dir } = setup(FULL);
     cleanupDirs.push(dir);


### PR DESCRIPTION
Closes #100.

## Problem
`google_api_call` forwarded a caller-supplied `body` straight into `executeApiMethod`, which used `args.body ?? undefined`. An empty `{}` (routinely sent by MCP clients on reads, and encouraged by `google_api_search`'s own invocation hint) reached gaxios, which JSON-stringifies any object `data` regardless of the HTTP verb. undici then rejects the request with `Request with GET/HEAD method cannot have body`, crashing every GET/HEAD escape-hatch call.

## Fix
`resolveRequestBody(httpMethod, body)` in the single `executeApiMethod` sink:
- GET/HEAD never carry a body (no Discovery GET/HEAD method declares a request schema; the WHATWG Fetch spec forbids one and undici throws at Request construction).
- Write verbs keep prior semantics (`null`/`undefined` to no body, real payloads pass through).

This covers the escape hatch, which is the only path that forwarded `body` unconditionally; generated tools already guard via `def.hasBody`.

## Scope note
Kept to GET/HEAD only. We deliberately did NOT also strip empty `{}` on write verbs: that would drop the `application/json` Content-Type and can change `{}`-body / no-op endpoints, which is out of scope for this crash and riskier during the pre-v6 stabilization hold.

## Tests
`tests/google-api.test.ts` +2: a GET with `body: {}` calls `auth.request` with `data: undefined` (the repro), and a write verb passes its body through unchanged. Full suite green (357 tests).

Reported-by: @mjreddy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
