### PR TITLE
fix: silence dotenv banner that corrupts the MCP stdio stream

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -5,8 +5,11 @@ import { homedir } from 'node:os';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-dotenv.config();
-dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+// quiet: dotenv v17 prints a banner to stdout by default, which corrupts the
+// stdio JSON-RPC channel (DOTENV_CONFIG_QUIET can't help — it would be read
+// from .env after config() already ran).
+dotenv.config({ quiet: true });
+dotenv.config({ path: path.resolve(__dirname, '..', '.env'), quiet: true });
 
 const defaultTokenDir = path.join(
   process.env.XDG_CONFIG_HOME || path.join(homedir(), '.config'),

--- a/tests/stdout-purity.test.ts
+++ b/tests/stdout-purity.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// stdout IS the JSON-RPC channel for a stdio MCP server — nothing may write to
+// it at import time. Regression guard for the dotenv v17 banner (issue #109).
+describe('import-time stdout purity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('importing accounts.ts writes nothing to stdout', async () => {
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const consoleLog = vi.spyOn(console, 'log');
+
+    vi.resetModules();
+    await import('../src/accounts.js');
+
+    expect(stdoutWrite).not.toHaveBeenCalled();
+    expect(consoleLog).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #109.

dotenv v17 prints an informational banner to stdout by default. For a stdio MCP server stdout **is** the JSON-RPC channel, so the banner lands ahead of the first protocol message and clients report JSON parse errors on startup.

`DOTENV_CONFIG_QUIET=true` works around it client-side, but it can't be set in `.env` itself (dotenv reads it from `process.env` before `.env` is parsed) — so `quiet: true` is now passed explicitly at both `dotenv.config()` call sites in `src/accounts.ts`.

## Verification

- Before: `node dist/index.js < /dev/null` emits a 149-byte banner on stdout before any protocol output. After: 0 bytes.
- New regression test `tests/stdout-purity.test.ts` guards import-time stdout purity; confirmed it fails on the unfixed code and passes with the fix.
- typecheck + lint + 358/358 tests green.

Thanks @ethan-yz-hao for the precise report and suggested fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)