### PR TITLE
feat: opt-in gmail_settings / gmail_settings_sharing scope bundles

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,6 +47,13 @@ Add bundle names to `GOOGLE_OPTIONAL_SCOPES` (CSV), then re-run `auth` for each 
 
 `slides`, `forms`, `chat`, `classroom`, `cloudidentity`, `cloudsearch`, `vault`, `keep`, `driveactivity`, `drivelabels`, `script`, `postmaster`, `groupssettings`, `groupsmigration`, `licensing`, `reseller`, `appsmarket`.
 
+Two bundles extend the always-on `gmail` service instead of enabling a new one — Gmail settings **writes** only accept the dedicated settings scopes (reads already work with the base scope):
+
+| Bundle | Scope | Unlocks |
+|---|---|---|
+| `gmail_settings` | `gmail.settings.basic` | writing filters, vacation responder, IMAP/POP, language |
+| `gmail_settings_sharing` | `gmail.settings.sharing` | send-as, delegates, auto-forwarding — kept separate because it can redirect or delegate your mail |
+
 A tool whose scope was never granted returns a typed `insufficient_scope` error with a re-auth hint instead of failing silently.
 
 ## Secrets management

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -42,6 +42,16 @@ export const OPTIONAL_SCOPE_BUNDLES: Record<string, string[]> = {
     'https://www.googleapis.com/auth/chat.messages',
     'https://www.googleapis.com/auth/chat.messages.create',
   ],
+  // Unlike the service bundles these extend the always-on gmail service:
+  // users.settings.* writes only accept the settings scopes (reads already
+  // work via gmail.modify). sharing is separate — it governs delegation,
+  // auto-forwarding and send-as, a different risk profile from e.g. filters.
+  gmail_settings: [
+    'https://www.googleapis.com/auth/gmail.settings.basic',
+  ],
+  gmail_settings_sharing: [
+    'https://www.googleapis.com/auth/gmail.settings.sharing',
+  ],
   classroom: [
     'https://www.googleapis.com/auth/classroom.courses',
     'https://www.googleapis.com/auth/classroom.coursework.me',

--- a/tests/optional-bundles.test.ts
+++ b/tests/optional-bundles.test.ts
@@ -42,4 +42,23 @@ describe('optional scope bundles', () => {
     process.env.GOOGLE_OPTIONAL_SCOPES = ' slides , forms ,bogus';
     expect(getOptionalBundles()).toEqual(['slides', 'forms']);
   });
+
+  it('gmail_settings grants settings.basic only; sharing needs its own bundle', () => {
+    process.env.GOOGLE_OPTIONAL_SCOPES = 'gmail_settings';
+    const scopes = resolveScopesForAccount('test');
+    expect(scopes).toContain('https://www.googleapis.com/auth/gmail.settings.basic');
+    expect(scopes).not.toContain('https://www.googleapis.com/auth/gmail.settings.sharing');
+  });
+
+  it('gmail_settings_sharing grants settings.sharing', () => {
+    process.env.GOOGLE_OPTIONAL_SCOPES = 'gmail_settings,gmail_settings_sharing';
+    const scopes = resolveScopesForAccount('test');
+    expect(scopes).toContain('https://www.googleapis.com/auth/gmail.settings.basic');
+    expect(scopes).toContain('https://www.googleapis.com/auth/gmail.settings.sharing');
+  });
+
+  it('gmail settings scopes are absent by default', () => {
+    const scopes = resolveScopesForAccount('test');
+    expect(scopes.join()).not.toContain('gmail.settings');
+  });
 });


### PR DESCRIPTION
Fixes #108.

## Problem

The 43 generated `gmail_users_settings_*` tools register and pass write-control, but their **write** methods only accept `gmail.settings.basic` / `gmail.settings.sharing` — and neither scope was requestable under any configuration. Every settings write died with `insufficient_scope`.

Two corrections to the report, both verified against the Discovery snapshot and live against the API:

- **Settings reads were never broken.** `users.settings.filters.list`, `getVacation`, `sendAs.list` etc. accept `gmail.modify` (in `BASE_SCOPES`) per Discovery — confirmed live: both calls succeed on a base-scope token. Only the 26 write methods are unreachable.
- **`workspaceevents` is not in the same boat**: its methods accept `auth/drive` and `meetings.space.readonly`, both in `BASE_SCOPES`, so it's reachable by design (that's why it registers ungated).

## Fix

Two opt-in bundles in `OPTIONAL_SCOPE_BUNDLES` — deliberately **not** `BASE_SCOPES` (which would force a re-auth on every existing user and grow default consent):

| Bundle | Scope | Unlocks |
|---|---|---|
| `gmail_settings` | `gmail.settings.basic` | filters, vacation responder, IMAP/POP, language writes |
| `gmail_settings_sharing` | `gmail.settings.sharing` | send-as, delegates, auto-forwarding |

`sharing` is a separate bundle on purpose: it can redirect or delegate your mail — a very different risk profile from creating a filter, as the issue itself points out. These are the first bundles that extend an always-on service instead of gating an optional one; nothing in the service-gate logic keys on them, verified against `services.ts`/`buildRegistry`.

## Not in this PR

The build-time "fail when a generated tool's scopes aren't requestable" idea doesn't survive contact with the data: ~247 methods across 12 APIs ship without a requestable scope **by design** (chat admin, classroom add-ons, admin directory long tail…). The useful subset — bake Discovery scopes into generated-tool metadata so `config check` can report *registered-but-not-requestable* and 403 hints can name the exact bundle — is tracked as a follow-up issue.

## Verification

- Live on a base-scope token: `gmail.users.settings.filters.list` and `getVacation` succeed (reads OK today).
- Issue reporter ran the same bundle patch locally: consent grows to 11 scopes, `users.settings.filters.*` writes succeed.
- 3 new bundle tests; typecheck + lint + 360/360 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)