### PR TITLE
ci: add Windows job (build + test on windows-latest)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# LF everywhere: gen:tools emits LF and tests diff committed vs regenerated
+# output byte-for-byte, so a CRLF checkout (Windows autocrlf) fails them.
+* text=auto eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,25 @@ jobs:
 
       - name: Test
         run: npm test
+
+  # Separate job on purpose: branch protection requires the check literally named
+  # "ci" — turning the job above into an OS matrix would rename it to "ci (...)".
+  ci-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
Adds a `ci-windows` job running build + tests on `windows-latest` with Node 24. Motivation: v5.1.1 shipped a Windows-only token-store regression (fsync EPERM on a read-only handle, fixed in #73) that ubuntu-only CI could not catch.

Deliberately a **separate job**, not an OS matrix on the existing `ci` job: branch protection requires the check literally named `ci`, and a matrix would rename it to `ci (ubuntu-latest)`, silently disabling protection. Lint/typecheck remain ubuntu-only since they are platform-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)