### PR TITLE
refactor: drop server-destroy for server.close()+closeAllConnections()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "googleapis-common": "^8.0.3",
         "mime-types": "^3.0.2",
         "open": "^11.0.0",
-        "server-destroy": "^1.0.1",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -38,7 +37,6 @@
         "@eslint/js": "^10.0.1",
         "@types/mime-types": "^3.0.1",
         "@types/node": "^25.6.0",
-        "@types/server-destroy": "^1.0.3",
         "eslint": "^10.2.1",
         "semantic-release": "^25.0.3",
         "tsx": "^4.23.1",
@@ -2011,16 +2009,6 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/server-destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/server-destroy/-/server-destroy-1.0.4.tgz",
-      "integrity": "sha512-+x8oAQ4Xp1wtDi2Hlmi7gUNXZNVhB5EoSQpi0qEmINdDN5Ab724WLGAalEdT1SudVY/NzMhbfZO7vU+klT0R+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.1",
@@ -8796,12 +8784,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/server-destroy": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
-      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-google-multi",
   "version": "0.0.0-semantically-released",
-  "description": "Local MCP server for Google Workspace (Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console, +Forms/Chat/Admin) across multiple accounts \u2014 OAuth-only, encrypted token storage, deny-by-default writes.",
+  "description": "Local MCP server for Google Workspace (Gmail, Drive, Calendar, Sheets, Docs, Contacts, Tasks, Meet, Search Console, +Forms/Chat/Admin) across multiple accounts — OAuth-only, encrypted token storage, deny-by-default writes.",
   "type": "module",
   "license": "MIT",
   "bin": {
@@ -79,14 +79,12 @@
     "googleapis-common": "^8.0.3",
     "mime-types": "^3.0.2",
     "open": "^11.0.0",
-    "server-destroy": "^1.0.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^25.6.0",
-    "@types/server-destroy": "^1.0.3",
     "eslint": "^10.2.1",
     "semantic-release": "^25.0.3",
     "tsx": "^4.23.1",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,7 +3,6 @@ import http from 'node:http';
 import { URL } from 'node:url';
 import { randomBytes } from 'node:crypto';
 import open from 'open';
-import destroyer from 'server-destroy';
 import { ACCOUNTS, ACCOUNT_CONFIG } from './accounts.js';
 import { writeToken } from './token-store.js';
 
@@ -186,7 +185,8 @@ export async function runAuthFlow(args: string[]): Promise<void> {
             if (error) {
               res.writeHead(400, { 'Content-Type': 'text/plain' });
               res.end(`Authorization denied: ${error}`);
-              (server as any).destroy();
+              server.close();
+              server.closeAllConnections();
               reject(new Error(`Authorization denied: ${error}`));
               return;
             }
@@ -195,7 +195,8 @@ export async function runAuthFlow(args: string[]): Promise<void> {
             if (!code) {
               res.writeHead(400, { 'Content-Type': 'text/plain' });
               res.end('No authorization code received.');
-              (server as any).destroy();
+              server.close();
+              server.closeAllConnections();
               reject(new Error('No authorization code received'));
               return;
             }
@@ -204,7 +205,8 @@ export async function runAuthFlow(args: string[]): Promise<void> {
             if (returnedState !== expectedState) {
               res.writeHead(400, { 'Content-Type': 'text/plain' });
               res.end('State mismatch — possible CSRF attempt. Aborting.');
-              (server as any).destroy();
+              server.close();
+              server.closeAllConnections();
               reject(new Error('OAuth state token mismatch'));
               return;
             }
@@ -217,7 +219,8 @@ export async function runAuthFlow(args: string[]): Promise<void> {
             res.end(
               '<h2>Authentication successful!</h2><p>You can close this tab.</p>',
             );
-            (server as any).destroy();
+            server.close();
+            server.closeAllConnections();
 
             console.log(`Token saved (encrypted) for ${alias}.`);
             console.log('Next: authenticate your other aliases, then verify with: mcp-google-multi config check');
@@ -226,7 +229,8 @@ export async function runAuthFlow(args: string[]): Promise<void> {
         } catch (e) {
           res.writeHead(500, { 'Content-Type': 'text/plain' });
           res.end('Internal error during authentication.');
-          (server as any).destroy();
+          server.close();
+          server.closeAllConnections();
           reject(e);
         }
       })
@@ -237,7 +241,6 @@ export async function runAuthFlow(args: string[]): Promise<void> {
         open(authorizeUrl, { wait: false }).then((cp) => cp.unref());
       });
 
-    destroyer(server);
 
     server.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'EADDRINUSE') {


### PR DESCRIPTION
Removes the 11-year-unmaintained `server-destroy` dependency (+`@types/server-destroy`). Node >=18.2 provides `server.closeAllConnections()` natively; combined with `server.close()` it is behaviorally identical for the loopback OAuth callback server teardown in `src/auth.ts` (five call sites, plus the `destroyer(server)` wrap). Also drops the `(server as any).destroy()` casts the old typings forced.

Non-releasing `refactor:` — rides along with the next promotion.

## Verification
- typecheck + lint + 361/361 tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)