### PR TITLE
ci: run ci and ci-windows on v6 integration branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,12 @@
 name: ci
 
+# v6 + v6/** are the long-lived integration branch and its stacked slices:
+# they get ci but stay OUT of release.yml, so pushes there publish nothing.
 on:
   push:
-    branches: [main, staging, dev]
+    branches: [main, staging, dev, v6, 'v6/**']
   pull_request:
-    branches: [main, staging, dev]
+    branches: [main, staging, dev, v6, 'v6/**']
 
 # Least privilege: CI only checks out code + runs npm. (CodeQL: actions/missing-workflow-permissions)
 permissions:


### PR DESCRIPTION
Prerequisite P0 for the upcoming `v6` long-lived integration branch (stacked-PR development of the next major): adds `v6` + `v6/**` to `test.yml`'s `push` and `pull_request` branch lists so every stacked slice gets the `ci` check.

`release.yml` is deliberately untouched — `v6` remains absent from both the release workflow triggers and `.releaserc` branches, so nothing on the stack can ever publish; the eventual single `v6 -> dev` merge mints the one `6.0.0-alpha.1`.

Non-releasing `ci:` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)