### PR TITLE
chore: ignore googleapis-common major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
     allow:
       - dependency-name: "@googleapis/*"
       - dependency-name: "googleapis-common"
+    # The @googleapis/* packages pin googleapis-common@^N; a direct major bump
+    # ahead of the graph resolves two copies (cross-major auth mismatch). The
+    # direct pin follows the graph, never leads it.
+    ignore:
+      - dependency-name: "googleapis-common"
+        update-types: ["version-update:semver-major"]
     groups:
       googleapis:
         patterns:


### PR DESCRIPTION
Follow-up to #122 / closes the recurrence path of #123: Dependabot immediately proposed `googleapis-common` 8.0.3 → 9.0.1, but the 14 `@googleapis/*` packages all depend on `^8` — a direct major bump ahead of the graph resolves two copies of googleapis-common (and a cross-major `google-auth-library` mismatch). This adds an `ignore` rule for googleapis-common **majors only**; minors/patches within the graph's range still flow through the grouped weekly PR, and the direct pin moves to ^9 when the service packages themselves do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)