### PR TITLE
feat!: require Node >=22 [v6 stack 1/4]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,12 +1,13 @@
 name: ci
 
-# v6 + v6/** are the long-lived integration branch and its stacked slices:
+# v6 + v6-** are the long-lived integration branch and its stacked slices
+# (a git ref cannot nest under an existing branch, so slices use v6-NN-name):
 # they get ci but stay OUT of release.yml, so pushes there publish nothing.
 on:
   push:
-    branches: [main, staging, dev, v6, 'v6/**']
+    branches: [main, staging, dev, v6, 'v6-**']
   pull_request:
-    branches: [main, staging, dev, v6, 'v6/**']
+    branches: [main, staging, dev, v6, 'v6-**']
 
 # Least privilege: CI only checks out code + runs npm. (CodeQL: actions/missing-workflow-permissions)
 permissions:
@@ -32,6 +33,29 @@ jobs:
 
       - name: Typecheck
         run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+  # Separate job on purpose: branch protection requires the check literally named
+  # "ci" — a version matrix would rename it to "ci (...)". This is the only leg
+  # exercising the declared engines floor (BV-7); the main job stays on 24.
+  ci-node22:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Build
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The most complete **local Google Workspace MCP server**: Gmail, Drive, Calendar,
 
 You don't need to know anything about MCP or OAuth — five steps, all copy-paste:
 
-1. **Install [Node.js](https://nodejs.org) 20 or newer**, then install the server:
+1. **Install [Node.js](https://nodejs.org) 22 or newer**, then install the server:
 
    ```bash
    npm install -g mcp-google-multi

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/mime-types": "^3.0.1",
-        "@types/node": "^25.6.0",
+        "@types/node": "^22.20.1",
         "eslint": "^10.2.1",
         "semantic-release": "^25.0.3",
         "tsx": "^4.23.1",
@@ -1994,13 +1994,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -9696,9 +9696,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": {
     "type": "git",
@@ -84,7 +84,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/mime-types": "^3.0.1",
-    "@types/node": "^25.6.0",
+    "@types/node": "^22.20.1",
     "eslint": "^10.2.1",
     "semantic-release": "^25.0.3",
     "tsx": "^4.23.1",


### PR DESCRIPTION
First slice of the v6 stack — THE 6.0.0 semver anchor (`BREAKING CHANGE` footer). engines >=22, @types/node ^22 (types can't exceed the runtime floor), new `ci-node22` job exercising the declared floor (BV-7), and the stack's CI trigger fix (`v6-**`: a git ref cannot nest under the existing `v6` branch, so slices are `v6-NN-name`).

Lands into `v6` by fast-forward only; nothing on the stack publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)