### PR TITLE
refactor: replace open with an internal spawn helper [v6 stack 3/4]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "googleapis-common": "^8.0.3",
         "mime-types": "^3.0.2",
-        "open": "^11.0.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -2647,21 +2646,6 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3284,46 +3268,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -4935,21 +4879,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4980,36 +4909,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-in-ssh": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
-      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -5072,21 +4971,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7797,26 +7681,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.4.0",
-        "define-lazy-prop": "^3.0.0",
-        "is-in-ssh": "^1.0.0",
-        "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.1.0",
-        "wsl-utils": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8267,18 +8131,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/powershell-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8618,18 +8470,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/run-applescript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safe-buffer": {
@@ -10140,22 +9980,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/wsl-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0",
-        "powershell-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "googleapis-common": "^8.0.3",
     "mime-types": "^3.0.2",
-    "open": "^11.0.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -2,7 +2,7 @@ import { OAuth2Client } from 'googleapis-common';
 import http from 'node:http';
 import { URL } from 'node:url';
 import { randomBytes } from 'node:crypto';
-import open from 'open';
+import { openUrl } from './open-url.js';
 import { ACCOUNTS, ACCOUNT_CONFIG } from './accounts.js';
 import { writeToken } from './token-store.js';
 
@@ -236,9 +236,10 @@ export async function runAuthFlow(args: string[]): Promise<void> {
       })
       // Bind to loopback only — never expose the OAuth callback to the local network.
       .listen(4242, '127.0.0.1', () => {
-        // Always print the URL: `open` silently no-ops on headless/SSH sessions.
+        // Always print the URL first: the browser launch is best-effort and
+        // silently does nothing on headless/SSH sessions.
         console.log(`Opening your browser to authorize "${alias}". If nothing opens, visit:\n${authorizeUrl}`);
-        open(authorizeUrl, { wait: false }).then((cp) => cp.unref());
+        openUrl(authorizeUrl);
       });
 
 

--- a/src/open-url.ts
+++ b/src/open-url.ts
@@ -1,0 +1,30 @@
+import { spawn } from 'node:child_process';
+import { release } from 'node:os';
+
+const isWsl = (): boolean =>
+  process.platform === 'linux' && release().toLowerCase().includes('microsoft');
+
+// Best-effort browser launch. Never throws, never blocks, writes nothing to
+// the parent's stdio — the caller has already printed the URL as the fallback.
+export function openUrl(url: string): void {
+  try {
+    let cmd: string;
+    let args: string[];
+    if (process.platform === 'darwin') {
+      cmd = 'open';
+      args = [url];
+    } else if (process.platform === 'win32' || isWsl()) {
+      const encoded = Buffer.from(`Start-Process "${url}"`, 'utf16le').toString('base64');
+      cmd = 'powershell.exe';
+      args = ['-NoProfile', '-NonInteractive', '-EncodedCommand', encoded];
+    } else {
+      cmd = 'xdg-open';
+      args = [url];
+    }
+    const child = spawn(cmd, args, { detached: true, stdio: 'ignore' });
+    child.on('error', () => {});
+    child.unref();
+  } catch {
+    // Headless/odd platforms: the printed URL is the supported path.
+  }
+}

--- a/tests/open-url.test.ts
+++ b/tests/open-url.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock('node:child_process', () => ({ spawn: spawnMock }));
+
+// Pin os.release so the WSL detection is deterministic even when the suite
+// itself runs under WSL.
+const releaseMock = vi.hoisted(() => vi.fn(() => '6.1.0-generic'));
+vi.mock('node:os', () => ({ release: releaseMock }));
+
+const fakeChild = () => ({ on: vi.fn(), unref: vi.fn() });
+
+let realPlatform: PropertyDescriptor;
+
+const setPlatform = (p: string) =>
+  Object.defineProperty(process, 'platform', { value: p, configurable: true });
+
+beforeEach(() => {
+  realPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  spawnMock.mockReset().mockReturnValue(fakeChild());
+  releaseMock.mockReturnValue('6.1.0-generic');
+  vi.resetModules();
+});
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', realPlatform);
+  vi.restoreAllMocks();
+});
+
+describe('openUrl (T7)', () => {
+  it('darwin uses open', async () => {
+    setPlatform('darwin');
+    const { openUrl } = await import('../src/open-url.js');
+    openUrl('https://example.com/x?a=1&b=2');
+    expect(spawnMock).toHaveBeenCalledWith(
+      'open',
+      ['https://example.com/x?a=1&b=2'],
+      { detached: true, stdio: 'ignore' },
+    );
+  });
+
+  it('win32 uses powershell -EncodedCommand with the url embedded', async () => {
+    setPlatform('win32');
+    const { openUrl } = await import('../src/open-url.js');
+    openUrl('https://example.com/x?a=1&b=2');
+    const [cmd, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(cmd).toBe('powershell.exe');
+    const encoded = args[args.indexOf('-EncodedCommand') + 1];
+    const decoded = Buffer.from(encoded, 'base64').toString('utf16le');
+    expect(decoded).toBe('Start-Process "https://example.com/x?a=1&b=2"');
+  });
+
+  it('linux uses xdg-open', async () => {
+    setPlatform('linux');
+    const { openUrl } = await import('../src/open-url.js');
+    openUrl('https://example.com');
+    expect(spawnMock.mock.calls[0]?.[0]).toBe('xdg-open');
+  });
+
+  it('WSL (linux + microsoft kernel) uses powershell.exe', async () => {
+    setPlatform('linux');
+    releaseMock.mockReturnValue('5.15.90.1-microsoft-standard-WSL2');
+    const { openUrl } = await import('../src/open-url.js');
+    openUrl('https://example.com');
+    expect(spawnMock.mock.calls[0]?.[0]).toBe('powershell.exe');
+  });
+
+  it('a spawn throw is swallowed and openUrl returns void', async () => {
+    setPlatform('linux');
+    spawnMock.mockImplementation(() => { throw new Error('ENOENT'); });
+    const { openUrl } = await import('../src/open-url.js');
+    expect(() => openUrl('https://example.com')).not.toThrow();
+  });
+
+  it('detaches and unrefs the child so the parent never blocks', async () => {
+    setPlatform('linux');
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+    const { openUrl } = await import('../src/open-url.js');
+    openUrl('https://example.com');
+    expect(child.unref).toHaveBeenCalled();
+    expect(child.on).toHaveBeenCalledWith('error', expect.any(Function));
+  });
+});


### PR DESCRIPTION
`src/open-url.ts`: ~25-line best-effort launcher (darwin `open`, win32/WSL `powershell -EncodedCommand`, else `xdg-open`), detached + unref'd, error-swallowing, zero parent-stdio writes. URL is always printed before the launch attempt, so headless keeps working (verified live: headless `auth` prints the URL and keeps serving the loopback callback). Drops the `open` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)