### PR TITLE
chore: regen generated tools from Discovery drift; deterministic requiredParams

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -40,7 +40,7 @@ Not covered: Alert Center (service-account auth; planned for v6), Drive v2 (supe
 | workspaceevents | 0 | 15 | 15 | default |
 | **Total** | **182** | **690** | **872** | |
 
-Optional scope bundles: `appsmarket`, `chat`, `classroom`, `cloudidentity`, `cloudsearch`, `driveactivity`, `drivelabels`, `forms`, `groupsmigration`, `groupssettings`, `keep`, `licensing`, `postmaster`, `reseller`, `script`, `slides`, `vault`.
+Optional scope bundles: `appsmarket`, `chat`, `classroom`, `cloudidentity`, `cloudsearch`, `driveactivity`, `drivelabels`, `forms`, `gmail_settings`, `gmail_settings_sharing`, `groupsmigration`, `groupssettings`, `keep`, `licensing`, `postmaster`, `reseller`, `script`, `slides`, `vault`.
 
 ## Tools by service
 

--- a/src/discovery-client.ts
+++ b/src/discovery-client.ts
@@ -104,10 +104,19 @@ export function buildMethodIndex(doc: DiscoveryDoc, api: string): DiscoveryMetho
         flatPath?: string;
         description?: string;
         parameters?: Record<string, DiscoveryParam>;
+        parameterOrder?: string[];
         scopes?: string[];
       };
       if (!method.id || !method.httpMethod || !method.path) continue;
       const params = method.parameters ?? {};
+      // Google serves parameters{} with unstable key order between fetches;
+      // parameterOrder is the canonical sequence, so sort by it (alphabetical
+      // tie-break) to keep gen-tools output deterministic.
+      const order = method.parameterOrder ?? [];
+      const pos = (n: string) => {
+        const i = order.indexOf(n);
+        return i === -1 ? order.length : i;
+      };
       out.push({
         id: method.id,
         api,
@@ -118,7 +127,8 @@ export function buildMethodIndex(doc: DiscoveryDoc, api: string): DiscoveryMetho
         params,
         requiredParams: Object.entries(params)
           .filter(([, p]) => p.required)
-          .map(([name]) => name),
+          .map(([name]) => name)
+          .sort((a, b) => pos(a) - pos(b) || a.localeCompare(b)),
         scopes: method.scopes ?? [],
       });
     }

--- a/src/tools/generated/admin.ts
+++ b/src/tools/generated/admin.ts
@@ -108,7 +108,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customer_devices_chromeos_commands_get",
     cud: "read",
     description: "Gets command data a specific command issued to the device.",
-    method: { id: "admin.customer.devices.chromeos.commands.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}/commands/{commandId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["commandId","customerId","deviceId"] },
+    method: { id: "admin.customer.devices.chromeos.commands.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}/commands/{commandId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId","commandId"] },
     params: [{"field":"commandId","api":"commandId","location":"path"},{"field":"customerId","api":"customerId","location":"path"},{"field":"deviceId","api":"deviceId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -373,7 +373,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_asps_delete",
     cud: "delete",
     description: "Deletes an ASP issued by a user.",
-    method: { id: "directory.asps.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}/asps/{codeId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["codeId","userKey"] },
+    method: { id: "directory.asps.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}/asps/{codeId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","codeId"] },
     params: [{"field":"codeId","api":"codeId","location":"path"},{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -465,7 +465,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_chromeosdevices_move_devices_to_ou",
     cud: "update",
     description: "Moves or inserts multiple Chrome OS devices to an organizational unit. You can move up to 50 devices at once.",
-    method: { id: "directory.chromeosdevices.moveDevicesToOu", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/moveDevicesToOu", baseUrl: "https://admin.googleapis.com/", requiredParams: ["orgUnitPath","customerId"] },
+    method: { id: "directory.chromeosdevices.moveDevicesToOu", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/moveDevicesToOu", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"orgUnitPath","api":"orgUnitPath","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -772,7 +772,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_delete",
     cud: "delete",
     description: "Removes a member from a group.",
-    method: { id: "directory.members.delete", httpMethod: "DELETE", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["memberKey","groupKey"] },
+    method: { id: "directory.members.delete", httpMethod: "DELETE", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"memberKey","api":"memberKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -786,7 +786,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_get",
     cud: "read",
     description: "Retrieves a group member's properties.",
-    method: { id: "directory.members.get", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["memberKey","groupKey"] },
+    method: { id: "directory.members.get", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"memberKey","api":"memberKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -800,7 +800,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_has_member",
     cud: "read",
     description: "Checks whether the given user is a member of the group. Membership can be direct or nested, but if nested, the `memberKey` and `groupKey` must be entities in th",
-    method: { id: "directory.members.hasMember", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}/hasMember/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["memberKey","groupKey"] },
+    method: { id: "directory.members.hasMember", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}/hasMember/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"memberKey","api":"memberKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -828,7 +828,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_patch",
     cud: "update",
     description: "Updates the membership properties of a user in the specified group. This method supports [patch semantics](https://developers.google.com/workspace/admin/directo",
-    method: { id: "directory.members.patch", httpMethod: "PATCH", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["memberKey","groupKey"] },
+    method: { id: "directory.members.patch", httpMethod: "PATCH", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"memberKey","api":"memberKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -843,7 +843,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_update",
     cud: "update",
     description: "Updates the membership of a user in the specified group.",
-    method: { id: "directory.members.update", httpMethod: "PUT", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["memberKey","groupKey"] },
+    method: { id: "directory.members.update", httpMethod: "PUT", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"memberKey","api":"memberKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -978,7 +978,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_orgunits_patch",
     cud: "update",
     description: "Updates an organizational unit. This method supports [patch semantics](https://developers.google.com/workspace/admin/directory/v1/guides/performance#patch)",
-    method: { id: "directory.orgunits.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["orgUnitPath","customerId"] },
+    method: { id: "directory.orgunits.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"orgUnitPath","api":"orgUnitPath","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1021,7 +1021,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_buildings_delete",
     cud: "delete",
     description: "Deletes a building.",
-    method: { id: "directory.resources.buildings.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["buildingId","customer"] },
+    method: { id: "directory.resources.buildings.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","buildingId"] },
     params: [{"field":"buildingId","api":"buildingId","location":"path"},{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1095,7 +1095,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_buildings_update",
     cud: "update",
     description: "Updates a building.",
-    method: { id: "directory.resources.buildings.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["buildingId","customer"] },
+    method: { id: "directory.resources.buildings.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","buildingId"] },
     params: [{"field":"buildingId","api":"buildingId","location":"path"},{"field":"customer","api":"customer","location":"path"},{"field":"coordinatesSource","api":"coordinatesSource","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1257,7 +1257,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_features_patch",
     cud: "update",
     description: "Patches a feature.",
-    method: { id: "directory.resources.features.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["featureKey","customer"] },
+    method: { id: "directory.resources.features.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","featureKey"] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"featureKey","api":"featureKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1287,7 +1287,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_features_update",
     cud: "update",
     description: "Updates a feature.",
-    method: { id: "directory.resources.features.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["featureKey","customer"] },
+    method: { id: "directory.resources.features.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","featureKey"] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"featureKey","api":"featureKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1362,7 +1362,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_roles_delete",
     cud: "delete",
     description: "Deletes a role.",
-    method: { id: "directory.roles.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["roleId","customer"] },
+    method: { id: "directory.roles.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"roleId","api":"roleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1376,7 +1376,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_roles_get",
     cud: "read",
     description: "Retrieves a role.",
-    method: { id: "directory.roles.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["roleId","customer"] },
+    method: { id: "directory.roles.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"roleId","api":"roleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1419,7 +1419,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_roles_patch",
     cud: "update",
     description: "Patches a role.",
-    method: { id: "directory.roles.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["roleId","customer"] },
+    method: { id: "directory.roles.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"roleId","api":"roleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1858,7 +1858,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_activities_watch",
     cud: "create",
     description: "Start receiving notifications for account activities. For more information, see Receiving Push Notifications.",
-    method: { id: "reports.activities.watch", httpMethod: "POST", path: "admin/reports/v1/activity/users/{userKey}/applications/{applicationName}/watch", baseUrl: "https://admin.googleapis.com/", requiredParams: ["applicationName","userKey"] },
+    method: { id: "reports.activities.watch", httpMethod: "POST", path: "admin/reports/v1/activity/users/{userKey}/applications/{applicationName}/watch", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","applicationName"] },
     params: [{"field":"applicationName","api":"applicationName","location":"path"},{"field":"userKey","api":"userKey","location":"path"},{"field":"actorIpAddress","api":"actorIpAddress","location":"query"},{"field":"customerId","api":"customerId","location":"query"},{"field":"endTime","api":"endTime","location":"query"},{"field":"eventName","api":"eventName","location":"query"},{"field":"filters","api":"filters","location":"query"},{"field":"groupIdFilter","api":"groupIdFilter","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"orgUnitID","api":"orgUnitID","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"startTime","api":"startTime","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1899,7 +1899,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_entity_usage_reports_get",
     cud: "read",
     description: "Retrieves a report which is a collection of properties and statistics for entities used by users within the account. For more information, see the Entities Usag",
-    method: { id: "reports.entityUsageReports.get", httpMethod: "GET", path: "admin/reports/v1/usage/{entityType}/{entityKey}/dates/{date}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["entityKey","entityType","date"] },
+    method: { id: "reports.entityUsageReports.get", httpMethod: "GET", path: "admin/reports/v1/usage/{entityType}/{entityKey}/dates/{date}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["entityType","entityKey","date"] },
     params: [{"field":"date","api":"date","location":"path"},{"field":"entityKey","api":"entityKey","location":"path"},{"field":"entityType","api":"entityType","location":"path"},{"field":"customerId","api":"customerId","location":"query"},{"field":"filters","api":"filters","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"parameters","api":"parameters","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/appsmarket.ts
+++ b/src/tools/generated/appsmarket.ts
@@ -8,7 +8,7 @@ export function registerAppsmarketGeneratedTools(registry: ToolRegistry): void {
     name: "appsmarket_customer_license_get",
     cud: "read",
     description: "Gets the customer's licensing status to determine if they have access to a given app. For more information, see [Getting app installation and licensing details]",
-    method: { id: "appsmarket.customerLicense.get", httpMethod: "GET", path: "appsmarket/v2/customerLicense/{applicationId}/{customerId}", baseUrl: "https://appsmarket.googleapis.com/", requiredParams: ["customerId","applicationId"] },
+    method: { id: "appsmarket.customerLicense.get", httpMethod: "GET", path: "appsmarket/v2/customerLicense/{applicationId}/{customerId}", baseUrl: "https://appsmarket.googleapis.com/", requiredParams: ["applicationId","customerId"] },
     params: [{"field":"applicationId","api":"applicationId","location":"path"},{"field":"customerId","api":"customerId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -22,7 +22,7 @@ export function registerAppsmarketGeneratedTools(registry: ToolRegistry): void {
     name: "appsmarket_user_license_get",
     cud: "read",
     description: "Gets the user's licensing status to determine if they have permission to use a given app. For more information, see [Getting app installation and licensing deta",
-    method: { id: "appsmarket.userLicense.get", httpMethod: "GET", path: "appsmarket/v2/userLicense/{applicationId}/{userId}", baseUrl: "https://appsmarket.googleapis.com/", requiredParams: ["userId","applicationId"] },
+    method: { id: "appsmarket.userLicense.get", httpMethod: "GET", path: "appsmarket/v2/userLicense/{applicationId}/{userId}", baseUrl: "https://appsmarket.googleapis.com/", requiredParams: ["applicationId","userId"] },
     params: [{"field":"applicationId","api":"applicationId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/calendar.ts
+++ b/src/tools/generated/calendar.ts
@@ -9,7 +9,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_acl_delete",
     cud: "delete",
     description: "Deletes an access control rule.",
-    method: { id: "calendar.acl.delete", httpMethod: "DELETE", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["ruleId","calendarId"] },
+    method: { id: "calendar.acl.delete", httpMethod: "DELETE", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","ruleId"] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"ruleId","api":"ruleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -23,7 +23,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_acl_get",
     cud: "read",
     description: "Returns an access control rule.",
-    method: { id: "calendar.acl.get", httpMethod: "GET", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["ruleId","calendarId"] },
+    method: { id: "calendar.acl.get", httpMethod: "GET", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","ruleId"] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"ruleId","api":"ruleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/classroom.ts
+++ b/src/tools/generated/classroom.ts
@@ -69,7 +69,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_add_on_attachments_delete",
     cud: "delete",
     description: "Deletes an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.announcements.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","attachmentId","courseId"] },
+    method: { id: "classroom.courses.announcements.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -85,7 +85,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_add_on_attachments_get",
     cud: "read",
     description: "Returns an add-on attachment. Requires the add-on requesting the attachment to be the original creator of the attachment. This method returns the following erro",
-    method: { id: "classroom.courses.announcements.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","attachmentId","courseId"] },
+    method: { id: "classroom.courses.announcements.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -101,7 +101,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_add_on_attachments_list",
     cud: "read",
     description: "Returns all attachments created by an add-on under the post. Requires the add-on to have active attachments on the post or have permission to create new attachm",
-    method: { id: "classroom.courses.announcements.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","courseId"] },
+    method: { id: "classroom.courses.announcements.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -227,7 +227,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_patch",
     cud: "update",
     description: "Updates one or more fields of an announcement. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting developer project did not",
-    method: { id: "classroom.courses.announcements.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/announcements/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id","courseId"] },
+    method: { id: "classroom.courses.announcements.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/announcements/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -243,7 +243,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_add_on_attachments_create",
     cud: "create",
     description: "Creates an add-on attachment under a post. Requires the add-on to have permission to create new attachments on the post. This method returns the following error",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","courseId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -260,7 +260,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_add_on_attachments_delete",
     cud: "delete",
     description: "Deletes an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","attachmentId","courseId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -276,7 +276,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_add_on_attachments_get",
     cud: "read",
     description: "Returns an add-on attachment. Requires the add-on requesting the attachment to be the original creator of the attachment. This method returns the following erro",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","attachmentId","courseId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -292,7 +292,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_add_on_attachments_list",
     cud: "read",
     description: "Returns all attachments created by an add-on under the post. Requires the add-on to have active attachments on the post or have permission to create new attachm",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","courseId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -309,7 +309,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_add_on_attachments_patch",
     cud: "update",
     description: "Updates an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","attachmentId","courseId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -405,7 +405,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_get_add_on_context",
     cud: "read",
     description: "Gets metadata for Classroom add-ons in the context of a specific post. To maintain the integrity of its own data and permissions model, an add-on should call th",
-    method: { id: "classroom.courses.courseWork.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","courseId"] },
+    method: { id: "classroom.courses.courseWork.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"attachmentId","api":"attachmentId","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -470,7 +470,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_rubrics_create",
     cud: "create",
     description: "Creates a rubric. The requesting user and course owner must have rubrics creation capabilities. For details, see [licensing requirements](https://developers.goo",
-    method: { id: "classroom.courses.courseWork.rubrics.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseWorkId","courseId"] },
+    method: { id: "classroom.courses.courseWork.rubrics.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -485,7 +485,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_rubrics_delete",
     cud: "delete",
     description: "Deletes a rubric. The requesting user and course owner must have rubrics creation capabilities. For details, see [licensing requirements](https://developers.goo",
-    method: { id: "classroom.courses.courseWork.rubrics.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id","courseWorkId"] },
+    method: { id: "classroom.courses.courseWork.rubrics.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -500,7 +500,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_rubrics_get",
     cud: "read",
     description: "Returns a rubric. This method returns the following error codes: * `PERMISSION_DENIED` for access errors. * `INVALID_ARGUMENT` if the request is malformed. * `N",
-    method: { id: "classroom.courses.courseWork.rubrics.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id","courseWorkId","courseId"] },
+    method: { id: "classroom.courses.courseWork.rubrics.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -515,7 +515,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_rubrics_list",
     cud: "read",
     description: "Returns a list of rubrics that the requester is permitted to view. This method returns the following error codes: * `PERMISSION_DENIED` for access errors. * `IN",
-    method: { id: "classroom.courses.courseWork.rubrics.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseWorkId","courseId"] },
+    method: { id: "classroom.courses.courseWork.rubrics.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -531,7 +531,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_rubrics_patch",
     cud: "update",
     description: "Updates a rubric. See google.classroom.v1.Rubric for details of which fields can be updated. Rubric update capabilities are [limited](/classroom/rubrics/limitat",
-    method: { id: "classroom.courses.courseWork.rubrics.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id","courseWorkId"] },
+    method: { id: "classroom.courses.courseWork.rubrics.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -548,7 +548,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_student_submissions_get",
     cud: "read",
     description: "Returns a student submission. * `PERMISSION_DENIED` if the requesting user is not permitted to access the requested course, course work, or student submission o",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id","courseWorkId","courseId"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -582,7 +582,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_coursework_submissions_modify_attachments",
     cud: "update",
     description: "Modifies attachments of student submission. Attachments may only be added to student submissions belonging to course work objects with a `workType` of `ASSIGNME",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.modifyAttachments", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:modifyAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id","courseWorkId","courseId"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.modifyAttachments", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:modifyAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -615,7 +615,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_student_submissions_reclaim",
     cud: "create",
     description: "Reclaims a student submission on behalf of the student that owns it. Reclaiming a student submission transfers ownership of attached Drive files to the student",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.reclaim", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:reclaim", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseWorkId","id","courseId"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.reclaim", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:reclaim", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -647,7 +647,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_student_submissions_turn_in",
     cud: "create",
     description: "Turns in a student submission. Turning in a student submission transfers ownership of attached Drive files to the teacher and may also update the submission sta",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.turnIn", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:turnIn", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id","courseWorkId"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.turnIn", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:turnIn", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -680,7 +680,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_coursework_materials_addons_create",
     cud: "create",
     description: "Creates an add-on attachment under a post. Requires the add-on to have permission to create new attachments on the post. This method returns the following error",
-    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","courseId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -697,7 +697,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_coursework_materials_addons_delete",
     cud: "delete",
     description: "Deletes an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","attachmentId","courseId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -713,7 +713,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_add_on_attachments_get",
     cud: "read",
     description: "Returns an add-on attachment. Requires the add-on requesting the attachment to be the original creator of the attachment. This method returns the following erro",
-    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","attachmentId","courseId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -729,7 +729,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_add_on_attachments_list",
     cud: "read",
     description: "Returns all attachments created by an add-on under the post. Requires the add-on to have active attachments on the post or have permission to create new attachm",
-    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","courseId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -746,7 +746,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_add_on_attachments_patch",
     cud: "update",
     description: "Updates an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","attachmentId","courseId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -806,7 +806,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_get_add_on_context",
     cud: "read",
     description: "Gets metadata for Classroom add-ons in the context of a specific post. To maintain the integrity of its own data and permissions model, an add-on should call th",
-    method: { id: "classroom.courses.courseWorkMaterials.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["itemId","courseId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"attachmentId","api":"attachmentId","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -975,7 +975,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_posts_add_on_attachments_get",
     cud: "read",
     description: "Returns an add-on attachment. Requires the add-on requesting the attachment to be the original creator of the attachment. This method returns the following erro",
-    method: { id: "classroom.courses.posts.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["attachmentId","courseId","postId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"itemId","api":"itemId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1008,7 +1008,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_posts_add_on_attachments_patch",
     cud: "update",
     description: "Updates an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.posts.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["postId","courseId","attachmentId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"itemId","api":"itemId","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1026,7 +1026,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_posts_addon_submissions_get",
     cud: "read",
     description: "Returns a student submission for an add-on attachment. This method returns the following error codes: * `PERMISSION_DENIED` for access errors. * `INVALID_ARGUME",
-    method: { id: "classroom.courses.posts.addOnAttachments.studentSubmissions.get", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","attachmentId","postId","submissionId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.studentSubmissions.get", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId","submissionId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"submissionId","api":"submissionId","location":"path"},{"field":"itemId","api":"itemId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1043,7 +1043,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_posts_addon_submissions_patch",
     cud: "update",
     description: "Updates data associated with an add-on attachment submission. Requires the add-on to have been the original creator of the attachment and the attachment to have",
-    method: { id: "classroom.courses.posts.addOnAttachments.studentSubmissions.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["submissionId","postId","attachmentId","courseId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.studentSubmissions.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId","submissionId"] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"submissionId","api":"submissionId","location":"path"},{"field":"itemId","api":"itemId","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1062,7 +1062,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_posts_get_add_on_context",
     cud: "read",
     description: "Gets metadata for Classroom add-ons in the context of a specific post. To maintain the integrity of its own data and permissions model, an add-on should call th",
-    method: { id: "classroom.courses.posts.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["postId","courseId"] },
+    method: { id: "classroom.courses.posts.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"attachmentId","api":"attachmentId","location":"query"},{"field":"itemId","api":"itemId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1153,7 +1153,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_student_groups_student_group_members_delete",
     cud: "delete",
     description: "Deletes a student group member. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to delete the reque",
-    method: { id: "classroom.courses.studentGroups.studentGroupMembers.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/studentGroups/{studentGroupId}/studentGroupMembers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentGroupId","userId","courseId"] },
+    method: { id: "classroom.courses.studentGroups.studentGroupMembers.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/studentGroups/{studentGroupId}/studentGroupMembers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","studentGroupId","userId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"studentGroupId","api":"studentGroupId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1168,7 +1168,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_student_groups_student_group_members_list",
     cud: "read",
     description: "Returns a list of students in a group. This method returns the following error codes: * `NOT_FOUND` if the course or student group does not exist.",
-    method: { id: "classroom.courses.studentGroups.studentGroupMembers.list", httpMethod: "GET", path: "v1/courses/{courseId}/studentGroups/{studentGroupId}/studentGroupMembers", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentGroupId","courseId"] },
+    method: { id: "classroom.courses.studentGroups.studentGroupMembers.list", httpMethod: "GET", path: "v1/courses/{courseId}/studentGroups/{studentGroupId}/studentGroupMembers", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","studentGroupId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"studentGroupId","api":"studentGroupId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1213,7 +1213,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_students_get",
     cud: "read",
     description: "Returns a student of a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to view students of",
-    method: { id: "classroom.courses.students.get", httpMethod: "GET", path: "v1/courses/{courseId}/students/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["userId","courseId"] },
+    method: { id: "classroom.courses.students.get", httpMethod: "GET", path: "v1/courses/{courseId}/students/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1256,7 +1256,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_teachers_delete",
     cud: "delete",
     description: "Removes the specified teacher from the specified course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not perm",
-    method: { id: "classroom.courses.teachers.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/teachers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["userId","courseId"] },
+    method: { id: "classroom.courses.teachers.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/teachers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1270,7 +1270,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_teachers_get",
     cud: "read",
     description: "Returns a teacher of a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to view teachers of",
-    method: { id: "classroom.courses.teachers.get", httpMethod: "GET", path: "v1/courses/{courseId}/teachers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["userId","courseId"] },
+    method: { id: "classroom.courses.teachers.get", httpMethod: "GET", path: "v1/courses/{courseId}/teachers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1356,7 +1356,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_topics_patch",
     cud: "update",
     description: "Updates one or more fields of a topic. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting developer project did not create t",
-    method: { id: "classroom.courses.topics.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/topics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id","courseId"] },
+    method: { id: "classroom.courses.topics.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/topics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/drive.ts
+++ b/src/tools/generated/drive.ts
@@ -426,7 +426,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_permissions_get",
     cud: "read",
     description: "Gets a permission by ID. For more information, see [Share files, folders, and drives](https://developers.google.com/workspace/drive/api/guides/manage-sharing).",
-    method: { id: "drive.permissions.get", httpMethod: "GET", path: "files/{fileId}/permissions/{permissionId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["permissionId","fileId"] },
+    method: { id: "drive.permissions.get", httpMethod: "GET", path: "files/{fileId}/permissions/{permissionId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","permissionId"] },
     params: [{"field":"fileId","api":"fileId","location":"path"},{"field":"permissionId","api":"permissionId","location":"path"},{"field":"supportsAllDrives","api":"supportsAllDrives","location":"query"},{"field":"supportsTeamDrives","api":"supportsTeamDrives","location":"query"},{"field":"useDomainAdminAccess","api":"useDomainAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -443,7 +443,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_replies_get",
     cud: "read",
     description: "Gets a reply by ID. For more information, see [Manage comments and replies](https://developers.google.com/workspace/drive/api/guides/manage-comments).",
-    method: { id: "drive.replies.get", httpMethod: "GET", path: "files/{fileId}/comments/{commentId}/replies/{replyId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["commentId","replyId","fileId"] },
+    method: { id: "drive.replies.get", httpMethod: "GET", path: "files/{fileId}/comments/{commentId}/replies/{replyId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","commentId","replyId"] },
     params: [{"field":"commentId","api":"commentId","location":"path"},{"field":"fileId","api":"fileId","location":"path"},{"field":"replyId","api":"replyId","location":"path"},{"field":"includeDeleted","api":"includeDeleted","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/forms.ts
+++ b/src/tools/generated/forms.ts
@@ -23,7 +23,7 @@ export function registerFormsGeneratedTools(registry: ToolRegistry): void {
     name: "forms_forms_watches_delete",
     cud: "delete",
     description: "Delete a watch.",
-    method: { id: "forms.forms.watches.delete", httpMethod: "DELETE", path: "v1/forms/{formId}/watches/{watchId}", baseUrl: "https://forms.googleapis.com/", requiredParams: ["watchId","formId"] },
+    method: { id: "forms.forms.watches.delete", httpMethod: "DELETE", path: "v1/forms/{formId}/watches/{watchId}", baseUrl: "https://forms.googleapis.com/", requiredParams: ["formId","watchId"] },
     params: [{"field":"formId","api":"formId","location":"path"},{"field":"watchId","api":"watchId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/gmail.ts
+++ b/src/tools/generated/gmail.ts
@@ -305,7 +305,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_delegates_delete",
     cud: "delete",
     description: "Removes the specified delegate (which can be of any verification status), and revokes any verification that may have been required for using it. For more inform",
-    method: { id: "gmail.users.settings.delegates.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/delegates/{delegateEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["delegateEmail","userId"] },
+    method: { id: "gmail.users.settings.delegates.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/delegates/{delegateEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","delegateEmail"] },
     params: [{"field":"delegateEmail","api":"delegateEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -429,7 +429,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_forwarding_addresses_get",
     cud: "read",
     description: "Gets the specified forwarding address. For more information, see [Manage email forwarding](https://developers.google.com/workspace/gmail/api/guides/forwarding_s",
-    method: { id: "gmail.users.settings.forwardingAddresses.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["forwardingEmail","userId"] },
+    method: { id: "gmail.users.settings.forwardingAddresses.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","forwardingEmail"] },
     params: [{"field":"forwardingEmail","api":"forwardingEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -578,7 +578,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_smime_info_delete",
     cud: "delete",
     description: "Deletes the specified S/MIME config for the specified send-as alias. For more information, see [Manage S/MIME certificates with the Gmail API](https://developer",
-    method: { id: "gmail.users.settings.sendAs.smimeInfo.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["id","userId","sendAsEmail"] },
+    method: { id: "gmail.users.settings.sendAs.smimeInfo.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail","id"] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -637,7 +637,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_smime_info_set_default",
     cud: "update",
     description: "Sets the default S/MIME config for the specified send-as alias. For more information, see [Manage S/MIME certificates with the Gmail API](https://developers.goo",
-    method: { id: "gmail.users.settings.sendAs.smimeInfo.setDefault", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}/setDefault", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["id","userId","sendAsEmail"] },
+    method: { id: "gmail.users.settings.sendAs.smimeInfo.setDefault", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}/setDefault", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail","id"] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/licensing.ts
+++ b/src/tools/generated/licensing.ts
@@ -24,7 +24,7 @@ export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
     name: "licensing_license_assignments_get",
     cud: "read",
     description: "Get a specific user's license by product SKU.",
-    method: { id: "licensing.licenseAssignments.get", httpMethod: "GET", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","userId","skuId"] },
+    method: { id: "licensing.licenseAssignments.get", httpMethod: "GET", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"skuId","api":"skuId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -70,7 +70,7 @@ export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
     name: "licensing_license_assignments_list_for_product_and_sku",
     cud: "read",
     description: "List all users assigned licenses for a specific product SKU.",
-    method: { id: "licensing.licenseAssignments.listForProductAndSku", httpMethod: "GET", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/users", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["customerId","productId","skuId"] },
+    method: { id: "licensing.licenseAssignments.listForProductAndSku", httpMethod: "GET", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/users", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","customerId"] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"skuId","api":"skuId","location":"path"},{"field":"customerId","api":"customerId","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -87,7 +87,7 @@ export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
     name: "licensing_license_assignments_patch",
     cud: "update",
     description: "Reassign a user's product SKU with a different SKU in the same product. This method supports patch semantics.",
-    method: { id: "licensing.licenseAssignments.patch", httpMethod: "PATCH", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","userId","skuId"] },
+    method: { id: "licensing.licenseAssignments.patch", httpMethod: "PATCH", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"skuId","api":"skuId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -103,7 +103,7 @@ export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
     name: "licensing_license_assignments_update",
     cud: "update",
     description: "Reassign a user's product SKU with a different SKU in the same product.",
-    method: { id: "licensing.licenseAssignments.update", httpMethod: "PUT", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["skuId","userId","productId"] },
+    method: { id: "licensing.licenseAssignments.update", httpMethod: "PUT", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"skuId","api":"skuId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/reseller.ts
+++ b/src/tools/generated/reseller.ts
@@ -102,7 +102,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_activate",
     cud: "create",
     description: "Activates a subscription previously suspended by the reseller. If you did not suspend the customer subscription and it is suspended for any other reason, such a",
-    method: { id: "reseller.subscriptions.activate", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/activate", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["subscriptionId","customerId"] },
+    method: { id: "reseller.subscriptions.activate", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/activate", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -131,7 +131,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_change_renewal_settings",
     cud: "create",
     description: "Updates a user license's renewal settings. This is applicable for accounts with annual commitment plans only. For more information, see the description in [mana",
-    method: { id: "reseller.subscriptions.changeRenewalSettings", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/changeRenewalSettings", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["subscriptionId","customerId"] },
+    method: { id: "reseller.subscriptions.changeRenewalSettings", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/changeRenewalSettings", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -146,7 +146,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_change_seats",
     cud: "create",
     description: "Updates a subscription's user license settings. For more information about updating an annual commitment plan or a flexible plan subscription’s licenses, see [M",
-    method: { id: "reseller.subscriptions.changeSeats", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/changeSeats", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["subscriptionId","customerId"] },
+    method: { id: "reseller.subscriptions.changeSeats", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/changeSeats", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -161,7 +161,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_delete",
     cud: "delete",
     description: "Cancels, suspends, or transfers a subscription to direct.",
-    method: { id: "reseller.subscriptions.delete", httpMethod: "DELETE", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["subscriptionId","customerId","deletionType"] },
+    method: { id: "reseller.subscriptions.delete", httpMethod: "DELETE", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId","deletionType"] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"deletionType","api":"deletionType","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -176,7 +176,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_get",
     cud: "read",
     description: "Gets a specific subscription. The `subscriptionId` can be found using the [Retrieve all reseller subscriptions](https://developers.google.com/workspace/admin/re",
-    method: { id: "reseller.subscriptions.get", httpMethod: "GET", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["subscriptionId","customerId"] },
+    method: { id: "reseller.subscriptions.get", httpMethod: "GET", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/script.ts
+++ b/src/tools/generated/script.ts
@@ -124,7 +124,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_deployments_update",
     cud: "update",
     description: "Updates a deployment of an Apps Script project.",
-    method: { id: "script.projects.deployments.update", httpMethod: "PUT", path: "v1/projects/{scriptId}/deployments/{deploymentId}", baseUrl: "https://script.googleapis.com/", requiredParams: ["deploymentId","scriptId"] },
+    method: { id: "script.projects.deployments.update", httpMethod: "PUT", path: "v1/projects/{scriptId}/deployments/{deploymentId}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId","deploymentId"] },
     params: [{"field":"deploymentId","api":"deploymentId","location":"path"},{"field":"scriptId","api":"scriptId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {


### PR DESCRIPTION
Two things, found together:

1. **Generator non-determinism fix.** Google serves discovery `parameters{}` with unstable key order between fetches; `buildMethodIndex` derived `requiredParams` from that order, so two regens from semantically identical docs could flap (the determinism test caught it live: `tasks.tasks.update` flipped `["task","tasklist"]` vs `["tasklist","task"]` while `parameterOrder` was identical in both docs). Now sorted by the canonical `parameterOrder` (alphabetical tie-break) in the shared `discovery-client` path. Runtime impact: only the escape hatch's required-params hint ordering.

2. **Routine drift regen** since the 2026-08-03 snapshot (12 files, counts unchanged at 872). COVERAGE.md folds in the previously-uncommitted `gmail_settings`/`gmail_settings_sharing` bundle entries.

Non-releasing. `ci-windows` is the check to watch (byte-for-byte codegen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)