### PR TITLE
feat!: native process.loadEnvFile + ~/.config .env tier [v6 stack 2/4]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ Reads are never gated. CUD is **deny-by-default**: `GOOGLE_PROFILE` (read-only /
 ## Versioning & releases (automated — CI controls it)
 
 - semantic-release on push to `dev` (alpha) / `staging` (beta) / `main` (stable). Never bump `package.json`, write a changelog, or tag by hand.
-- Conventional Commits: `fix:`=patch, `feat:`=minor, `feat!:`/`BREAKING CHANGE:`=major. A new `BASE_SCOPES` scope is breaking (`feat!:`).
+- Conventional Commits: `fix:`=patch, `feat:`=minor, a `BREAKING CHANGE:` footer=major. The analyzer's default (angular) preset does NOT parse a bare `feat!:` — a breaking commit MUST carry the footer or it releases nothing. A new `BASE_SCOPES` scope is breaking.
 - **Merge commits only** (squash/rebase disabled) — each branch's commits land individually, so keep them clean Conventional Commits.
 - After a stable release, `.github/workflows/backmerge.yml` resyncs `main → staging → dev`.
 
@@ -104,7 +104,7 @@ Reads are never gated. CUD is **deny-by-default**: `GOOGLE_PROFILE` (read-only /
 
 ## Don'ts
 
-- No `console.log` from handlers, and nothing may write to stdout at import time either — stdio is the MCP channel (the dotenv v17 banner corrupted it; `dotenv.config` must keep `quiet: true`, guarded by `tests/stdout-purity.test.ts`). `process.stderr.write` only.
+- No `console.log` from handlers, and nothing may write to stdout at import time either — stdio is the MCP channel (the dotenv v17 banner corrupted it, which is why env loading is the native `process.loadEnvFile` in `src/env-load.ts`; guarded by `tests/stdout-purity.test.ts`). `process.stderr.write` only.
 - Don't hardcode aliases — read `ACCOUNTS` / `ACCOUNT_CONFIG`.
 - Don't bypass `getClient`; don't write plaintext tokens or perms wider than `0o600`.
 - Don't re-implement error mapping or write gating — use the shared helpers.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-Everything is configured through environment variables (a `.env` in the working directory is loaded automatically). Back to the [README](../README.md).
+Everything is configured through environment variables. `.env` files load automatically with this precedence (highest first): real environment, then `.env` in the working directory, then `.env` in the package root, then `${XDG_CONFIG_HOME:-~/.config}/mcp-google-multi/.env`. Set `MCP_GOOGLE_MULTI_ENV=/abs/path/.env` to load exactly that file instead of searching; a missing or unreadable pointed file is a fatal `E_ENV_NOT_FOUND`. Node.js 22+ is required; older runtimes exit with `E_NODE_TOO_OLD`. Back to the [README](../README.md).
 
 ## Environment variables
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "@googleapis/tasks": "^13.0.0",
         "@googleapis/webmasters": "^4.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "dotenv": "^17.4.0",
         "googleapis-common": "^8.0.3",
         "mime-types": "^3.0.2",
         "open": "^11.0.0",
@@ -45,7 +44,7 @@
         "vitest": "^3.2.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@actions/core": {
@@ -3359,18 +3358,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@googleapis/tasks": "^13.0.0",
     "@googleapis/webmasters": "^4.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "dotenv": "^17.4.0",
     "googleapis-common": "^8.0.3",
     "mime-types": "^3.0.2",
     "open": "^11.0.0",

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,14 +1,8 @@
-import dotenv from 'dotenv';
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { homedir } from 'node:os';
+import { loadEnvFiles } from './env-load.js';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
-// dotenv v17 prints a banner to stdout, corrupting the stdio JSON-RPC channel;
-// DOTENV_CONFIG_QUIET cannot help, it would be read from .env after config() ran.
-dotenv.config({ quiet: true });
-dotenv.config({ path: path.resolve(__dirname, '..', '.env'), quiet: true });
+const envLoad = loadEnvFiles();
 
 const defaultTokenDir = path.join(
   process.env.XDG_CONFIG_HOME || path.join(homedir(), '.config'),
@@ -29,9 +23,14 @@ export interface AccountConfig {
 function parseAccounts(): { aliases: [string, ...string[]]; configs: Record<string, AccountConfig> } {
   const raw = process.env.GOOGLE_ACCOUNTS;
   if (!raw || raw.trim() === '') {
+    const noEnvFile =
+      envLoad.loaded.length === 0
+        ? `\nE_ENV_NOT_FOUND: no readable .env file was found (searched: ${envLoad.searched.join(', ')}).`
+        : '';
     throw new Error(
       'GOOGLE_ACCOUNTS is not set. Define it in .env like:\n' +
-        'GOOGLE_ACCOUNTS=work:user@company.com,personal:user@gmail.com',
+        'GOOGLE_ACCOUNTS=work:user@company.com,personal:user@gmail.com' +
+        noEnvFile,
     );
   }
 

--- a/src/env-load.ts
+++ b/src/env-load.ts
@@ -1,0 +1,77 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export interface EnvLoadResult {
+  loaded: string[];
+  searched: string[];
+}
+
+/** Path overrides are for tests only; production callers pass nothing. */
+export interface EnvLoadPaths {
+  cwd?: string;
+  packageRoot?: string;
+  configDir?: string;
+}
+
+// Precedence: real env > CWD .env > package-root .env > ~/.config .env.
+// process.loadEnvFile never overwrites keys already in process.env (pinned by
+// tests/env-load.test.ts T4), so highest-priority file loads FIRST and real
+// env wins by already being present; the boot snapshot re-assert is a second
+// line of defense should those semantics ever change.
+export function loadEnvFiles(paths: EnvLoadPaths = {}): EnvLoadResult {
+  // loadEnvFile exists since 20.12, so a feature check alone would let 20.12-21.x through.
+  const major = Number(process.versions.node.split('.', 1)[0]);
+  if (major < 22 || typeof process.loadEnvFile !== 'function') {
+    process.stderr.write(
+      `E_NODE_TOO_OLD: mcp-google-multi requires Node.js >= 22 (running ${process.versions.node}). Upgrade to Node 22 LTS or newer.\n`,
+    );
+    process.exit(1);
+  }
+
+  const configDir =
+    paths.configDir ??
+    path.join(
+      process.env.XDG_CONFIG_HOME || path.join(homedir(), '.config'),
+      'mcp-google-multi',
+    );
+  const explicit = process.env.MCP_GOOGLE_MULTI_ENV;
+  const candidates = explicit
+    ? [path.resolve(explicit)]
+    : [
+        path.join(paths.cwd ?? process.cwd(), '.env'),
+        path.join(paths.packageRoot ?? path.resolve(__dirname, '..'), '.env'),
+        path.join(configDir, '.env'),
+      ];
+
+  const boot = new Map(
+    Object.entries(process.env).filter((e): e is [string, string] => e[1] !== undefined),
+  );
+  const loaded: string[] = [];
+  for (const p of candidates) {
+    try {
+      process.loadEnvFile(p);
+      loaded.push(p);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') {
+        // Node collapses every open()-stage failure (EACCES, ENOTDIR, ...) into
+        // ENOENT, so stat to tell "absent" from "present but unreadable".
+        if (explicit) {
+          const reason = existsSync(p) ? 'exists but is not readable' : 'does not exist';
+          process.stderr.write(
+            `E_ENV_NOT_FOUND: MCP_GOOGLE_MULTI_ENV points to "${p}" but the file ${reason}.\n`,
+          );
+          process.exit(1);
+        }
+        continue;
+      }
+      throw e;
+    }
+  }
+  for (const [k, v] of boot) process.env[k] = v;
+
+  return { loaded, searched: candidates };
+}

--- a/tests/env-load.test.ts
+++ b/tests/env-load.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { loadEnvFiles } from '../src/env-load.js';
+
+// Each test gets throwaway dirs for all three tiers so the repo's own .env
+// (if any) never leaks in.
+let base: string;
+let cwd: string;
+let pkgRoot: string;
+let configDir: string;
+const dirs = () => ({ cwd, packageRoot: pkgRoot, configDir });
+
+const KEYS = ['EL_A', 'EL_B', 'EL_C', 'EL_REAL'];
+let realEnvBackup: Record<string, string | undefined>;
+
+beforeEach(() => {
+  base = mkdtempSync(path.join(tmpdir(), 'env-load-'));
+  cwd = path.join(base, 'cwd');
+  pkgRoot = path.join(base, 'pkg');
+  configDir = path.join(base, 'config');
+  for (const d of [cwd, pkgRoot, configDir]) mkdirSync(d, { recursive: true });
+  realEnvBackup = {};
+  for (const k of [...KEYS, 'MCP_GOOGLE_MULTI_ENV']) {
+    realEnvBackup[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const [k, v] of Object.entries(realEnvBackup)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  rmSync(base, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('loadEnvFiles', () => {
+  it('T1: no .env on any tier loads nothing and does not throw', () => {
+    const res = loadEnvFiles(dirs());
+    expect(res.loaded).toEqual([]);
+    expect(res.searched).toHaveLength(3);
+  });
+
+  it('T2: .env only in the config dir reaches process.env', () => {
+    writeFileSync(path.join(configDir, '.env'), 'EL_A=from-config\n');
+    const res = loadEnvFiles(dirs());
+    expect(process.env.EL_A).toBe('from-config');
+    expect(res.loaded).toEqual([path.join(configDir, '.env')]);
+  });
+
+  it('T3: MCP_GOOGLE_MULTI_ENV replaces the file search entirely', () => {
+    writeFileSync(path.join(configDir, '.env'), 'EL_A=from-config\nEL_B=config-only\n');
+    const pointed = path.join(base, 'pointed.env');
+    writeFileSync(pointed, 'EL_A=from-pointed\n');
+    process.env.MCP_GOOGLE_MULTI_ENV = pointed;
+    const res = loadEnvFiles(dirs());
+    expect(process.env.EL_A).toBe('from-pointed');
+    expect(process.env.EL_B).toBeUndefined();
+    expect(res.searched).toEqual([pointed]);
+  });
+
+  it('T3b: a missing MCP_GOOGLE_MULTI_ENV path is fatal with E_ENV_NOT_FOUND', () => {
+    process.env.MCP_GOOGLE_MULTI_ENV = path.join(base, 'nope.env');
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const exit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => { throw new Error('exit-called'); });
+    expect(() => loadEnvFiles(dirs())).toThrow('exit-called');
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(String(stderr.mock.calls[0]?.[0])).toContain('E_ENV_NOT_FOUND');
+    expect(String(stderr.mock.calls[0]?.[0])).toContain('nope.env');
+  });
+
+  it('T4: precedence is real env > CWD > package-root > config dir', () => {
+    process.env.EL_REAL = 'boot';
+    writeFileSync(
+      path.join(configDir, '.env'),
+      'EL_REAL=config\nEL_A=config\nEL_B=config\nEL_C=config\n',
+    );
+    writeFileSync(path.join(pkgRoot, '.env'), 'EL_A=pkg\nEL_B=pkg\n');
+    writeFileSync(path.join(cwd, '.env'), 'EL_A=cwd\n');
+    loadEnvFiles(dirs());
+    expect(process.env.EL_REAL).toBe('boot');
+    expect(process.env.EL_A).toBe('cwd');
+    expect(process.env.EL_B).toBe('pkg');
+    expect(process.env.EL_C).toBe('config');
+  });
+
+  it('T6: pre-22 Node (no process.loadEnvFile) fails fast with E_NODE_TOO_OLD, no TypeError', () => {
+    const original = process.loadEnvFile;
+    // @ts-expect-error simulating a pre-22 runtime
+    process.loadEnvFile = undefined;
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const exit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => { throw new Error('exit-called'); });
+    try {
+      expect(() => loadEnvFiles(dirs())).toThrow('exit-called');
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(String(stderr.mock.calls[0]?.[0])).toContain('E_NODE_TOO_OLD');
+    } finally {
+      process.loadEnvFile = original;
+    }
+  });
+
+  it('rethrows non-ENOENT loader errors instead of swallowing them', () => {
+    // A directory named .env fails at the READ stage (ERR_INVALID_ARG_TYPE on
+    // both Linux and Windows) — open()-stage failures all collapse into ENOENT.
+    mkdirSync(path.join(cwd, '.env'));
+    expect(() => loadEnvFiles(dirs())).toThrow();
+  });
+
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'an unreadable .env in a search tier is skipped, not fatal',
+    () => {
+      const p = path.join(cwd, '.env');
+      writeFileSync(p, 'EL_A=locked\n', { mode: 0o000 });
+      const res = loadEnvFiles(dirs());
+      expect(res.loaded).toEqual([]);
+      expect(process.env.EL_A).toBeUndefined();
+    },
+  );
+
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'an unreadable MCP_GOOGLE_MULTI_ENV path is fatal and says so accurately',
+    () => {
+      const p = path.join(base, 'locked.env');
+      writeFileSync(p, 'EL_A=locked\n', { mode: 0o000 });
+      process.env.MCP_GOOGLE_MULTI_ENV = p;
+      const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+      const exit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation(() => { throw new Error('exit-called'); });
+      expect(() => loadEnvFiles(dirs())).toThrow('exit-called');
+      expect(exit).toHaveBeenCalledWith(1);
+      expect(String(stderr.mock.calls[0]?.[0])).toContain('is not readable');
+    },
+  );
+});


### PR DESCRIPTION
Stack 2/4 on #137. Drops `dotenv` for native `process.loadEnvFile`; precedence real env > CWD > package-root > `~/.config/mcp-google-multi/.env`; `MCP_GOOGLE_MULTI_ENV` override; `E_NODE_TOO_OLD`/`E_ENV_NOT_FOUND`; loadEnvFile no-overwrite semantics pinned by test T4; absent-vs-unreadable reported accurately (Node collapses open failures into ENOENT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)