### PR TITLE
refactor: stop fetching the alertcenter discovery document [v6 stack 4/4]

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -6,7 +6,7 @@ Every OAuth-reachable Google Workspace API method is a named tool: **182 curated
 
 All operational tools are hidden until their `{service}_discover` tool reveals them, so the idle context cost stays at the eager meta-tools only. Writes are deny-by-default via write-control regardless of tier. Generated tools whose scope is not granted return a typed `insufficient_scope` hint at call time; add the relevant bundle and re-auth to use them.
 
-Not covered: Alert Center (service-account auth; planned for v6), Drive v2 (superseded by v3), and non-REST surfaces (Marketplace SDK, CalDAV).
+Not covered: Alert Center (requires service-account domain-wide delegation; this server is per-user OAuth consent by design), Drive v2 (superseded by v3), and non-REST surfaces (Marketplace SDK, CalDAV).
 
 | Service | Curated | Generated | Total | Enabled by |
 |---|---:|---:|---:|---|

--- a/scripts/fetch-discovery.ts
+++ b/scripts/fetch-discovery.ts
@@ -12,7 +12,6 @@ const APIS: Api[] = [
   { id: 'admin', version: 'datatransfer_v1' },
   { id: 'admin', version: 'directory_v1' },
   { id: 'admin', version: 'reports_v1' },
-  { id: 'alertcenter', version: 'v1beta1' },
   { id: 'appsmarket', version: 'v2' },
   { id: 'calendar', version: 'v3' },
   { id: 'chat', version: 'v1' },

--- a/scripts/gen-config.ts
+++ b/scripts/gen-config.ts
@@ -8,8 +8,8 @@ export interface GenApi {
   service: string;
 }
 
-// alertcenter (service-account-only auth) and drive v2 (superseded by v3)
-// are deliberately not generated.
+// drive v2 is deliberately not generated (superseded by v3). alertcenter is
+// not even fetched: it needs service-account DWD, which this server declines.
 export const GEN_APIS: GenApi[] = [
   { file: 'admin.datatransfer_v1.json', service: 'admin' },
   { file: 'admin.directory_v1.json', service: 'admin' },

--- a/scripts/gen-coverage.ts
+++ b/scripts/gen-coverage.ts
@@ -64,7 +64,7 @@ const lines: string[] = [
   '',
   'All operational tools are hidden until their `{service}_discover` tool reveals them, so the idle context cost stays at the eager meta-tools only. Writes are deny-by-default via write-control regardless of tier. Generated tools whose scope is not granted return a typed `insufficient_scope` hint at call time; add the relevant bundle and re-auth to use them.',
   '',
-  'Not covered: Alert Center (service-account auth; planned for v6), Drive v2 (superseded by v3), and non-REST surfaces (Marketplace SDK, CalDAV).',
+  'Not covered: Alert Center (requires service-account domain-wide delegation; this server is per-user OAuth consent by design), Drive v2 (superseded by v3), and non-REST surfaces (Marketplace SDK, CalDAV).',
   '',
   '| Service | Curated | Generated | Total | Enabled by |',
   '|---|---:|---:|---:|---|',


### PR DESCRIPTION
Stack 4/4. Proven no-op (872 tools unchanged, generated files byte-identical); coverage template's stale 'planned for v6' claim fixed (service-account DWD is declined by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)