### PR TITLE
feat!: config.json account registry + IdentityContext seam [v6 B1]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,10 @@ Conventions for AI assistants modifying this codebase. v5 is **local, stdio, use
 - `src/token-store.ts` — encrypted token store (AES-256-GCM, key from `MASTER_KEY`); `readToken`/`writeToken`/`updateToken`. The `migrate-tokens` CLI lives in `src/migrate-tokens.ts`.
 - `src/auth.ts` — OAuth flow + scope tiers (`BASE_SCOPES` always, `OPTIONAL_SCOPE_BUNDLES` env-gated, `ADMIN_SCOPES` per-account).
 - `src/client.ts` — `getClient(account)`: fresh OAuth2Client per call from the encrypted token; its `tokens` listener re-encrypts on refresh (`updateToken`).
-- `src/accounts.ts` — parses `GOOGLE_ACCOUNTS`; token dir defaults to `~/.config/mcp-google-multi/tokens` (override `TOKEN_STORE_PATH`).
+- `src/accounts.ts` — `resolveAccounts()` builds the `AccountSet` (registry): whole-registry env override via `GOOGLE_ACCOUNTS`, else `config.json`; `getAccountSet()` is the live accessor (dispatch-time readers use it, never a captured snapshot); `invalidateAccountSet()`/`isAccountSetStale()` back the reload path. Token dir defaults to `~/.config/mcp-google-multi/tokens` (override `TOKEN_STORE_PATH`).
+- `src/config-file.ts` — `config.json` zod-strict schema (secrets-shaped keys fail), version gate, `mutateConfigFile` read-latest-under-lock writer. `src/fs-atomic.ts` — path-keyed hardlink lock + atomic write (generalized from the token store; token writes delegate to it).
+- `src/identity.ts` — `buildIdentityContext()`: the frozen forward-compat seam `{subject:'owner', accounts, policy, getClient, tokenStore}`; `buildRegistry(server, ctx)` consumes it. Exactly one context in the free core.
+- `src/migrate-config.ts` — `migrate-config` CLI: env -> `config.json` accounts (idempotent, never edits env).
 - `src/tools/_errors.ts` — `mapGoogleError` typed taxonomy + `handleGoogleApiError` result wrapper; each service file defines its own `handle<Service>Error` shim over it (optionally with a service-specific 403 hint).
 - `src/tools/_coerce.ts` — `coerceArray`/`coerceJson`/`coerceBoolean` for string-encoded client args.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,26 @@
 # Configuration reference
 
-Everything is configured through environment variables. `.env` files load automatically with this precedence (highest first): real environment, then `.env` in the working directory, then `.env` in the package root, then `${XDG_CONFIG_HOME:-~/.config}/mcp-google-multi/.env`. Set `MCP_GOOGLE_MULTI_ENV=/abs/path/.env` to load exactly that file instead of searching; a missing or unreadable pointed file is a fatal `E_ENV_NOT_FOUND`. Node.js 22+ is required; older runtimes exit with `E_NODE_TOO_OLD`. Back to the [README](../README.md).
+Everything is configured through environment variables and an optional `${XDG_CONFIG_HOME:-~/.config}/mcp-google-multi/config.json`. `.env` files load automatically with this precedence (highest first): real environment, then `.env` in the working directory, then `.env` in the package root, then `${XDG_CONFIG_HOME:-~/.config}/mcp-google-multi/.env`. Set `MCP_GOOGLE_MULTI_ENV=/abs/path/.env` to load exactly that file instead of searching; a missing or unreadable pointed file is a fatal `E_ENV_NOT_FOUND`. Node.js 22+ is required; older runtimes exit with `E_NODE_TOO_OLD`. Back to the [README](../README.md).
+
+## config.json (account registry)
+
+Accounts live in a mutable, plaintext-by-design `config.json` (no secrets ever; safe to commit):
+
+```jsonc
+{
+  "version": 1,
+  "accounts": {
+    "work":     { "email": "you@company.com", "admin": true },
+    "personal": { "email": "you@gmail.com" }
+  }
+}
+```
+
+- **Env override:** while `GOOGLE_ACCOUNTS` is set and non-empty, the whole registry comes from env and the file is ignored (12-factor deployments keep working unchanged). `GOOGLE_ADMIN_ACCOUNTS`, when set, overrides per-account `admin` flags.
+- **`mcp-google-multi migrate-config`** synthesizes the file from your current env (idempotent; never edits env).
+- On first start with `GOOGLE_ACCOUNTS` set and no file, the file is materialized automatically.
+- Secrets (`GOOGLE_CLIENT_ID`/`SECRET`, `MASTER_KEY`) are never config fields — a secret-shaped key fails validation (`E_CONFIG_INVALID`).
+- Startup errors: no accounts anywhere = `E_NO_ACCOUNTS_CONFIGURED`; invalid file = `E_CONFIG_INVALID`; a file written by a newer version = `E_CONFIG_VERSION_UNSUPPORTED` (upgrade the package).
 
 ## Environment variables
 

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,14 +1,12 @@
 import path from 'node:path';
-import { homedir } from 'node:os';
+import fs from 'node:fs';
 import { loadEnvFiles } from './env-load.js';
+import { CONFIG_VERSION, configDir, configFilePath, failStartup, loadConfigFile, mutateConfigFile } from './config-file.js';
+import type { ConfigFile } from './config-file.js';
 
 const envLoad = loadEnvFiles();
 
-const defaultTokenDir = path.join(
-  process.env.XDG_CONFIG_HOME || path.join(homedir(), '.config'),
-  'mcp-google-multi',
-  'tokens',
-);
+const defaultTokenDir = path.join(configDir(), 'tokens');
 const tokenDir = process.env.TOKEN_STORE_PATH
   ? path.resolve(process.env.TOKEN_STORE_PATH)
   : defaultTokenDir;
@@ -17,23 +15,31 @@ export interface AccountConfig {
   email: string;
   tokenPath: string;
   encPath: string;
+  scopeProfile?: string;
+  admin?: boolean;
+  source: 'config' | 'env';
 }
 
-/** Format: GOOGLE_ACCOUNTS="alias1:email1,alias2:email2". */
-function parseAccounts(): { aliases: [string, ...string[]]; configs: Record<string, AccountConfig> } {
-  const raw = process.env.GOOGLE_ACCOUNTS;
-  if (!raw || raw.trim() === '') {
-    const noEnvFile =
-      envLoad.loaded.length === 0
-        ? `\nE_ENV_NOT_FOUND: no readable .env file was found (searched: ${envLoad.searched.join(', ')}).`
-        : '';
-    throw new Error(
-      'GOOGLE_ACCOUNTS is not set. Define it in .env like:\n' +
-        'GOOGLE_ACCOUNTS=work:user@company.com,personal:user@gmail.com' +
-        noEnvFile,
-    );
-  }
+export interface AccountSet {
+  aliases: [string, ...string[]];
+  configs: Record<string, AccountConfig>;
+  source: 'env' | 'file' | 'merged';
+  stamp: string;
+}
 
+function parseCsv(value: string | undefined): string[] {
+  return (value ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+function accountPaths(alias: string): { tokenPath: string; encPath: string } {
+  return {
+    tokenPath: path.join(tokenDir, alias, 'token.json'),
+    encPath: path.join(tokenDir, `${alias}.enc`),
+  };
+}
+
+/** v5 env parser, guards verbatim. Format: GOOGLE_ACCOUNTS="alias1:email1,alias2:email2". */
+function parseEnvAccounts(raw: string, adminAliases: string[]): { aliases: string[]; configs: Record<string, AccountConfig> } {
   const configs: Record<string, AccountConfig> = {};
   const aliases: string[] = [];
 
@@ -59,7 +65,7 @@ function parseAccounts(): { aliases: [string, ...string[]]; configs: Record<stri
 
     // Restrict alias to a safe charset so it can't escape `tokenDir` via path traversal
     // (e.g. "../../etc/passwd:foo@bar.com" in .env).
-    if (!/^[a-zA-Z0-9_-]+$/.test(alias)) {
+    if (!/^[a-zA-Z0-9_-]+$/.test(alias) || ['__proto__', 'constructor', 'prototype'].includes(alias)) {
       throw new Error(
         `Invalid alias "${alias}". Allowed characters: letters, digits, underscore, hyphen.`,
       );
@@ -74,8 +80,9 @@ function parseAccounts(): { aliases: [string, ...string[]]; configs: Record<stri
     aliases.push(alias);
     configs[alias] = {
       email,
-      tokenPath: path.join(tokenDir, alias, 'token.json'),
-      encPath: path.join(tokenDir, `${alias}.enc`),
+      ...accountPaths(alias),
+      admin: adminAliases.includes(alias) || undefined,
+      source: 'env',
     };
   }
 
@@ -83,16 +90,168 @@ function parseAccounts(): { aliases: [string, ...string[]]; configs: Record<stri
     throw new Error('GOOGLE_ACCOUNTS must define at least one account.');
   }
 
-  return { aliases: aliases as [string, ...string[]], configs };
+  return { aliases, configs };
 }
 
-const parsed = parseAccounts();
+function noAccountsMessage(): string {
+  const envHint =
+    envLoad.loaded.length === 0
+      ? ` No readable .env file was found (searched: ${envLoad.searched.join(', ')}).`
+      : '';
+  return (
+    `no accounts configured. Add them to ${configFilePath()} (run: mcp-google-multi migrate-config), ` +
+    `or set GOOGLE_ACCOUNTS=work:user@company.com,personal:user@gmail.com in the environment.${envHint}`
+  );
+}
 
-/** Tuple of account aliases (at least one) — usable with z.enum() */
-export const ACCOUNTS = parsed.aliases;
+/**
+ * Registry resolution (BR-2): a non-empty GOOGLE_ACCOUNTS env takes the WHOLE
+ * registry from env (12-factor override, never merged key-by-key); otherwise
+ * the registry comes from config.json. GOOGLE_ADMIN_ACCOUNTS, when NON-EMPTY,
+ * overrides per-account admin flags from the file (env var > config field);
+ * empty behaves as unset, mirroring GOOGLE_ACCOUNTS semantics.
+ */
+export function resolveAccounts(
+  env: NodeJS.ProcessEnv = process.env,
+  filePath = configFilePath(),
+  onInvalid: 'exit' | 'throw' = 'exit',
+): AccountSet {
+  const adminEnv = parseCsv(env.GOOGLE_ADMIN_ACCOUNTS);
+  const rawEnv = env.GOOGLE_ACCOUNTS;
 
-/** Map of alias → { email, tokenPath } */
-export const ACCOUNT_CONFIG = parsed.configs;
+  if (rawEnv && rawEnv.trim() !== '') {
+    const { aliases, configs } = parseEnvAccounts(rawEnv, adminEnv);
+    materializeFirstRun(aliases, configs, filePath);
+    return {
+      aliases: aliases as [string, ...string[]],
+      configs,
+      source: 'env',
+      stamp: 'env:0',
+    };
+  }
+
+  // Stat BEFORE read: a cross-process write landing between the two makes the
+  // stamp conservative (flags stale again next dispatch) instead of pinning
+  // stale content behind a fresh stamp.
+  const preStamp = fileStamp(filePath, CONFIG_VERSION);
+  const config = loadConfigFile(filePath, onInvalid);
+  const entries = Object.entries(config?.accounts ?? {});
+  if (entries.length === 0) {
+    if (onInvalid === 'throw') {
+      throw new Error(`E_NO_ACCOUNTS_CONFIGURED: ${noAccountsMessage()}`);
+    }
+    failStartup('E_NO_ACCOUNTS_CONFIGURED', noAccountsMessage());
+  }
+
+  const configs: Record<string, AccountConfig> = {};
+  const aliases: string[] = [];
+  for (const [alias, entry] of entries) {
+    aliases.push(alias);
+    configs[alias] = {
+      email: entry.email,
+      ...accountPaths(alias),
+      scopeProfile: entry.scopeProfile,
+      admin: adminEnv.length > 0 ? adminEnv.includes(alias) : entry.admin,
+      source: 'config',
+    };
+  }
+
+  return {
+    aliases: aliases as [string, ...string[]],
+    configs,
+    source: 'file',
+    stamp: `${config?.version ?? CONFIG_VERSION}:${preStamp.split(':')[1]}`,
+  };
+}
+
+function fileStamp(filePath: string, version: number): string {
+  try {
+    return `${version}:${fs.statSync(filePath).mtimeMs}`;
+  } catch {
+    return `${version}:0`;
+  }
+}
+
+// First-run shim (BC6): env is set and no config.json exists yet — materialize
+// the file so the wizard has something to edit. Env still wins this session;
+// a write failure must never block boot (warn on stderr and continue).
+function materializeFirstRun(
+  aliases: string[],
+  configs: Record<string, AccountConfig>,
+  filePath: string,
+): void {
+  if (fs.existsSync(filePath)) return;
+  try {
+    let wrote = false;
+    // mutateConfigFile = lock + re-check + atomic write, so a concurrent
+    // wizard/migrate writer is never clobbered (the loaded `current` is
+    // re-read under the lock; only a still-absent file gets the env content).
+    mutateConfigFile((current) => {
+      if (Object.keys(current.accounts ?? {}).length > 0) return current;
+      const accounts: NonNullable<ConfigFile['accounts']> = {};
+      for (const alias of aliases) {
+        accounts[alias] = {
+          email: configs[alias].email,
+          ...(configs[alias].admin ? { admin: true } : {}),
+        };
+      }
+      wrote = true;
+      return { ...current, version: current.version || CONFIG_VERSION, accounts };
+    }, filePath);
+    if (wrote) {
+      process.stderr.write(
+        `Materialized ${filePath} from GOOGLE_ACCOUNTS (env still overrides while set).\n`,
+      );
+    }
+  } catch (e) {
+    process.stderr.write(`Could not materialize ${filePath}: ${(e as Error).message}\n`);
+  }
+}
+
+let current = resolveAccounts();
+
+/** Live accessor: dispatch-time readers use this, never a captured snapshot. */
+export function getAccountSet(): AccountSet {
+  return current;
+}
+
+/** Re-resolve after a config.json mutation and swap the live set. */
+export function invalidateAccountSet(): AccountSet {
+  current = resolveAccounts();
+  return current;
+}
+
+/**
+ * Dispatch-path reload (BR-7): NEVER exits and never throws — a mid-edit,
+ * corrupt, or deleted config.json keeps the last-good set and warns once per
+ * distinct failure on stderr. failStartup semantics are boot/CLI-only.
+ */
+let lastReloadWarning = '';
+export function refreshAccountSetIfStale(): void {
+  if (!isAccountSetStale()) return;
+  try {
+    current = resolveAccounts(process.env, configFilePath(), 'throw');
+    lastReloadWarning = '';
+  } catch (e) {
+    const msg = (e as Error).message;
+    if (msg !== lastReloadWarning) {
+      process.stderr.write(`config.json reload skipped (keeping last-good registry): ${msg}\n`);
+      lastReloadWarning = msg;
+    }
+  }
+}
+
+/** Cross-process staleness probe (BR-7): one stat, compared against the stamp. */
+export function isAccountSetStale(): boolean {
+  if (current.source !== 'file') return false;
+  const [version] = current.stamp.split(':');
+  return current.stamp !== fileStamp(configFilePath(), Number(version));
+}
+
+/** Tuple of account aliases (at least one) — usable with z.enum().
+ * Snapshot from the initial load; enums widen only when the registry is
+ * rebuilt after a mutation (account_add, later slice). */
+export const ACCOUNTS = current.aliases;
 
 /** Valid account alias (string union isn't static, so tools use z.enum(ACCOUNTS)) */
 export type Account = string;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -3,7 +3,7 @@ import http from 'node:http';
 import { URL } from 'node:url';
 import { randomBytes } from 'node:crypto';
 import { openUrl } from './open-url.js';
-import { ACCOUNTS, ACCOUNT_CONFIG } from './accounts.js';
+import { ACCOUNTS, getAccountSet } from './accounts.js';
 import { writeToken } from './token-store.js';
 
 // Personal (non-Workspace) accounts 403 on admin scopes; ADMIN_SCOPES stays per-account opt-in, never granted by default.
@@ -97,9 +97,11 @@ export function getOptionalBundles(): string[] {
   return parseCsvEnv('GOOGLE_OPTIONAL_SCOPES').filter(b => b in OPTIONAL_SCOPE_BUNDLES);
 }
 
-/** Account aliases granted ADMIN_SCOPES via GOOGLE_ADMIN_ACCOUNTS. */
+/** Aliases granted ADMIN_SCOPES: admin flags on the AccountSet (env
+ * GOOGLE_ADMIN_ACCOUNTS overrides config.json per-account admin at resolve). */
 export function getAdminAccounts(): string[] {
-  return parseCsvEnv('GOOGLE_ADMIN_ACCOUNTS');
+  const { aliases, configs } = getAccountSet();
+  return aliases.filter((a) => configs[a].admin === true);
 }
 
 /** Scopes are fixed at consent time: changing GOOGLE_OPTIONAL_SCOPES or GOOGLE_ADMIN_ACCOUNTS requires re-running auth. */
@@ -140,7 +142,7 @@ export async function runAuthFlow(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const config = ACCOUNT_CONFIG[alias];
+  const config = getAccountSet().configs[alias];
   const scopes = resolveScopesForAccount(alias);
 
   if (!process.env.MASTER_KEY) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,10 +1,18 @@
 import { OAuth2Client } from 'googleapis-common';
-import { ACCOUNT_CONFIG } from './accounts.js';
+import { getAccountSet, refreshAccountSetIfStale } from './accounts.js';
 import type { Account } from './accounts.js';
 import { readToken, updateToken } from './token-store.js';
 
 export async function getClient(account: Account) {
-  const config = ACCOUNT_CONFIG[account];
+  // BR-7: lazy cross-process reload — one stat per dispatch, no watcher;
+  // reload failures keep the last-good registry, never kill the server.
+  refreshAccountSetIfStale();
+  const config = getAccountSet().configs[account];
+  if (!config) {
+    throw new Error(
+      `Unknown account "${account}". Valid aliases: ${getAccountSet().aliases.join(', ')}`,
+    );
+  }
 
   if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
     throw new Error(

--- a/src/config-file.ts
+++ b/src/config-file.ts
@@ -1,0 +1,141 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { homedir } from 'node:os';
+import { z } from 'zod';
+import { atomicWriteFileSync, withFileLock } from './fs-atomic.js';
+
+export const CONFIG_VERSION = 1;
+
+export function configDir(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(env.XDG_CONFIG_HOME || path.join(homedir(), '.config'), 'mcp-google-multi');
+}
+
+export function configFilePath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(configDir(env), 'config.json');
+}
+
+// Alias charset is load-bearing security, not cosmetics: the alias becomes a
+// tokenDir path segment (encPath), so this guard blocks path traversal.
+export const ALIAS_RE = /^[a-zA-Z0-9_-]+$/;
+
+const accountEntrySchema = z.strictObject({
+  email: z.string().min(1),
+  scopeProfile: z.string().optional(),
+  admin: z.boolean().optional(),
+});
+
+// .strict() everywhere: any unknown or secret-shaped key (clientSecret,
+// masterKey, jwtKey, clientId) fails validation, structurally enforcing
+// secrets-env-only. scopeProfiles/defaultAccount/discovery/toolsets are part
+// of the frozen envelope; their consumers land in later slices.
+const RESERVED_ALIASES = ['__proto__', 'constructor', 'prototype'];
+
+const configSchema = z.strictObject({
+  version: z.number().int(),
+  accounts: z.record(z.string().regex(ALIAS_RE), accountEntrySchema).optional(),
+  scopeProfiles: z
+    .record(z.string(), z.strictObject({ bundles: z.array(z.string()), admin: z.boolean().optional() }))
+    .optional(),
+  defaultAccount: z.string().optional(),
+  discovery: z.enum(['lazy', 'curated', 'eager']).optional(),
+  toolsets: z.string().optional(),
+});
+
+export interface ConfigFile {
+  version: number;
+  accounts?: Record<string, { email: string; scopeProfile?: string; admin?: boolean }>;
+  scopeProfiles?: Record<string, { bundles: string[]; admin?: boolean }>;
+  defaultAccount?: string;
+  discovery?: 'lazy' | 'curated' | 'eager';
+  toolsets?: string;
+}
+
+export function failStartup(slug: string, message: string): never {
+  process.stderr.write(`${slug}: ${message}\n`);
+  process.exit(1);
+}
+
+export class ConfigFileError extends Error {
+  constructor(
+    public slug: string,
+    message: string,
+  ) {
+    super(`${slug}: ${message}`);
+  }
+}
+
+/**
+ * Load + validate config.json. Returns null when the file does not exist.
+ * onInvalid 'exit' is for boot/CLI only; runtime reload paths use 'throw' so a
+ * mid-edit or corrupt file can NEVER kill a running server (and so lock
+ * finally-cleanup still runs).
+ */
+export function loadConfigFile(
+  filePath = configFilePath(),
+  onInvalid: 'exit' | 'throw' = 'exit',
+): ConfigFile | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw e;
+  }
+  function fail(slug: string, message: string): never {
+    if (onInvalid === 'throw') throw new ConfigFileError(slug, message);
+    failStartup(slug, message);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    fail('E_CONFIG_INVALID', `${filePath} is not valid JSON.`);
+  }
+  const version = (parsed as { version?: unknown })?.version;
+  if (typeof version === 'number' && version > CONFIG_VERSION) {
+    fail(
+      'E_CONFIG_VERSION_UNSUPPORTED',
+      `${filePath} has version ${version}; this build understands up to ${CONFIG_VERSION}. Upgrade mcp-google-multi.`,
+    );
+  }
+  const result = configSchema.safeParse(parsed);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    fail(
+      'E_CONFIG_INVALID',
+      `${filePath}: ${issue.path.join('.') || '(root)'}: ${issue.message}. Secrets never belong in config.json.`,
+    );
+  }
+  // Post-schema because zod's key regex passes these; a __proto__ record key
+  // is a prototype-pollution foothold, not an account.
+  const data = result.data as ConfigFile;
+  const reserved = Object.keys(data.accounts ?? {}).find((k) => RESERVED_ALIASES.includes(k));
+  if (reserved) {
+    fail('E_CONFIG_INVALID', `${filePath}: accounts: reserved alias name "${reserved}".`);
+  }
+  return data;
+}
+
+export function writeConfigFile(config: ConfigFile, filePath = configFilePath()): void {
+  atomicWriteFileSync(filePath, `${JSON.stringify(config, null, 2)}\n`, 0o600);
+}
+
+/**
+ * Read-latest-under-lock mutation: acquire the lock, re-read the current file,
+ * apply the change to that (never a stale in-memory copy), write atomically.
+ */
+export function mutateConfigFile(
+  fn: (current: ConfigFile) => ConfigFile,
+  filePath = configFilePath(),
+): ConfigFile {
+  return withFileLock(
+    filePath,
+    () => {
+      const current = loadConfigFile(filePath, 'throw') ?? { version: CONFIG_VERSION };
+      const next = fn(structuredClone(current));
+      writeConfigFile(next, filePath);
+      return next;
+    },
+    'E_CONFIG_LOCK_TIMEOUT (config.json)',
+  );
+}

--- a/src/fanout.ts
+++ b/src/fanout.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ACCOUNTS } from './accounts.js';
+import { ACCOUNTS, getAccountSet } from './accounts.js';
 
 export const CSV_RE = /^[a-zA-Z0-9_-]+(\s*,\s*[a-zA-Z0-9_-]+)+$/;
 
@@ -16,7 +16,7 @@ export type AccountSelector =
   | { ok: true; fanout: boolean; aliases: string[] }
   | { ok: false; invalid: string[] };
 
-export function parseAccountSelector(value: string, accounts: readonly string[] = ACCOUNTS): AccountSelector {
+export function parseAccountSelector(value: string, accounts: readonly string[] = getAccountSet().aliases): AccountSelector {
   if (value === '*') return { ok: true, fanout: true, aliases: [...accounts] };
   if (!value.includes(',')) return { ok: true, fanout: false, aliases: [value] };
   const seen = new Set<string>();
@@ -34,7 +34,7 @@ export function parseAccountSelector(value: string, accounts: readonly string[] 
   return { ok: true, fanout: aliases.length > 1, aliases };
 }
 
-export function invalidAccountsResult(invalid: string[], accounts: readonly string[] = ACCOUNTS) {
+export function invalidAccountsResult(invalid: string[], accounts: readonly string[] = getAccountSet().aliases) {
   return {
     content: [
       {

--- a/src/fs-atomic.ts
+++ b/src/fs-atomic.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+const LOCK_TIMEOUT_MS = 5_000;
+const LOCK_RETRY_MS = 10;
+const RENAME_ATTEMPTS = 5;
+const RENAME_RETRY_MS = 20;
+
+function sleep(ms: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+// Hardlink-based advisory lock, generalized path-keyed from the token store's
+// alias-keyed original (same mechanics: dead-owner recovery via signal-0 probe,
+// EPERM = alive, corrupt lock content recovered as dead, 5s timeout).
+export function withFileLock<T>(absPath: string, fn: () => T, label = `lock: ${absPath}`): T {
+  const dir = path.dirname(absPath);
+  const lock = path.join(dir, `.${path.basename(absPath)}.lock`);
+  const ownerFile = `${lock}.${process.pid}.${randomBytes(6).toString('hex')}.owner`;
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(ownerFile, String(process.pid), { mode: 0o600, flag: 'wx' });
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+  try {
+    while (true) {
+      try {
+        fs.linkSync(ownerFile, lock);
+        break;
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code !== 'EEXIST') throw error;
+        try {
+          const observedOwner = fs.readFileSync(lock, 'utf8');
+          const owner = Number(observedOwner);
+          let ownerDead = !(Number.isSafeInteger(owner) && owner > 0);
+          if (!ownerDead) {
+            try {
+              process.kill(owner, 0);
+            } catch (ownerError) {
+              const code = (ownerError as NodeJS.ErrnoException).code;
+              // EPERM: PID exists but is not signalable (recycled by another
+              // user); treat as alive, never break a lock we cannot verify.
+              if (code === 'ESRCH') ownerDead = true;
+              else if (code !== 'EPERM') throw ownerError;
+            }
+          }
+          if (ownerDead) {
+            if (fs.readFileSync(lock, 'utf8') === observedOwner) fs.rmSync(lock, { force: true });
+            continue;
+          }
+        } catch (readError) {
+          if ((readError as NodeJS.ErrnoException).code === 'ENOENT') {
+            continue;
+          }
+          throw readError;
+        }
+        if (Date.now() >= deadline) {
+          throw new Error(`Timed out waiting for ${label}`, { cause: error });
+        }
+        sleep(LOCK_RETRY_MS);
+      }
+    }
+  } finally {
+    fs.rmSync(ownerFile, { force: true });
+  }
+
+  try {
+    return fn();
+  } finally {
+    fs.rmSync(lock, { force: true });
+  }
+}
+
+export function atomicWriteFileSync(absPath: string, contents: string, mode = 0o600): void {
+  const dir = path.dirname(absPath);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const tmp = path.join(dir, `.${path.basename(absPath)}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`);
+  try {
+    fs.writeFileSync(tmp, contents, { mode, flag: 'wx' });
+    // Open read-write, not read-only: on Windows fsync maps to
+    // FlushFileBuffers, which returns EPERM on a read-only handle.
+    const fd = fs.openSync(tmp, 'r+');
+    try {
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
+    renameWithRetry(tmp, absPath);
+  } finally {
+    try {
+      fs.rmSync(tmp, { force: true });
+    } catch {
+      // force only suppresses ENOENT; a Windows handle-holder can make this
+      // throw and mask the real write error. The orphan tmp is harmless.
+    }
+  }
+}
+
+// Windows only: renaming over a momentarily-open file throws transient EPERM/EACCES/EBUSY (reads take no lock); see docs/internals.md.
+function renameWithRetry(from: string, to: string): void {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      fs.renameSync(from, to);
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      const transient = code === 'EPERM' || code === 'EACCES' || code === 'EBUSY';
+      if (!transient || attempt >= RENAME_ATTEMPTS) throw error;
+      sleep(RENAME_RETRY_MS * attempt);
+    }
+  }
+}
+
+export function atomicWriteWithLock(absPath: string, contents: string, mode = 0o600): void {
+  withFileLock(absPath, () => atomicWriteFileSync(absPath, contents, mode));
+}

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -1,0 +1,37 @@
+import type { AccountSet } from './accounts.js';
+import { getAccountSet } from './accounts.js';
+import { getClient } from './client.js';
+import { hasToken, readToken, updateToken, writeToken } from './token-store.js';
+import { resolvePolicy, type Policy } from './write-control.js';
+
+/**
+ * The one forward-compat seam (frozen public API): the free core builds
+ * exactly one context with subject "owner"; EE later instantiates N contexts
+ * from N registries. Nothing here may assume a global current-account.
+ */
+export interface IdentityContext {
+  subject: 'owner';
+  accounts: AccountSet;
+  policy: Policy;
+  getClient: typeof getClient;
+  tokenStore: {
+    readToken: typeof readToken;
+    writeToken: typeof writeToken;
+    updateToken: typeof updateToken;
+    hasToken: typeof hasToken;
+  };
+}
+
+export function buildIdentityContext(env: NodeJS.ProcessEnv = process.env): IdentityContext {
+  return {
+    subject: 'owner',
+    // Live getter: the seam must always see the current registry, never a
+    // snapshot pinned from before a wizard mutation or cross-process reload.
+    get accounts() {
+      return getAccountSet();
+    },
+    policy: resolvePolicy(env),
+    getClient,
+    tokenStore: { readToken, writeToken, updateToken, hasToken },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,14 @@ import { registerDiscoverTools } from './discover.js';
 import { registerEscapeTools } from './tools/google-api.js';
 import { registerAccountTools } from './tools/accounts-tool.js';
 import { getToolsets, toolsetEnabled } from './toolsets.js';
-import { resolvePolicy, isAllowed, describePolicy, type Policy } from './write-control.js';
+import { isAllowed, describePolicy } from './write-control.js';
+import { buildIdentityContext, type IdentityContext } from './identity.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'));
 
-function buildRegistry(server: McpServer, policy: Policy): ToolRegistry {
+function buildRegistry(server: McpServer, ctx: IdentityContext): ToolRegistry {
+  const policy = ctx.policy;
   const registry = new ToolRegistry(server, policy);
   const toolsets = getToolsets();
   if (toolsets !== 'all') {
@@ -79,11 +81,18 @@ async function main() {
     return;
   }
 
+  if (process.argv.includes('migrate-config')) {
+    const { runMigrateConfig } = await import('./migrate-config.js');
+    runMigrateConfig();
+    return;
+  }
+
   if (process.argv.includes('config') && process.argv.includes('check')) {
-    const policy = resolvePolicy();
+    const ctx = buildIdentityContext();
+    const policy = ctx.policy;
     const registry = buildRegistry(
       new McpServer({ name: 'mcp-google-multi', version: pkg.version }),
-      policy,
+      ctx,
     );
     const cud = registry.tools.filter((t) => t.cud !== 'read');
     const disabled = cud.filter((t) => !isAllowed(t, policy));
@@ -108,12 +117,12 @@ async function main() {
     return;
   }
 
-  const policy = resolvePolicy();
+  const ctx = buildIdentityContext();
   const server = new McpServer({
     name: 'mcp-google-multi',
     version: pkg.version,
   });
-  const registry = buildRegistry(server, policy);
+  const registry = buildRegistry(server, ctx);
   registry.installListHandler();
 
   const transport = new StdioServerTransport();

--- a/src/migrate-config.ts
+++ b/src/migrate-config.ts
@@ -1,0 +1,75 @@
+import { CONFIG_VERSION, configFilePath, loadConfigFile, mutateConfigFile } from './config-file.js';
+import type { ConfigFile } from './config-file.js';
+
+function parseCsv(value: string | undefined): string[] {
+  return (value ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+}
+
+/**
+ * Synthesize config.json accounts{} from the v5 env (GOOGLE_ACCOUNTS +
+ * GOOGLE_ADMIN_ACCOUNTS). Never deletes or edits env; idempotent (a re-run
+ * that changes nothing says so). Scope-profile and preference fields are
+ * migrated by their own slices' commands.
+ */
+export function runMigrateConfig(env: NodeJS.ProcessEnv = process.env): void {
+  const raw = env.GOOGLE_ACCOUNTS;
+  if (!raw || raw.trim() === '') {
+    console.log('GOOGLE_ACCOUNTS is not set — nothing to migrate.');
+    return;
+  }
+  const adminAliases = parseCsv(env.GOOGLE_ADMIN_ACCOUNTS);
+  const desired: NonNullable<ConfigFile['accounts']> = {};
+  const entries = raw.split(',');
+  for (let i = 0; i < entries.length; i++) {
+    const trimmed = entries[i].trim();
+    if (!trimmed) continue;
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) {
+      console.error(`Skipping GOOGLE_ACCOUNTS entry ${i + 1}: expected alias:email.`);
+      continue;
+    }
+    const alias = trimmed.slice(0, colonIdx).trim();
+    const email = trimmed.slice(colonIdx + 1).trim();
+    if (!alias || !email || !/^[a-zA-Z0-9_-]+$/.test(alias)) {
+      console.error(`Skipping GOOGLE_ACCOUNTS entry ${i + 1}: empty or invalid alias/email.`);
+      continue;
+    }
+    desired[alias] = { email };
+  }
+
+  const filePath = configFilePath(env);
+  const before = loadConfigFile(filePath);
+  // Merge per-alias: env owns the alias set and emails, but file-only fields
+  // (scopeProfile, admin) survive for retained aliases — mirroring runtime
+  // precedence, where unset GOOGLE_ADMIN_ACCOUNTS preserves file admin flags.
+  const existing = before?.accounts ?? {};
+  const dropped = Object.keys(existing).filter((a) => !(a in desired));
+  for (const [alias, entry] of Object.entries(desired)) {
+    const prev = existing[alias];
+    if (prev?.scopeProfile) entry.scopeProfile = prev.scopeProfile;
+    if (adminAliases.length > 0) {
+      if (adminAliases.includes(alias)) entry.admin = true;
+    } else if (prev?.admin) {
+      entry.admin = true;
+    }
+  }
+  const beforeAccounts = JSON.stringify(existing);
+  if (beforeAccounts === JSON.stringify(desired)) {
+    console.log(`${filePath} already matches the environment — nothing to do.`);
+    return;
+  }
+
+  mutateConfigFile((current) => {
+    current.version = current.version || CONFIG_VERSION;
+    current.accounts = desired;
+    return current;
+  }, filePath);
+
+  if (dropped.length > 0) {
+    console.error(`Dropping ${dropped.length} alias(es) present in config.json but absent from GOOGLE_ACCOUNTS.`);
+  }
+  console.log(`Wrote ${filePath}:`);
+  console.log(`  accounts before: ${beforeAccounts}`);
+  console.log(`  accounts after:  ${JSON.stringify(desired)}`);
+  console.log('Environment variables were NOT modified; while GOOGLE_ACCOUNTS is set, env still wins.');
+}

--- a/src/migrate-tokens.ts
+++ b/src/migrate-tokens.ts
@@ -1,12 +1,13 @@
 import fs from 'node:fs';
-import { ACCOUNTS, ACCOUNT_CONFIG } from './accounts.js';
+import { getAccountSet } from './accounts.js';
 import { writeToken, hasToken } from './token-store.js';
 
 export function runMigrateTokens(): void {
   let migrated = 0;
   let skipped = 0;
-  for (const alias of ACCOUNTS) {
-    const plain = ACCOUNT_CONFIG[alias].tokenPath;
+  const { aliases, configs } = getAccountSet();
+  for (const alias of aliases) {
+    const plain = configs[alias].tokenPath;
     if (!fs.existsSync(plain)) continue;
     if (hasToken(alias)) {
       console.log(`• ${alias}: encrypted token already exists, skipping`);

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -1,15 +1,11 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
 import fs from 'node:fs';
-import path from 'node:path';
-import { ACCOUNT_CONFIG } from './accounts.js';
+import { getAccountSet } from './accounts.js';
+import { atomicWriteFileSync, withFileLock } from './fs-atomic.js';
 import type { TokenData } from './types.js';
 
 const ENC_VERSION = 1;
 const ALGO = 'aes-256-gcm';
-const LOCK_TIMEOUT_MS = 5_000;
-const LOCK_RETRY_MS = 10;
-const RENAME_ATTEMPTS = 5;
-const RENAME_RETRY_MS = 20;
 
 interface EncFile {
   v: number;
@@ -65,135 +61,44 @@ function masterKey(): string {
   return process.env.MASTER_KEY ?? '';
 }
 
+function encPath(alias: string): string {
+  return getAccountSet().configs[alias].encPath;
+}
+
 export function readToken(alias: string): TokenData | null {
   let contents: string;
   try {
-    contents = fs.readFileSync(ACCOUNT_CONFIG[alias].encPath, 'utf8');
+    contents = fs.readFileSync(encPath(alias), 'utf8');
   } catch {
     return null;
   }
   return decryptToken(contents, masterKey());
 }
 
-function sleep(ms: number): void {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function withTokenLock<T>(alias: string, fn: () => T): T {
-  const p = ACCOUNT_CONFIG[alias].encPath;
-  const dir = path.dirname(p);
-  const lock = path.join(dir, `.${path.basename(p)}.lock`);
-  const ownerFile = `${lock}.${process.pid}.${randomBytes(6).toString('hex')}.owner`;
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(ownerFile, String(process.pid), { mode: 0o600, flag: 'wx' });
-  const deadline = Date.now() + LOCK_TIMEOUT_MS;
-
-  try {
-    while (true) {
-      try {
-        fs.linkSync(ownerFile, lock);
-        break;
-      } catch (error) {
-        const err = error as NodeJS.ErrnoException;
-        if (err.code !== 'EEXIST') throw error;
-        try {
-          const observedOwner = fs.readFileSync(lock, 'utf8');
-          const owner = Number(observedOwner);
-          // Non-PID content can only come from a corrupt or interrupted lock
-          // write — recover it like a dead owner instead of spinning to timeout.
-          let ownerDead = !(Number.isSafeInteger(owner) && owner > 0);
-          if (!ownerDead) {
-            try {
-              process.kill(owner, 0);
-            } catch (ownerError) {
-              const code = (ownerError as NodeJS.ErrnoException).code;
-              // EPERM: PID exists but is not signalable (recycled by another user);
-              // treat as alive, never break a lock we cannot verify.
-              if (code === 'ESRCH') ownerDead = true;
-              else if (code !== 'EPERM') throw ownerError;
-            }
-          }
-          if (ownerDead) {
-            if (fs.readFileSync(lock, 'utf8') === observedOwner) fs.rmSync(lock, { force: true });
-            continue;
-          }
-        } catch (readError) {
-          if ((readError as NodeJS.ErrnoException).code === 'ENOENT') {
-            continue;
-          }
-          throw readError;
-        }
-        if (Date.now() >= deadline) {
-          throw new Error(`Timed out waiting for token lock: ${alias}`, { cause: error });
-        }
-        sleep(LOCK_RETRY_MS);
-      }
-    }
-  } finally {
-    fs.rmSync(ownerFile, { force: true });
-  }
-
-  try {
-    return fn();
-  } finally {
-    fs.rmSync(lock, { force: true });
-  }
+// Lock + atomic-write mechanics live in fs-atomic.ts (generalized path-keyed
+// from this file's original alias-keyed implementation; behavior unchanged).
+export function writeToken(alias: string, data: object): void {
+  withFileLock(encPath(alias), () => writeTokenAtomic(alias, data), `token lock: ${alias}`);
 }
 
 function writeTokenAtomic(alias: string, data: object): void {
-  const p = ACCOUNT_CONFIG[alias].encPath;
-  const dir = path.dirname(p);
-  const tmp = path.join(dir, `.${path.basename(p)}.${process.pid}.${randomBytes(6).toString('hex')}.tmp`);
-  try {
-    fs.writeFileSync(tmp, encryptToken(data, masterKey()), { mode: 0o600, flag: 'wx' });
-    // Open read-write, not read-only: on Windows fsync maps to FlushFileBuffers,
-    // which returns EPERM on a read-only handle.
-    const fd = fs.openSync(tmp, 'r+');
-    try {
-      fs.fsyncSync(fd);
-    } finally {
-      fs.closeSync(fd);
-    }
-    renameWithRetry(tmp, p);
-  } finally {
-    try {
-      fs.rmSync(tmp, { force: true });
-    } catch {
-      // force only suppresses ENOENT; a Windows handle-holder can make this
-      // throw and mask the real write error. The orphan tmp is harmless.
-    }
-  }
-}
-
-// Windows only: renaming over a momentarily-open file throws transient EPERM/EACCES/EBUSY (reads take no lock); see docs/internals.md.
-function renameWithRetry(from: string, to: string): void {
-  for (let attempt = 1; ; attempt++) {
-    try {
-      fs.renameSync(from, to);
-      return;
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      const transient = code === 'EPERM' || code === 'EACCES' || code === 'EBUSY';
-      if (!transient || attempt >= RENAME_ATTEMPTS) throw error;
-      sleep(RENAME_RETRY_MS * attempt);
-    }
-  }
-}
-
-export function writeToken(alias: string, data: object): void {
-  withTokenLock(alias, () => writeTokenAtomic(alias, data));
+  atomicWriteFileSync(encPath(alias), encryptToken(data, masterKey()), 0o600);
 }
 
 export function updateToken(alias: string, updates: object): void {
-  withTokenLock(alias, () => {
-    const existing = readToken(alias) ?? {};
-    const definedUpdates = Object.fromEntries(
-      Object.entries(updates).filter(([, value]) => value !== null && value !== undefined),
-    );
-    writeTokenAtomic(alias, { ...existing, ...definedUpdates });
-  });
+  withFileLock(
+    encPath(alias),
+    () => {
+      const existing = readToken(alias) ?? {};
+      const definedUpdates = Object.fromEntries(
+        Object.entries(updates).filter(([, value]) => value !== null && value !== undefined),
+      );
+      writeTokenAtomic(alias, { ...existing, ...definedUpdates });
+    },
+    `token lock: ${alias}`,
+  );
 }
 
 export function hasToken(alias: string): boolean {
-  return fs.existsSync(ACCOUNT_CONFIG[alias].encPath);
+  return fs.existsSync(encPath(alias));
 }

--- a/src/tools/accounts-tool.ts
+++ b/src/tools/accounts-tool.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import type { ToolRegistry } from '../registry.js';
-import { ACCOUNTS, ACCOUNT_CONFIG } from '../accounts.js';
+import { getAccountSet, refreshAccountSetIfStale } from '../accounts.js';
 import { getAdminAccounts, resolveScopesForAccount } from '../auth.js';
 import { hasToken, readToken } from '../token-store.js';
 
@@ -24,15 +24,27 @@ export interface AccountHealth {
   alias: string;
   email: string;
   admin: boolean;
+  source: 'config' | 'env';
+  sourceNote?: string;
   token: { status: TokenStatus; expiryDate?: string; hint?: string };
   scopes: { configured: number; granted: number; missing: string[] };
 }
 
 export function deriveAccountHealth(alias: string, deps: AccountHealthDeps = DEFAULT_DEPS): AccountHealth {
-  const config = ACCOUNT_CONFIG[alias];
+  const config = getAccountSet().configs[alias];
   const admin = getAdminAccounts().includes(alias);
   const configured = resolveScopesForAccount(alias);
-  const base = { alias, email: config.email, admin };
+  // BR-10: env-sourced accounts are not persisted in config.json, so the
+  // account wizard cannot edit them — the deployer edits env instead.
+  const base = {
+    alias,
+    email: config.email,
+    admin,
+    source: config.source,
+    ...(config.source === 'env'
+      ? { sourceNote: 'Defined by GOOGLE_ACCOUNTS env (not editable via config.json)' }
+      : {}),
+  };
   const noScopes = { configured: configured.length, granted: 0, missing: configured };
 
   if (!deps.hasToken(alias)) {
@@ -96,13 +108,16 @@ export function registerAccountTools(registry: ToolRegistry, deps: AccountHealth
         'Use this to see which account aliases are available and healthy.',
       inputSchema: {},
     },
-    async () => ({
-      content: [
-        {
-          type: 'text' as const,
-          text: JSON.stringify({ accounts: ACCOUNTS.map((alias) => deriveAccountHealth(alias, deps)) }),
-        },
-      ],
-    }),
+    async () => {
+      refreshAccountSetIfStale();
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ accounts: getAccountSet().aliases.map((alias) => deriveAccountHealth(alias, deps)) }),
+          },
+        ],
+      };
+    },
   );
 }

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -2,7 +2,7 @@ import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean } from './_coerce.js';
 import { drive as driveClient, type drive_v3 } from '@googleapis/drive';
-import { ACCOUNTS, ACCOUNT_CONFIG } from '../accounts.js';
+import { ACCOUNTS, getAccountSet } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
@@ -1340,7 +1340,7 @@ export function registerDriveTools(server: ToolRegistry): void {
           };
         }
         const intendedName = newName ?? meta.data.name ?? 'transferred-file';
-        const targetEmail = ACCOUNT_CONFIG[toAccount as Account].email;
+        const targetEmail = getAccountSet().configs[toAccount as Account].email;
 
         const finish = async (
           data: drive_v3.Schema$File,

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -301,7 +301,7 @@ export function registerGmailTools(server: ToolRegistry): void {
       try {
         const auth = await getClient(account as Account);
         const gmail = gmailClient({ version: 'v1', auth });
-        const config = (await import('../accounts.js')).ACCOUNT_CONFIG[account as Account];
+        const config = (await import('../accounts.js')).getAccountSet().configs[account as Account];
 
         const headers = [
           `From: ${encodeAddressHeader(config.email)}`,
@@ -414,7 +414,7 @@ export function registerGmailTools(server: ToolRegistry): void {
       try {
         const auth = await getClient(account as Account);
         const gmail = gmailClient({ version: 'v1', auth });
-        const config = (await import('../accounts.js')).ACCOUNT_CONFIG[account as Account];
+        const config = (await import('../accounts.js')).getAccountSet().configs[account as Account];
 
         const headers = [
           `From: ${encodeAddressHeader(config.email)}`,

--- a/tests/config-registry.test.ts
+++ b/tests/config-registry.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { resolveAccounts } from '../src/accounts.js';
+import { ConfigFileError } from '../src/config-file.js';
+import { loadConfigFile, mutateConfigFile, CONFIG_VERSION } from '../src/config-file.js';
+import { atomicWriteWithLock, withFileLock } from '../src/fs-atomic.js';
+import { runMigrateConfig } from '../src/migrate-config.js';
+
+let base: string;
+let cfgPath: string;
+
+beforeEach(() => {
+  base = mkdtempSync(path.join(tmpdir(), 'cfgreg-'));
+  cfgPath = path.join(base, 'config.json');
+});
+
+afterEach(() => {
+  rmSync(base, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const spyExit = () => {
+  const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+  const exit = vi.spyOn(process, 'exit').mockImplementation(() => {
+    throw new Error('exit-called');
+  });
+  return { stderr, exit };
+};
+
+describe('resolveAccounts', () => {
+  it('BR-2: non-empty GOOGLE_ACCOUNTS takes the whole registry from env', () => {
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({ version: 1, accounts: { fileacct: { email: 'f@x.com' } } }),
+    );
+    const set = resolveAccounts({ GOOGLE_ACCOUNTS: 'work:w@x.com' } as NodeJS.ProcessEnv, cfgPath);
+    expect(set.source).toBe('env');
+    expect(set.aliases).toEqual(['work']);
+    expect(set.configs.work.source).toBe('env');
+  });
+
+  it('loads the registry from config.json when env is unset', () => {
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({
+        version: 1,
+        accounts: { work: { email: 'w@x.com', scopeProfile: 'base' }, pers: { email: 'p@x.com', admin: true } },
+      }),
+    );
+    const set = resolveAccounts({} as NodeJS.ProcessEnv, cfgPath);
+    expect(set.source).toBe('file');
+    expect(set.aliases).toEqual(['work', 'pers']);
+    expect(set.configs.work.scopeProfile).toBe('base');
+    expect(set.configs.pers.admin).toBe(true);
+    expect(set.configs.work.source).toBe('config');
+    expect(set.configs.work.encPath.endsWith('work.enc')).toBe(true);
+    expect(set.stamp).toMatch(/^1:/);
+  });
+
+  it('GOOGLE_ADMIN_ACCOUNTS env overrides file admin flags when set', () => {
+    writeFileSync(
+      cfgPath,
+      JSON.stringify({ version: 1, accounts: { a: { email: 'a@x.com', admin: true }, b: { email: 'b@x.com' } } }),
+    );
+    const set = resolveAccounts({ GOOGLE_ADMIN_ACCOUNTS: 'b' } as NodeJS.ProcessEnv, cfgPath);
+    expect(set.configs.a.admin).toBe(false);
+    expect(set.configs.b.admin).toBe(true);
+  });
+
+  it('E_NO_ACCOUNTS_CONFIGURED: neither env nor file refuses to start', () => {
+    const { stderr } = spyExit();
+    expect(() => resolveAccounts({} as NodeJS.ProcessEnv, cfgPath)).toThrow('exit-called');
+    expect(String(stderr.mock.calls[0]?.[0])).toContain('E_NO_ACCOUNTS_CONFIGURED');
+    expect(String(stderr.mock.calls[0]?.[0])).toContain('migrate-config');
+  });
+
+  it('first-run shim materializes config.json from env, and only once', () => {
+    const env = { GOOGLE_ACCOUNTS: 'work:w@x.com,ops:o@x.com', GOOGLE_ADMIN_ACCOUNTS: 'ops' } as NodeJS.ProcessEnv;
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    resolveAccounts(env, cfgPath);
+    expect(existsSync(cfgPath)).toBe(true);
+    const written = JSON.parse(readFileSync(cfgPath, 'utf8'));
+    expect(written).toEqual({
+      version: CONFIG_VERSION,
+      accounts: { work: { email: 'w@x.com' }, ops: { email: 'o@x.com', admin: true } },
+    });
+    // 0o600 is ACL-wise a no-op on Windows (mode reads 0o666 there).
+    if (process.platform !== 'win32') expect(statSync(cfgPath).mode & 0o777).toBe(0o600);
+    const mtime = statSync(cfgPath).mtimeMs;
+    resolveAccounts(env, cfgPath);
+    expect(statSync(cfgPath).mtimeMs).toBe(mtime);
+  });
+
+  it('keeps the v5 guards on env entries', () => {
+    expect(() => resolveAccounts({ GOOGLE_ACCOUNTS: 'bad entry' } as NodeJS.ProcessEnv, cfgPath)).toThrow(
+      'Expected format: alias:email',
+    );
+    expect(() => resolveAccounts({ GOOGLE_ACCOUNTS: '../evil:e@x.com' } as NodeJS.ProcessEnv, cfgPath)).toThrow(
+      'Allowed characters',
+    );
+    expect(() => resolveAccounts({ GOOGLE_ACCOUNTS: 'a:1@x.com,a:2@x.com' } as NodeJS.ProcessEnv, cfgPath)).toThrow(
+      'Duplicate alias',
+    );
+  });
+});
+
+describe('loadConfigFile', () => {
+  it('returns null when the file does not exist', () => {
+    expect(loadConfigFile(cfgPath)).toBeNull();
+  });
+
+  it('E_CONFIG_INVALID on malformed JSON', () => {
+    writeFileSync(cfgPath, '{nope');
+    const { stderr } = spyExit();
+    expect(() => loadConfigFile(cfgPath)).toThrow('exit-called');
+    expect(String(stderr.mock.calls[0]?.[0])).toContain('E_CONFIG_INVALID');
+  });
+
+  it('E_CONFIG_INVALID on a secret-shaped or unknown key (strict schema)', () => {
+    writeFileSync(cfgPath, JSON.stringify({ version: 1, clientSecret: 'oops' }));
+    const { stderr } = spyExit();
+    expect(() => loadConfigFile(cfgPath)).toThrow('exit-called');
+    expect(String(stderr.mock.calls[0]?.[0])).toContain('E_CONFIG_INVALID');
+  });
+
+  it('E_CONFIG_INVALID on a path-traversal alias key', () => {
+    writeFileSync(cfgPath, JSON.stringify({ version: 1, accounts: { '../evil': { email: 'e@x.com' } } }));
+    const { stderr } = spyExit();
+    expect(() => loadConfigFile(cfgPath)).toThrow('exit-called');
+    expect(String(stderr.mock.calls[0]?.[0])).toContain('E_CONFIG_INVALID');
+  });
+
+  it('E_CONFIG_VERSION_UNSUPPORTED on a newer schema version', () => {
+    writeFileSync(cfgPath, JSON.stringify({ version: 2, accounts: {} }));
+    const { stderr } = spyExit();
+    expect(() => loadConfigFile(cfgPath)).toThrow('exit-called');
+    expect(String(stderr.mock.calls[0]?.[0])).toContain('E_CONFIG_VERSION_UNSUPPORTED');
+  });
+});
+
+describe('mutateConfigFile', () => {
+  it('applies the mutation to the latest on-disk state, atomically', () => {
+    writeFileSync(cfgPath, JSON.stringify({ version: 1, accounts: { a: { email: 'a@x.com' } } }));
+    mutateConfigFile((c) => {
+      c.accounts = { ...c.accounts, b: { email: 'b@x.com' } };
+      return c;
+    }, cfgPath);
+    const after = loadConfigFile(cfgPath);
+    expect(Object.keys(after?.accounts ?? {})).toEqual(['a', 'b']);
+    if (process.platform !== 'win32') expect(statSync(cfgPath).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe('fs-atomic', () => {
+  it('atomicWriteWithLock writes content with 0600 and leaves no droppings', () => {
+    const p = path.join(base, 'x.json');
+    atomicWriteWithLock(p, 'hello');
+    expect(readFileSync(p, 'utf8')).toBe('hello');
+    if (process.platform !== 'win32') expect(statSync(p).mode & 0o777).toBe(0o600);
+    const leftovers = [
+      ...['.x.json.lock'],
+    ].filter((f) => existsSync(path.join(base, f)));
+    expect(leftovers).toEqual([]);
+  });
+
+  it('recovers a corrupt (non-PID) lock file instead of timing out', () => {
+    const p = path.join(base, 'y.json');
+    writeFileSync(path.join(base, '.y.json.lock'), 'garbage');
+    let ran = false;
+    withFileLock(p, () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+});
+
+describe('reload safety (dispatch path must never exit)', () => {
+  it("onInvalid 'throw' raises ConfigFileError instead of exiting on a corrupt file", () => {
+    writeFileSync(cfgPath, '{mid-edit');
+    const exit = vi.spyOn(process, 'exit');
+    expect(() => resolveAccounts({} as NodeJS.ProcessEnv, cfgPath, 'throw')).toThrow(ConfigFileError);
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("onInvalid 'throw' raises on a deleted/empty registry instead of exiting", () => {
+    const exit = vi.spyOn(process, 'exit');
+    expect(() => resolveAccounts({} as NodeJS.ProcessEnv, cfgPath, 'throw')).toThrow(
+      /E_NO_ACCOUNTS_CONFIGURED/,
+    );
+    expect(exit).not.toHaveBeenCalled();
+  });
+});
+
+describe('runMigrateConfig', () => {
+  it('synthesizes accounts{} with the admin fold and is idempotent', () => {
+    const env = {
+      GOOGLE_ACCOUNTS: 'work:w@x.com,ops:o@x.com',
+      GOOGLE_ADMIN_ACCOUNTS: 'ops',
+      XDG_CONFIG_HOME: base,
+    } as NodeJS.ProcessEnv;
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    runMigrateConfig(env);
+    const p = path.join(base, 'mcp-google-multi', 'config.json');
+    const cfg = JSON.parse(readFileSync(p, 'utf8'));
+    expect(cfg.accounts).toEqual({ work: { email: 'w@x.com' }, ops: { email: 'o@x.com', admin: true } });
+    expect(env.GOOGLE_ACCOUNTS).toBe('work:w@x.com,ops:o@x.com');
+    log.mockClear();
+    runMigrateConfig(env);
+    expect(log.mock.calls.some((c) => String(c[0]).includes('nothing to do'))).toBe(true);
+  });
+
+  it('preserves file-only fields for retained aliases (merge, not replace)', () => {
+    const dir = path.join(base, 'mcp-google-multi');
+    const p = path.join(dir, 'config.json');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      p,
+      JSON.stringify({ version: 1, accounts: { work: { email: 'w@x.com', scopeProfile: 'custom', admin: true } } }),
+    );
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    runMigrateConfig({ GOOGLE_ACCOUNTS: 'work:w@x.com', XDG_CONFIG_HOME: base } as NodeJS.ProcessEnv);
+    const cfg = JSON.parse(readFileSync(p, 'utf8'));
+    expect(cfg.accounts.work).toEqual({ email: 'w@x.com', scopeProfile: 'custom', admin: true });
+    expect(log.mock.calls.some((c) => String(c[0]).includes('nothing to do'))).toBe(true);
+  });
+
+  it('does nothing without GOOGLE_ACCOUNTS', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    runMigrateConfig({ XDG_CONFIG_HOME: base } as NodeJS.ProcessEnv);
+    expect(existsSync(path.join(base, 'mcp-google-multi', 'config.json'))).toBe(false);
+    expect(log.mock.calls.some((c) => String(c[0]).includes('nothing to migrate'))).toBe(true);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,15 @@
-// src/accounts.ts throws at import time if GOOGLE_ACCOUNTS is unset (CI has no .env) — seed a fixture before test imports pull it in.
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+// src/accounts.ts fails at import time if no accounts are configured (CI has
+// no .env) — seed a fixture before test imports pull it in.
 process.env.GOOGLE_ACCOUNTS ||= 'test:test@example.com';
+// Sandbox EVERY module-load filesystem side effect away from the real home:
+// the first-run shim materializes config.json into XDG_CONFIG_HOME, and the
+// env loader reads an .env tier from there.
+process.env.XDG_CONFIG_HOME = mkdtempSync(path.join(tmpdir(), 'mcp-gm-test-xdg-'));
+process.env.TOKEN_STORE_PATH = path.join(process.env.XDG_CONFIG_HOME, 'tokens');
 // ToolRegistry reads GOOGLE_TRIM at construction — pin it so an ambient
 // GOOGLE_TRIM=off in a developer shell can't redden the compaction tests.
 process.env.GOOGLE_TRIM = '';

--- a/tests/token-store.test.ts
+++ b/tests/token-store.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { ACCOUNT_CONFIG } from '../src/accounts.js';
+import { getAccountSet } from '../src/accounts.js';
+const ACCOUNT_CONFIG = getAccountSet().configs;
 import { deriveKey, encryptToken, decryptToken, readToken, writeToken, updateToken } from '../src/token-store.js';
 
 const KEY = 'test-master-key';


### PR DESCRIPTION
First Track-B slice per the §9.3 landing order. The account registry moves from the immutable `GOOGLE_ACCOUNTS` CSV to a mutable, zod-strict `config.json` (the wizard's prerequisite), behind the frozen `IdentityContext` seam so EE later is N contexts, not a rewrite.

- `resolveAccounts()` → `AccountSet` with live `getAccountSet()` accessor + `invalidateAccountSet()`/staleness probe (BR-7, one stat per `getClient`)
- BR-2 precedence: non-empty env = whole registry from env (never merged); `GOOGLE_ADMIN_ACCOUNTS` overrides file admin flags
- `migrate-config` CLI (idempotent, never edits env) + first-run materialization (BC6)
- `fs-atomic.ts`: path-keyed hardlink lock + atomic write generalized from the token store (token API unchanged, all v5 token tests pass)
- `account_list` flags per-account `source` (env-only = not wizard-editable)
- Slugs: `E_NO_ACCOUNTS_CONFIGURED`, `E_CONFIG_INVALID`, `E_CONFIG_VERSION_UNSUPPORTED`, lock timeout
- Scope note: `z.enum` account enums still snapshot at registration; they widen with the wizard slice's registry rebuild (B7), which owns `tools/list_changed` on `account_add`

## Verification
- 392/392 tests (16 new: precedence, guards, shim, version gate, strict-schema secrets rejection, lock recovery, migrate-config idempotence)
- Live smoke on real accounts: env-sourced AND file-sourced `config check` boots, first-run shim materialization, live Gmail call through the new `getClient`
- Found+fixed in review-of-self: the test suite's module-load shim was writing the fixture registry into the real `~/.config` — tests now sandbox `XDG_CONFIG_HOME`
- docs/configuration.md + CLAUDE.md updated with the new surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)