### PR TITLE
feat: MASTER_KEY auto-provisioning with keychain + hard guard [v6 B5]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ server.registerTool(
 
 ## Auth / tokens
 
-- Tokens are **encrypted at rest** — never write plaintext. `MASTER_KEY` is required; it lives only in env (never in the store, never logged).
+- Tokens are **encrypted at rest** — never write plaintext. `MASTER_KEY` resolves ONLY through `resolveMasterKey()` in `src/master-key.ts` (env > keychain > 0600 file > generate; hard guard: never generate while `<alias>.enc` exist). Never read the env var directly, never log key bytes (provenance label only).
 - Always go through `getClient(account)` (handles refresh + re-encrypt). Token files are `0600`.
 - Secret-injection patterns (why `MASTER_KEY` shouldn't live in `.env` long-term): `docs/secrets.md`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,7 @@ Each account can point at a named **scope profile** so consent is exactly what t
 |---|---|---|
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | ✓ | OAuth **Desktop** client from Google Cloud — see [Google Cloud setup](./google-cloud-setup.md) |
 | `GOOGLE_ACCOUNTS` | ✓ | `alias:email,…` — e.g. `work:you@co.com,personal:you@gmail.com` |
-| `MASTER_KEY` | ✓ | base64 32-byte key that encrypts the token store (`openssl rand -base64 32`) |
+| `MASTER_KEY` | | encrypts the token store. Optional since v6: auto-provisioned as env > OS keychain > `master.key` (0600) > generated-on-setup. Keep it in env for deployments that may downgrade or move hosts. Never regenerated while encrypted tokens exist (`E_MASTER_KEY_MISSING_TOKENS_EXIST`) |
 | `GOOGLE_PROFILE` | — | write policy: `read-only` (default) · `safe-writes` · `full-writes` |
 | `GOOGLE_READ_ONLY` | — | `true` = hard kill-switch for all writes |
 | `GOOGLE_WRITE_ALLOW` / `GOOGLE_WRITE_DENY` | — | glob overrides, e.g. `calendar:*`, `*:delete*` (deny wins) |

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,6 +1,6 @@
 # Keep secrets in a vault
 
-A plaintext `.env` is fine to try things out, but for a daily driver, **don't leave `GOOGLE_CLIENT_SECRET` + `MASTER_KEY` on disk** — inject them at launch from a secrets manager. The server just reads `process.env` (it has no idea where the values come from), so wrap it. Back to the [README](../README.md).
+A plaintext `.env` is fine to try things out, but for a daily driver, **don't leave `GOOGLE_CLIENT_SECRET` + `MASTER_KEY` on disk** — inject them at launch from a secrets manager. The server just reads `process.env` (it has no idea where the values come from), so wrap it. Since v6 `MASTER_KEY` auto-provisions when absent (OS keychain, else a 0600 `master.key` file, else generated on first run) — that protects tokens **at rest**, not against same-user malware, exactly like an `.env` did. Back to the [README](../README.md).
 
 Example with [Infisical](https://infisical.com):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@googleapis/tasks": "^13.0.0",
         "@googleapis/webmasters": "^4.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@napi-rs/keyring": "1.3.0",
         "googleapis-common": "^8.0.3",
         "mime-types": "^3.0.2",
         "zod": "^4.3.6"
@@ -44,6 +45,9 @@
       },
       "engines": {
         "node": ">=22"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring": "1.3.0"
       }
     },
     "node_modules/@actions/core": {
@@ -1062,6 +1066,226 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@napi-rs/keyring": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
+      "integrity": "sha512-WrOw/bcXm0f9qHkumlT1QlArXSTWqaY9sunsDpOk+yCCorCKMxvWT/a3xko4EYHVdeZoh00yI2TydXn6eyICDA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/keyring-darwin-arm64": "1.3.0",
+        "@napi-rs/keyring-darwin-x64": "1.3.0",
+        "@napi-rs/keyring-freebsd-x64": "1.3.0",
+        "@napi-rs/keyring-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-arm64-musl": "1.3.0",
+        "@napi-rs/keyring-linux-riscv64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-gnu": "1.3.0",
+        "@napi-rs/keyring-linux-x64-musl": "1.3.0",
+        "@napi-rs/keyring-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/keyring-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-arm64/-/keyring-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-darwin-x64/-/keyring-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-YcJtEV5LA3cvA4z3BurgxH5IhTsW1JfIvcAAcqcecwk06Si9F9NqkxbZVIfDwQ8oRHgaBmT3zZJnLAotCrVahw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-freebsd-x64/-/keyring-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-vlLf31TGhfRAaxLDBhg8b89ss0HHD/lyNmL5F3UjSaz5CUXElsJmKYq9fqA/B+cZKUEUcLHHGhF0I/CqcFdaVw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm-gnueabihf/-/keyring-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-KiWdMMu/Inz/bHHIAGrnF7r54FZDYXuHO6UFF/rhIrshUsxbMG1Rl9lEymNtqqsVo927G0VYcb02FzWQ3iBQRQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-gnu/-/keyring-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-eyKGpY40lm9Jvs1aD294XRH4y7+TlJM0YVAryZeXA6TX0mb4gMkxVXwSQv7MCwgah7raeUd0dKUb4BPAYIgcMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-arm64-musl/-/keyring-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-iIK6JWHXAJqDrEyLY3TmswwloVyt2vj+04TZnew+uSJ9gnDO8EwRbp3/iw3LpWaXiDO7VomGO6y8I0Id8uBZSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-riscv64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-riscv64-gnu/-/keyring-linux-riscv64-gnu-1.3.0.tgz",
+      "integrity": "sha512-/PGqrwn6EwgtK6vccASSXJRfOSP4vN1F4ASsIQ+7MdrK6hNvAJ1FZPrIuD5gGGdxezo3F++To2Wq7DbuGIeuNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-gnu/-/keyring-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-2PDK1WKWTu9lBGq9VvNEkSlQD3O7YwVpmnyN2M3cy4v7NJ/8gDMd9GXv3G+FVXN13uhp4gnnPBS+ScefmEeD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-linux-x64-musl/-/keyring-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-oJ2HkX8YUo46QBkn0pG+HuIKQNqr523q6vBobCn+P95s4C4K6/kLBqHY/1bg5J4ap31DzsznhnFKcfBNBsjCnw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-arm64-msvc/-/keyring-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-tOd3c/uAaeoE4ycVlmAdSvygz0Zt3zdca6Y7gokBeIbaRDWpjDIUOpU3MvML59XAaqyuKGsVVu0F/DZb1lHPmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-ia32-msvc/-/keyring-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-sPSqeAFZMGqP1R++M2JTza7GQJJ/TpCo6JU6Vcd4jnebvOaEDs9b7eipakU1PJdSvhpC2yXMCNRk9gXfrhuwHQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/keyring-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/keyring-win32-x64-msvc/-/keyring-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4DnCWXwDc0HRKwyRlG5y0VhKZW2tNRQfKKfyj6IX/KWfDNyq9hn4n+GL1auyDcOO/v8PwnhmYo2+rOOqCkvvOg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@octokit/auth-token": {

--- a/package.json
+++ b/package.json
@@ -89,5 +89,8 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1",
     "vitest": "^3.2.6"
+  },
+  "optionalDependencies": {
+    "@napi-rs/keyring": "1.3.0"
   }
 }

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -13,6 +13,10 @@ const tokenDir = process.env.TOKEN_STORE_PATH
   ? path.resolve(process.env.TOKEN_STORE_PATH)
   : defaultTokenDir;
 
+export function getTokenDir(): string {
+  return tokenDir;
+}
+
 export interface AccountConfig {
   email: string;
   tokenPath: string;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,6 +5,7 @@ import { randomBytes } from 'node:crypto';
 import { openUrl } from './open-url.js';
 import { ACCOUNTS, getAccountSet } from './accounts.js';
 import { ADMIN_SCOPES, BUNDLE_CATALOG, closestBundle, resolveBundleAliases } from './scope-catalog.js';
+import { resolveMasterKey } from './master-key.js';
 import type { ScopeProfile } from './scope-catalog.js';
 import { writeToken } from './token-store.js';
 
@@ -152,12 +153,9 @@ export async function runAuthFlow(args: string[]): Promise<void> {
   const config = getAccountSet().configs[alias];
   const scopes = resolveScopesForAccount(alias);
 
-  if (!process.env.MASTER_KEY) {
-    console.error(
-      'MASTER_KEY is not set. Generate one (openssl rand -base64 32) and add it to .env before authenticating.',
-    );
-    process.exit(1);
-  }
+  // Auto-provisions on a fresh install (env > keychain > file > generate);
+  // resolves eagerly so a provisioning failure surfaces before the browser opens.
+  resolveMasterKey();
 
   const oauth2Client = new OAuth2Client(
     process.env.GOOGLE_CLIENT_ID,

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,10 +114,17 @@ async function main() {
     console.log(`Services: ${registry.services().join(', ')}`);
     console.log(`Tool surface: ${counts.eager} eager (discover + escape hatch), ${counts.hidden} deferred until discovery`);
     console.log(`Escape hatch: google_api_call CUD verdicts follow profile=${policy.profile} and your allow/deny globs`);
+    const { peekMasterKeyProvenance } = await import('./master-key.js');
+    const prov = peekMasterKeyProvenance();
+    console.log(`MASTER_KEY: ${prov === 'unprovisioned' ? 'unprovisioned (will be generated on first use)' : prov}`);
     return;
   }
 
   const ctx = buildIdentityContext();
+  // Resolve (or provision) the master key BEFORE serving: the hard guard is
+  // specced "fatal at startup", never mid-dispatch.
+  const { resolveMasterKey } = await import('./master-key.js');
+  resolveMasterKey();
   const server = new McpServer({
     name: 'mcp-google-multi',
     version: pkg.version,

--- a/src/master-key.ts
+++ b/src/master-key.ts
@@ -1,0 +1,253 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { createRequire } from 'node:module';
+import { configDir, failStartup } from './config-file.js';
+import { atomicWriteFileSync, withFileLock } from './fs-atomic.js';
+import { getTokenDir } from './accounts.js';
+
+export type KeyProvenance = 'env' | 'keychain' | 'file' | 'generated';
+
+export interface ResolvedKey {
+  key: string;
+  provenance: KeyProvenance;
+}
+
+interface KeychainEntry {
+  get(): string | null;
+  set(value: string): void;
+  del(): void;
+}
+
+export interface KeyDeps {
+  env?: NodeJS.ProcessEnv;
+  dir?: string;
+  keychain?: (account: string) => KeychainEntry | null;
+  hasAnyToken?: () => boolean;
+}
+
+// The keychain is a native optionalDependency: load lazily and synchronously
+// (createRequire — the token store's key read is sync), and treat EVERY
+// failure (no prebuild, native load error, headless Linux without a Secret
+// Service) as "keychain unavailable", falling through to the 0600 file.
+const require_ = createRequire(import.meta.url);
+
+function systemKeychain(account: string): KeychainEntry | null {
+  try {
+    const { Entry } = require_('@napi-rs/keyring') as {
+      Entry: new (service: string, account: string) => {
+        getPassword(): string;
+        setPassword(v: string): void;
+        deletePassword(): void;
+      };
+    };
+    const entry = new Entry('mcp-google-multi', account);
+    return {
+      get: () => {
+        try {
+          return entry.getPassword();
+        } catch {
+          return null;
+        }
+      },
+      set: (value: string) => entry.setPassword(value),
+      del: () => entry.deletePassword(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Default keychain factory, replaceable ONLY for tests: unit tests must never
+// read or write the developer's real OS keyring (the BR-5 mirror once leaked a
+// test fixture key into a real GNOME keyring — never again).
+let keychainFactory: (account: string) => KeychainEntry | null = systemKeychain;
+
+export function __setKeychainFactoryForTest(fn: ((account: string) => KeychainEntry | null) | null): void {
+  keychainFactory = fn ?? systemKeychain;
+}
+
+// Glob the token dir instead of iterating registered aliases: an orphan .enc
+// (alias removed from the registry, or a partial GOOGLE_ACCOUNTS override in
+// one client) must still stop a fresh key from being minted.
+function anyTokenFileExists(): boolean {
+  try {
+    return fs.readdirSync(getTokenDir()).some((f) => f.endsWith('.enc'));
+  } catch {
+    return false;
+  }
+}
+
+function readKeyFile(filePath: string): string | null {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8').trim();
+    if (!raw) return null;
+    try {
+      const mode = fs.statSync(filePath).mode & 0o777;
+      if (process.platform !== 'win32' && (mode & 0o077) !== 0) {
+        process.stderr.write(`WARN: ${filePath} is readable by others (mode ${mode.toString(8)}); chmod 600 it.\n`);
+      }
+    } catch {
+      // stat raced a delete; the read already succeeded.
+    }
+    return raw;
+  } catch {
+    return null;
+  }
+}
+
+function resolveKey(
+  envName: 'MASTER_KEY' | 'MCP_JWT_KEY',
+  fileName: string,
+  hardGuard: boolean,
+  deps: KeyDeps,
+  onFail: 'exit' | 'throw' = 'exit',
+): ResolvedKey {
+  const env = deps.env ?? process.env;
+  const dir = deps.dir ?? configDir();
+  const keychain = deps.keychain ?? keychainFactory;
+  const hasAnyToken = deps.hasAnyToken ?? anyTokenFileExists;
+
+  const fail = (slug: string, message: string): never => {
+    if (onFail === 'throw') throw new Error(`${slug}: ${message}`);
+    failStartup(slug, message);
+  };
+
+  const fromEnv = env[envName]?.trim();
+  if (fromEnv) return { key: fromEnv, provenance: 'env' };
+
+  const entry = keychain(envName);
+  const fromKeychain = entry?.get();
+  if (fromKeychain) return { key: fromKeychain, provenance: 'keychain' };
+
+  const filePath = path.join(dir, fileName);
+  const fromFile = readKeyFile(filePath);
+  if (fromFile) return { key: fromFile, provenance: 'file' };
+
+  // Generate-on-setup. The hard guard is cc-security Cgen: minting a fresh
+  // MASTER_KEY while <alias>.enc files exist would silently brick them all.
+  if (hardGuard && hasAnyToken()) {
+    fail(
+      'E_MASTER_KEY_MISSING_TOKENS_EXIST',
+      `no ${envName} found in env, keychain or ${filePath}, but encrypted tokens exist under ${getTokenDir()}. ` +
+        'Restore the original key, or delete those .enc files and re-auth each account.',
+    );
+  }
+
+  // Lock the generate critical section so two concurrent first-boots cannot
+  // both mint (the loser re-reads the winner's key under the lock).
+  return withFileLock(
+    filePath,
+    () => {
+      const racedKeychain = keychain(envName)?.get();
+      if (racedKeychain) return { key: racedKeychain, provenance: 'keychain' as const };
+      const racedFile = readKeyFile(filePath);
+      if (racedFile) return { key: racedFile, provenance: 'file' as const };
+
+      // Exactly randomBytes(32) base64: hits deriveKey's 32-byte fast path.
+      const generated = randomBytes(32).toString('base64');
+
+      // The 0600 file is ALWAYS written: on Linux the "keychain" can be the
+      // kernel keyutils keyring, which does not survive a reboot — a key that
+      // lives only there bricks every token at the next boot. The file is the
+      // durable sink; byte-exact read-back gates any use of the key.
+      atomicWriteFileSync(filePath, `${generated}\n`, 0o600);
+      if (readKeyFile(filePath) !== generated) {
+        fail(
+          'E_KEY_PROVISIONING_FAILED',
+          `generated ${envName} could not be read back byte-exact from ${filePath}; refusing to encrypt anything with an unverified key.`,
+        );
+      }
+
+      // Keychain copy is best-effort QoL; a mismatched read-back would SHADOW
+      // the file on the next boot (keychain > file), so clean it up.
+      let keychainNote = '';
+      try {
+        if (entry) {
+          entry.set(generated);
+          if (keychain(envName)?.get() === generated) {
+            keychainNote = ' and the OS keychain (service mcp-google-multi)';
+          } else {
+            try {
+              entry.del();
+            } catch {
+              process.stderr.write(`WARN: OS keychain holds a mismatched ${envName} entry; the ${fileName} file is authoritative.\n`);
+            }
+          }
+        }
+      } catch {
+        // Keychain unavailable; the file already has the key.
+      }
+      process.stderr.write(`Generated ${envName}: stored at ${filePath} (0600)${keychainNote}.\n`);
+      return { key: generated, provenance: 'generated' as const };
+    },
+    `${envName} provisioning`,
+  );
+}
+
+let cachedMaster: ResolvedKey | null = null;
+let cachedJwt: ResolvedKey | null = null;
+
+/** BR-1 single choke point: no other module may read the env vars directly.
+ * Boot/CLI form: failures exit with a clean stderr slug ("fatal at startup"). */
+export function resolveMasterKey(deps?: KeyDeps): ResolvedKey {
+  if (deps) return resolveKey('MASTER_KEY', 'master.key', true, deps);
+  cachedMaster ??= resolveKey('MASTER_KEY', 'master.key', true, {});
+  return cachedMaster;
+}
+
+/** Dispatch form: identical resolution, but failures THROW (caught by the tool
+ * handler into an error envelope) — a live server is never process.exit'd. */
+export function resolveMasterKeyForDispatch(): ResolvedKey {
+  cachedMaster ??= resolveKey('MASTER_KEY', 'master.key', true, {}, 'throw');
+  return cachedMaster;
+}
+
+/** Side-effect-free provenance probe for diagnostics: NEVER generates, never
+ * fires the hard guard (config check must not mint keys or exit). */
+export function peekMasterKeyProvenance(deps?: KeyDeps): KeyProvenance | 'unprovisioned' {
+  const env = deps?.env ?? process.env;
+  if (env.MASTER_KEY?.trim()) return 'env';
+  const keychain = deps?.keychain ?? keychainFactory;
+  if (keychain('MASTER_KEY')?.get()) return 'keychain';
+  const dir = deps?.dir ?? configDir();
+  if (readKeyFile(path.join(dir, 'master.key'))) return 'file';
+  return 'unprovisioned';
+}
+
+/** MCP_JWT_KEY variant: NO hard guard — regenerating only invalidates
+ * outstanding MCP tokens and clients re-auth silently. */
+export function resolveJwtKey(deps?: KeyDeps): ResolvedKey {
+  if (deps) return resolveKey('MCP_JWT_KEY', 'mcp-jwt.key', false, deps);
+  cachedJwt ??= resolveKey('MCP_JWT_KEY', 'mcp-jwt.key', false, {});
+  return cachedJwt;
+}
+
+let mirrored = false;
+
+/**
+ * BR-5: after the FIRST successful token decrypt with an env-sourced key,
+ * mirror it into the keychain (only when the keychain holds no entry) so the
+ * key survives an env loss. Gating on a successful decrypt means a stale or
+ * wrong env key is never mirrored. Best-effort: failures are doctor material,
+ * never fatal.
+ */
+export function noteSuccessfulDecrypt(): void {
+  if (mirrored) return;
+  mirrored = true;
+  try {
+    if (cachedMaster?.provenance !== 'env') return;
+    const entry = keychainFactory('MASTER_KEY');
+    if (!entry || entry.get()) return;
+    entry.set(cachedMaster.key);
+  } catch {
+    // Keychain backend unavailable; env stays the working source.
+  }
+}
+
+/** Test hook: the production cache is process-lifetime by design. */
+export function clearKeyCacheForTest(): void {
+  cachedMaster = null;
+  cachedJwt = null;
+  mirrored = false;
+}

--- a/src/token-store.ts
+++ b/src/token-store.ts
@@ -1,6 +1,7 @@
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
 import fs from 'node:fs';
 import { getAccountSet } from './accounts.js';
+import { noteSuccessfulDecrypt, resolveMasterKeyForDispatch } from './master-key.js';
 import { atomicWriteFileSync, withFileLock } from './fs-atomic.js';
 import type { TokenData } from './types.js';
 
@@ -14,6 +15,10 @@ interface EncFile {
   data: string;
 }
 
+// KDF is COMPAT-FROZEN: generated keys are randomBytes(32) base64 and take the
+// raw path; only human-passphrase keys hit the bare-sha256 branch (v5 legacy —
+// changing it would brick every existing token). HKDF + ENC_VERSION=2 is the
+// sanctioned post-6.0 hardening route.
 export function deriveKey(masterKey: string): Buffer {
   if (!masterKey) {
     throw new Error(
@@ -58,7 +63,7 @@ export function decryptToken(fileContents: string, masterKey: string): TokenData
 }
 
 function masterKey(): string {
-  return process.env.MASTER_KEY ?? '';
+  return resolveMasterKeyForDispatch().key;
 }
 
 function encPath(alias: string): string {
@@ -72,7 +77,9 @@ export function readToken(alias: string): TokenData | null {
   } catch {
     return null;
   }
-  return decryptToken(contents, masterKey());
+  const data = decryptToken(contents, masterKey());
+  noteSuccessfulDecrypt();
+  return data;
 }
 
 // Lock + atomic-write mechanics live in fs-atomic.ts (generalized path-keyed

--- a/tests/master-key.test.ts
+++ b/tests/master-key.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync, statSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { resolveMasterKey, resolveJwtKey, peekMasterKeyProvenance, clearKeyCacheForTest, noteSuccessfulDecrypt, __setKeychainFactoryForTest } from '../src/master-key.js';
+
+let dir: string;
+
+const fakeKeychain = (store: Map<string, string>, available = true) =>
+  (account: string) =>
+    available
+      ? {
+          get: () => store.get(account) ?? null,
+          set: (v: string) => void store.set(account, v),
+          del: () => void store.delete(account),
+        }
+      : null;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'mkey-'));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('resolveMasterKey precedence (BR-2)', () => {
+  it('env wins over keychain and file, trimmed', () => {
+    const store = new Map([['MASTER_KEY', 'from-keychain']]);
+    writeFileSync(path.join(dir, 'master.key'), 'from-file\n');
+    const r = resolveMasterKey({
+      env: { MASTER_KEY: '  from-env  ' } as NodeJS.ProcessEnv,
+      dir,
+      keychain: fakeKeychain(store),
+      hasAnyToken: () => false,
+    });
+    expect(r).toEqual({ key: 'from-env', provenance: 'env' });
+  });
+
+  it('keychain beats file', () => {
+    const store = new Map([['MASTER_KEY', 'from-keychain']]);
+    writeFileSync(path.join(dir, 'master.key'), 'from-file\n');
+    const r = resolveMasterKey({ env: {} as NodeJS.ProcessEnv, dir, keychain: fakeKeychain(store), hasAnyToken: () => false });
+    expect(r).toEqual({ key: 'from-keychain', provenance: 'keychain' });
+  });
+
+  it('file is the fallback when the keychain backend is unavailable', () => {
+    writeFileSync(path.join(dir, 'master.key'), 'from-file\n', { mode: 0o600 });
+    const r = resolveMasterKey({
+      env: {} as NodeJS.ProcessEnv,
+      dir,
+      keychain: fakeKeychain(new Map(), false),
+      hasAnyToken: () => false,
+    });
+    expect(r).toEqual({ key: 'from-file', provenance: 'file' });
+  });
+
+  it.skipIf(process.platform === 'win32')('warns when the key file is readable by others', () => {
+    const p = path.join(dir, 'master.key');
+    writeFileSync(p, 'k\n');
+    chmodSync(p, 0o644);
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    resolveMasterKey({ env: {} as NodeJS.ProcessEnv, dir, keychain: fakeKeychain(new Map(), false), hasAnyToken: () => false });
+    expect(stderr.mock.calls.some((c) => String(c[0]).includes('chmod 600'))).toBe(true);
+  });
+});
+
+describe('generate-on-setup (BR-4)', () => {
+  it('generates a 32-byte base64 key, ALWAYS writes the durable file, and copies to the keychain', () => {
+    const store = new Map<string, string>();
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const r = resolveMasterKey({ env: {} as NodeJS.ProcessEnv, dir, keychain: fakeKeychain(store), hasAnyToken: () => false });
+    expect(r.provenance).toBe('generated');
+    expect(Buffer.from(r.key, 'base64')).toHaveLength(32);
+    expect(store.get('MASTER_KEY')).toBe(r.key);
+    // The kernel-keyutils "keychain" on Linux is volatile: the 0600 file is
+    // the durable sink and must exist even when the keychain write succeeded.
+    expect(readFileSync(path.join(dir, 'master.key'), 'utf8').trim()).toBe(r.key);
+    expect(stderr.mock.calls.some((c) => String(c[0]).includes('master.key'))).toBe(true);
+  });
+
+  it('falls back to a 0600 file when the keychain is unavailable', () => {
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const r = resolveMasterKey({
+      env: {} as NodeJS.ProcessEnv,
+      dir,
+      keychain: fakeKeychain(new Map(), false),
+      hasAnyToken: () => false,
+    });
+    expect(r.provenance).toBe('generated');
+    const p = path.join(dir, 'master.key');
+    expect(readFileSync(p, 'utf8').trim()).toBe(r.key);
+    if (process.platform !== 'win32') expect(statSync(p).mode & 0o777).toBe(0o600);
+  });
+
+  it('removes a keychain entry that does not read back byte-exact (it would shadow the file)', () => {
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    let wrote = false;
+    let deleted = false;
+    const lying = {
+      get: () => (wrote && !deleted ? 'tampered' : null),
+      set: () => {
+        wrote = true;
+      },
+      del: () => {
+        deleted = true;
+      },
+    };
+    const r = resolveMasterKey({
+      env: {} as NodeJS.ProcessEnv,
+      dir,
+      keychain: () => lying,
+      hasAnyToken: () => false,
+    });
+    expect(r.provenance).toBe('generated');
+    expect(readFileSync(path.join(dir, 'master.key'), 'utf8').trim()).toBe(r.key);
+    expect(deleted).toBe(true);
+  });
+});
+
+describe('peekMasterKeyProvenance (diagnostics must be side-effect free)', () => {
+  it('never generates: keyless install reports unprovisioned and mints nothing', () => {
+    const store = new Map<string, string>();
+    const prov = peekMasterKeyProvenance({ env: {} as NodeJS.ProcessEnv, dir, keychain: fakeKeychain(store) });
+    expect(prov).toBe('unprovisioned');
+    expect(store.size).toBe(0);
+    expect(existsSync(path.join(dir, 'master.key'))).toBe(false);
+  });
+
+  it('reports the source without touching it', () => {
+    writeFileSync(path.join(dir, 'master.key'), 'k\n', { mode: 0o600 });
+    expect(
+      peekMasterKeyProvenance({ env: {} as NodeJS.ProcessEnv, dir, keychain: fakeKeychain(new Map(), false) }),
+    ).toBe('file');
+  });
+});
+
+describe('BR-5 mirror (the path that once leaked a fixture key into a real keyring)', () => {
+  afterEach(() => {
+    clearKeyCacheForTest();
+    __setKeychainFactoryForTest(null);
+  });
+
+  it('mirrors an env-sourced key into an empty keychain only after a successful decrypt', () => {
+    const store = new Map<string, string>();
+    __setKeychainFactoryForTest(fakeKeychain(store));
+    clearKeyCacheForTest();
+    const saved = process.env.MASTER_KEY;
+    process.env.MASTER_KEY = 'env-key-value';
+    try {
+      resolveMasterKey({ env: process.env, dir, keychain: fakeKeychain(store), hasAnyToken: () => false });
+      // deps form does not cache; resolve via production path to set the cache
+      clearKeyCacheForTest();
+      resolveMasterKeyProduction();
+      expect(store.has('MASTER_KEY')).toBe(false);
+      noteSuccessfulDecrypt();
+      expect(store.get('MASTER_KEY')).toBe('env-key-value');
+    } finally {
+      if (saved === undefined) delete process.env.MASTER_KEY;
+      else process.env.MASTER_KEY = saved;
+    }
+  });
+
+  it('never overwrites an existing keychain entry', () => {
+    const store = new Map<string, string>([['MASTER_KEY', 'existing']]);
+    __setKeychainFactoryForTest(fakeKeychain(store));
+    clearKeyCacheForTest();
+    const saved = process.env.MASTER_KEY;
+    process.env.MASTER_KEY = 'env-key-value';
+    try {
+      resolveMasterKeyProduction();
+      noteSuccessfulDecrypt();
+      expect(store.get('MASTER_KEY')).toBe('existing');
+    } finally {
+      if (saved === undefined) delete process.env.MASTER_KEY;
+      else process.env.MASTER_KEY = saved;
+    }
+  });
+});
+
+function resolveMasterKeyProduction() {
+  return resolveMasterKey();
+}
+
+describe('dispatch path never exits the process', () => {
+  it('resolveMasterKeyForDispatch with tokens present and no key THROWS, never exits', async () => {
+    const { resolveMasterKeyForDispatch } = await import('../src/master-key.js');
+    __setKeychainFactoryForTest(fakeKeychain(new Map(), false));
+    clearKeyCacheForTest();
+    const saved = process.env.MASTER_KEY;
+    delete process.env.MASTER_KEY;
+    const exit = vi.spyOn(process, 'exit');
+    try {
+      const { mkdirSync } = await import('node:fs');
+      const tokenDir = process.env.TOKEN_STORE_PATH!;
+      mkdirSync(tokenDir, { recursive: true });
+      writeFileSync(path.join(tokenDir, 'ghost.enc'), '{}');
+      expect(() => resolveMasterKeyForDispatch()).toThrow(/E_MASTER_KEY_MISSING_TOKENS_EXIST/);
+      expect(exit).not.toHaveBeenCalled();
+      rmSync(path.join(tokenDir, 'ghost.enc'), { force: true });
+    } finally {
+      if (saved === undefined) delete process.env.MASTER_KEY;
+      else process.env.MASTER_KEY = saved;
+      clearKeyCacheForTest();
+      __setKeychainFactoryForTest(null);
+    }
+  });
+});
+
+describe('hard guard (BR-3)', () => {
+  it('never generates while encrypted tokens exist: E_MASTER_KEY_MISSING_TOKENS_EXIST', () => {
+    const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const exit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('exit-called');
+    });
+    expect(() =>
+      resolveMasterKey({ env: {} as NodeJS.ProcessEnv, dir, keychain: fakeKeychain(new Map(), false), hasAnyToken: () => true }),
+    ).toThrow('exit-called');
+    expect(exit).toHaveBeenCalledWith(1);
+    expect(String(stderr.mock.calls[0]?.[0])).toContain('E_MASTER_KEY_MISSING_TOKENS_EXIST');
+    expect(existsSync(path.join(dir, 'master.key'))).toBe(false);
+  });
+
+  it('MCP_JWT_KEY has no hard guard: generates freely with tokens present', () => {
+    vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const r = resolveJwtKey({ env: {} as NodeJS.ProcessEnv, dir, keychain: fakeKeychain(new Map(), false), hasAnyToken: () => true });
+    expect(r.provenance).toBe('generated');
+    expect(readFileSync(path.join(dir, 'mcp-jwt.key'), 'utf8').trim()).toBe(r.key);
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,6 +10,16 @@ process.env.GOOGLE_ACCOUNTS ||= 'test:test@example.com';
 // env loader reads an .env tier from there.
 process.env.XDG_CONFIG_HOME = mkdtempSync(path.join(tmpdir(), 'mcp-gm-test-xdg-'));
 process.env.TOKEN_STORE_PATH = path.join(process.env.XDG_CONFIG_HOME, 'tokens');
+
+// The OS keyring is real state on a developer machine: stub it process-wide so
+// no test (or the BR-5 env->keychain mirror) can ever touch it.
+const { __setKeychainFactoryForTest } = await import('../src/master-key.js');
+const fakeKeyringStore = new Map<string, string>();
+__setKeychainFactoryForTest((account) => ({
+  get: () => fakeKeyringStore.get(account) ?? null,
+  set: (v: string) => void fakeKeyringStore.set(account, v),
+  del: () => void fakeKeyringStore.delete(account),
+}));
 // ToolRegistry reads GOOGLE_TRIM at construction — pin it so an ambient
 // GOOGLE_TRIM=off in a developer shell can't redden the compaction tests.
 process.env.GOOGLE_TRIM = '';

--- a/tests/token-store.test.ts
+++ b/tests/token-store.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { getAccountSet } from '../src/accounts.js';
+import { clearKeyCacheForTest } from '../src/master-key.js';
 const ACCOUNT_CONFIG = getAccountSet().configs;
+// masterKey() caches process-lifetime; without this, per-test env mutations
+// would be inert and the suite green only by shared-constant luck.
+beforeEach(() => clearKeyCacheForTest());
 import { deriveKey, encryptToken, decryptToken, readToken, writeToken, updateToken } from '../src/token-store.js';
 
 const KEY = 'test-master-key';


### PR DESCRIPTION
B5 per the §9.3 landing order: kills the "first terminal hurdle" (`openssl rand -base64 32`) without ever risking a token brick.

- `resolveMasterKey()` single choke point: **env > OS keychain > 0600 `master.key` > generate-on-setup**, provenance tracked (`config check` prints it; never key bytes)
- `@napi-rs/keyring@1.3.0` as **optionalDependency**, lazy sync load, every failure = fall through to the 0600 file (headless Linux without Secret Service uses the kernel keyutils backend — verified live)
- Generation: exactly `randomBytes(32)` base64, under the file lock (no concurrent double-mint), persist-then-read-back **byte-exact assert** before anything encrypts (BR-4)
- **Hard guard (BR-3/Cgen)**: with any `<alias>.enc` present and no key recoverable → `E_MASTER_KEY_MISSING_TOKENS_EXIST`, never a silent regenerate-and-brick
- BR-5 mirror: an env key is copied into the keychain only **after the first successful decrypt** (stale/wrong keys never mirrored)
- `resolveJwtKey()` sibling ships now for B13 (no hard guard)
- v5 parity: env key stays precedence #1; zero migration

## Verification
- 416/416 tests (13 new: precedence, trim, perms warning, generate→keychain/file, lying-sink round-trip fallback, hard guard, JWT no-guard)
- Live smokes: provenance `env` on the real setup; generate-on-fresh-sandbox verified; second boot re-reads the persisted key
- Found+fixed during smoke: the BR-5 mirror wrote the **test fixture key into the real GNOME keyring** during `npm test` (dozens of duplicate entries from racing vitest workers) — tests now stub the keychain factory process-wide, and the polluted entries were purged

🤖 Generated with [Claude Code](https://claude.com/claude-code)