### PR TITLE
feat: granted-aware scope observability (#114 three-state) [v6 B3]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Conventions for AI assistants modifying this codebase. v5 is **local, stdio, use
 - `src/migrate-config.ts` — `migrate-config` CLI: env -> `config.json` accounts (idempotent, never edits env).
 - `src/tools/_errors.ts` — `mapGoogleError` typed taxonomy + `handleGoogleApiError` result wrapper; each service file defines its own `handle<Service>Error` shim over it (optionally with a service-specific 403 hint).
 - `src/tools/_coerce.ts` — `coerceArray`/`coerceJson`/`coerceBoolean` for string-encoded client args.
+- `src/scope-observability.ts` — the #114 three-state classifier (callable / requestable_not_granted / not_requestable{add_bundle|account_type|unknown_scope}): joins a method's required scopes (escape hatch: runtime Discovery; generated tools: baked+interned at gen time on `ApiMethodRef.scopes`) against the account's GRANTED token scopes, enriches `insufficient_scope` hints with copy-pasteable remediation and an honest `retriable`. `account_list`'s scopes block is the compact profile∪granted report; the registered-tool universe is doctor's (B9).
 
 ## Adding a tool
 

--- a/scripts/gen-tools.ts
+++ b/scripts/gen-tools.ts
@@ -165,9 +165,42 @@ function emitShapeField(field: string, zod: string): string {
 
 export function emitService(doc: DiscoveryDocJson, api: GenApi, alreadyEmitted: Set<string> = new Set()): { fileText: string; report: ServiceReport; names: string[] } {
   const { plans, report } = planTools(doc, api, alreadyEmitted);
+
+  // Baked + INTERNED scope sets (#114): tools sharing a scope set share one
+  // frozen array. Keys sorted for deterministic regen diffs.
+  const scopeSetIndex = new Map<string, number>();
+  const scopeSets: string[][] = [];
+  for (const plan of plans) {
+    const sorted = [...new Set(plan.method.scopes ?? [])].sort();
+    if (sorted.length === 0) continue;
+    const key = sorted.join(' ');
+    if (!scopeSetIndex.has(key)) {
+      scopeSetIndex.set(key, scopeSets.length);
+      scopeSets.push(sorted);
+    }
+  }
+
+  // Bodies from multiple Discovery docs merge into one service file
+  // (buildServiceFile slices between the outer braces), so the interned table
+  // lives INSIDE the body under a per-doc unique name.
+  const tableName = `S_${api.file.replace(/\.json$/, '')}`.replace(/[^a-zA-Z0-9_]/g, '_');
   const lines: string[] = [
     `export function register${api.service[0].toUpperCase()}${api.service.slice(1)}GeneratedTools(registry: ToolRegistry): void {`,
+    ...(scopeSets.length > 0
+      ? [
+          '  // Interned method scope sets (shared across tools; see scope-observability).',
+          `  const ${tableName}: readonly (readonly string[])[] = [`,
+          ...scopeSets.map((set) => `    ${JSON.stringify(set)},`),
+          '  ];',
+        ]
+      : []),
   ];
+
+  const scopeRef = (m: DiscoveryMethod): string => {
+    const sorted = [...new Set(m.scopes ?? [])].sort();
+    if (sorted.length === 0) return '';
+    return `, scopes: ${tableName}[${scopeSetIndex.get(sorted.join(' '))}]`;
+  };
 
   for (const plan of plans) {
     const m = plan.method;
@@ -194,7 +227,7 @@ export function emitService(doc: DiscoveryDocJson, api: GenApi, alreadyEmitted: 
       `    name: ${stringLiteral(plan.name)},`,
       `    cud: ${stringLiteral(plan.cud)},`,
       `    description: ${stringLiteral(plan.description)},`,
-      `    method: { id: ${stringLiteral(m.id)}, httpMethod: ${stringLiteral(m.httpMethod)}, path: ${stringLiteral(m.path)}, baseUrl: ${stringLiteral(m.baseUrl)}, requiredParams: ${JSON.stringify(m.requiredParams)} },`,
+      `    method: { id: ${stringLiteral(m.id)}, httpMethod: ${stringLiteral(m.httpMethod)}, path: ${stringLiteral(m.path)}, baseUrl: ${stringLiteral(m.baseUrl)}, requiredParams: ${JSON.stringify(m.requiredParams)}${scopeRef(m)} },`,
       `    params: ${JSON.stringify(paramEntries)},`,
       `    hasBody: ${plan.bodyRef ? 'true' : 'false'},`,
       '    shape: {',

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -2,6 +2,7 @@ import type { Account } from './accounts.js';
 import { getClient } from './client.js';
 import { expandPath, isGoogleApiUrl } from './discovery-client.js';
 import { handleGoogleApiError } from './tools/_errors.js';
+import { scopeHintForMethod } from './scope-observability.js';
 
 export const MAX_RESPONSE_CHARS = 100_000;
 
@@ -14,6 +15,8 @@ export interface ApiMethodRef {
   path: string;
   baseUrl: string;
   requiredParams: string[];
+  /** Escape hatch: from runtime Discovery. Generated tools: baked at gen time. */
+  scopes?: readonly string[];
 }
 
 export interface ExecuteDeps {
@@ -130,6 +133,8 @@ export async function executeApiMethod(method: ApiMethodRef, args: ExecuteArgs, 
     }
     return { content: [{ type: 'text' as const, text }] };
   } catch (error) {
-    return handleGoogleApiError(error, args.account as Account);
+    return handleGoogleApiError(error, args.account as Account, undefined, () =>
+      method.scopes?.length ? scopeHintForMethod(method.scopes, args.account) : null,
+    );
   }
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -15,6 +15,9 @@ export interface ToolEntry {
   inputShape: z.ZodRawShape;
   annotations: Record<string, unknown>;
   meta: boolean;
+  /** Baked per-method scopes (generated tools); curated tools authorize at
+   * service/bundle grain and leave this undefined. */
+  requiredScopes?: readonly string[];
 }
 
 export interface CatalogOperation {
@@ -31,6 +34,7 @@ interface ToolConfig {
   // Set only by generated tools (cud from HTTP semantics at gen time): open-ended
   // Discovery verbs (undeploy, wipeout, …) would slip past name-based write-control.
   cud?: Cud;
+  requiredScopes?: readonly string[];
 }
 
 const CUD_OVERRIDES: Record<string, Cud> = {
@@ -110,6 +114,7 @@ export class ToolRegistry {
         inputShape,
         annotations,
         meta: this.registeringMeta,
+        requiredScopes: config.requiredScopes,
       });
       const guarded =
         cud === 'read'

--- a/src/scope-observability.ts
+++ b/src/scope-observability.ts
@@ -1,0 +1,247 @@
+import { ADMIN_SCOPES, BUNDLE_CATALOG } from './scope-catalog.js';
+import { BASE_SCOPES, resolveScopesForAccount } from './auth.js';
+import { readToken } from './token-store.js';
+
+// The #114 three-state model: what action, if any, reaches a granted state.
+export type ScopeState = 'callable' | 'requestable_not_granted' | 'not_requestable';
+export type NotRequestableReason = 'add_bundle' | 'account_type' | 'unknown_scope';
+
+export interface ScopeClassification {
+  state: ScopeState;
+  reason?: NotRequestableReason;
+  bundle?: string;
+  alsoIn?: string[];
+}
+
+// Reverse index scope -> bundles offering it, narrowest bundle first (fewest
+// scopes) so the remediation names the smallest grant. BASE_SCOPES map to the
+// pseudo-bundle "base" (outside a profile only via includesBase:false).
+let reverseIndex: Map<string, string[]> | null = null;
+
+function scopeIndex(): Map<string, string[]> {
+  if (reverseIndex) return reverseIndex;
+  const idx = new Map<string, string[]>();
+  const add = (scope: string, bundle: string) => {
+    const list = idx.get(scope) ?? [];
+    list.push(bundle);
+    idx.set(scope, list);
+  };
+  for (const [name, entry] of Object.entries(BUNDLE_CATALOG)) {
+    for (const scope of entry.scopes) add(scope, name);
+  }
+  for (const scope of BASE_SCOPES) add(scope, 'base');
+  const size = (b: string) => (b === 'base' ? BASE_SCOPES.length : BUNDLE_CATALOG[b].scopes.length);
+  for (const list of idx.values()) list.sort((a, b) => size(a) - size(b) || a.localeCompare(b));
+  reverseIndex = idx;
+  return idx;
+}
+
+export function classifyScope(scope: string, granted: ReadonlySet<string>, profile: ReadonlySet<string>): ScopeClassification {
+  if (granted.has(scope)) return { state: 'callable' };
+  if (profile.has(scope)) return { state: 'requestable_not_granted' };
+  const bundles = scopeIndex().get(scope);
+  if (bundles && bundles.length > 0) {
+    return {
+      state: 'not_requestable',
+      reason: 'add_bundle',
+      bundle: bundles[0],
+      ...(bundles.length > 1 ? { alsoIn: bundles.slice(1) } : {}),
+    };
+  }
+  return { state: 'not_requestable', reason: 'unknown_scope' };
+}
+
+const STATE_ORDER: Record<ScopeState, number> = {
+  callable: 0,
+  requestable_not_granted: 1,
+  not_requestable: 2,
+};
+
+export interface MethodScopeClassification {
+  state: ScopeState;
+  /** The alternative that achieved the best state — hint and classification
+   * always refer to this SAME scope. */
+  scope: string;
+  classification: ScopeClassification;
+}
+
+/**
+ * Discovery `method.scopes` is an ANY-OF list: holding any ONE listed scope
+ * authorizes the call. The method's state is therefore the BEST state among
+ * the alternatives (a catalog-unknown alternative like chat.bot must never
+ * mask a requestable one), and the remediation targets the cheapest fix.
+ */
+export function classifyMethodScopes(
+  alternatives: readonly string[],
+  granted: ReadonlySet<string>,
+  profile: ReadonlySet<string>,
+): MethodScopeClassification | null {
+  let best: MethodScopeClassification | null = null;
+  for (const scope of alternatives) {
+    const c = classifyScope(scope, granted, profile);
+    if (!best || STATE_ORDER[c.state] < STATE_ORDER[best.classification.state]) {
+      best = { state: c.state, scope, classification: c };
+    }
+    if (best.state === 'callable') break;
+  }
+  return best;
+}
+
+/**
+ * gh-CLI-style copy-pasteable remediation. Never promises a delta-only consent
+ * screen (Google re-lists everything at re-consent).
+ */
+export function scopeHint(scope: string, c: ScopeClassification, alias: string): { hint: string; retriable: boolean } {
+  switch (c.state) {
+    case 'requestable_not_granted':
+      return {
+        hint:
+          `Scope ${scope} is in ${alias}'s profile but not granted (you unchecked it at consent). ` +
+          `Re-grant: npx mcp-google-multi auth --account ${alias}`,
+        retriable: true,
+      };
+    case 'not_requestable':
+      if (c.reason === 'add_bundle') {
+        // "base" is a pseudo-bundle (BASE_SCOPES excluded by includesBase:
+        // false), NOT a catalog key — telling users to add it to bundles[]
+        // would fail boot with E_UNKNOWN_BUNDLE.
+        if (c.bundle === 'base') {
+          return {
+            hint:
+              `Scope ${scope} is a base scope excluded by "includesBase": false in ${alias}'s profile. ` +
+              `Set includesBase back to true (or remove it) in config.json, then npx mcp-google-multi auth --account ${alias}`,
+            retriable: false,
+          };
+        }
+        return {
+          hint:
+            `Scope ${scope} needs the "${c.bundle}" bundle, which is not in ${alias}'s profile. ` +
+            `Add it: set ${alias}'s profile bundles to include "${c.bundle}" in config.json, then npx mcp-google-multi auth --account ${alias}`,
+          retriable: false,
+        };
+      }
+      if (c.reason === 'account_type') {
+        return {
+          hint: `Scope ${scope} requires a Google Workspace account; ${alias} is a personal account and will 403. Use a Workspace alias. Do not retry.`,
+          retriable: false,
+        };
+      }
+      return {
+        hint: `Scope ${scope} is not offered by this server (no bundle grants it). Not requestable. Do not retry.`,
+        retriable: false,
+      };
+    default:
+      return { hint: '', retriable: true };
+  }
+}
+
+export interface AccountScopeSets {
+  granted: Set<string>;
+  profile: Set<string>;
+}
+
+/** Best-effort per-account sets; null when the token/profile is unreadable
+ * (decrypt error, missing token) — callers fall back to generic hints. */
+export function accountScopeSets(
+  alias: string,
+  deps: { readTokenFn?: typeof readToken; profileFn?: typeof resolveScopesForAccount } = {},
+): AccountScopeSets | null {
+  try {
+    const token = (deps.readTokenFn ?? readToken)(alias);
+    const granted = new Set(typeof token?.scope === 'string' ? token.scope.split(' ').filter(Boolean) : []);
+    const profile = new Set((deps.profileFn ?? resolveScopesForAccount)(alias));
+    return { granted, profile };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Runtime enrichment for a scope 403 on a method whose required scopes are
+ * known (escape hatch: runtime Discovery; generated tools: baked). The
+ * account_type refinement lives here: a 403 on an admin scope that IS in the
+ * profile means Google refuses it for this account type (personal Gmail),
+ * so re-auth would loop — report the dead end instead.
+ */
+export function scopeHintForMethod(
+  required: readonly string[],
+  alias: string,
+  deps: Parameters<typeof accountScopeSets>[1] = {},
+): { hint: string; retriable: boolean } | null {
+  const sets = accountScopeSets(alias, deps);
+  if (!sets || required.length === 0) return null;
+  const best = classifyMethodScopes(required, sets.granted, sets.profile);
+  if (!best || best.state === 'callable') return null; // 403 despite grants: not a scope-classification problem
+  const base = scopeHint(best.scope, best.classification, alias);
+  // Hedged, never fabricated: an in-profile admin scope that 403s is EITHER a
+  // Workspace account needing re-auth OR a personal account that can never be
+  // granted admin — the inputs cannot distinguish, so say both.
+  if (best.state === 'requestable_not_granted' && ADMIN_SCOPES.includes(best.scope)) {
+    return {
+      hint:
+        `${base.hint} Note: personal (non-Workspace) accounts can never grant admin scopes — if ${alias} is a personal Gmail account, use a Workspace alias instead.`,
+      retriable: true,
+    };
+  }
+  return base;
+}
+
+export interface ScopesReport {
+  configured: number;
+  granted: number;
+  callable: string[];
+  requestable: string[];
+  notRequestable: {
+    addBundle: { scope: string; bundle: string }[];
+    /** Runtime-signal bucket: static classification cannot prove account
+     * type; doctor (B9) fills it from observed persistent admin 403s. */
+    accountType: string[];
+    unknown: string[];
+  };
+  missing: string[];
+}
+
+/**
+ * The account_list / doctor block. Universe = profile ∪ granted ∪ the scopes
+ * required by REGISTERED tools ("registered but not requestable" is the
+ * original #114 ask).
+ */
+export function buildScopesReport(
+  granted: ReadonlySet<string>,
+  profile: ReadonlySet<string>,
+  registeredScopes: Iterable<string> = [],
+): ScopesReport {
+  const callable: string[] = [];
+  const requestable: string[] = [];
+  const addBundle: { scope: string; bundle: string }[] = [];
+  const accountType: string[] = [];
+  const unknown: string[] = [];
+
+  const universe = new Set<string>([...profile, ...granted, ...registeredScopes]);
+  for (const scope of [...universe].sort()) {
+    const c = classifyScope(scope, granted, profile);
+    // Spec-exact: callable = granted ∩ profile (a granted scope the profile
+    // dropped is not reported as callable capacity).
+    if (c.state === 'callable') {
+      if (profile.has(scope)) callable.push(scope);
+      continue;
+    }
+    if (c.state === 'requestable_not_granted') requestable.push(scope);
+    else if (c.reason === 'add_bundle') addBundle.push({ scope, bundle: c.bundle! });
+    else if (c.reason === 'account_type') accountType.push(scope);
+    else unknown.push(scope);
+  }
+
+  return {
+    configured: profile.size,
+    granted: granted.size,
+    callable,
+    requestable,
+    notRequestable: { addBundle, accountType, unknown },
+    missing: [...requestable, ...addBundle.map((e) => e.scope), ...accountType, ...unknown],
+  };
+}
+
+export function clearScopeIndexForTest(): void {
+  reverseIndex = null;
+}

--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -30,6 +30,7 @@ export function mapGoogleError(
   error: any,
   account: Account,
   forbiddenHint?: string,
+  scopeContext?: () => { hint: string; retriable: boolean } | null,
 ): ErrorEnvelope {
   const status = statusOf(error);
   const reason = reasonOf(error);
@@ -50,11 +51,15 @@ export function mapGoogleError(
       reason === 'ACCESS_TOKEN_SCOPE_INSUFFICIENT' ||
       /insufficient.*scope/i.test(message);
     if (scopeIssue) {
+      // #114 three-state enrichment when the method's required scopes are
+      // known (escape hatch / generated tools): state-specific remediation and
+      // an honest retriable so agents stop retrying dead ends.
+      const enriched = scopeContext?.() ?? null;
       return {
         error: 'insufficient_scope',
         message,
-        hint: forbiddenHint ?? `Re-auth "${account}" with the scope this operation needs.`,
-        retriable: false,
+        hint: enriched?.hint ?? forbiddenHint ?? `Re-auth "${account}" with the scope this operation needs.`,
+        retriable: enriched?.retriable ?? false,
         account,
       };
     }
@@ -82,8 +87,8 @@ export function mapGoogleError(
   return { error: 'upstream_error', message, retriable: false, account };
 }
 
-export function handleGoogleApiError(error: any, account: Account, forbiddenHint?: string) {
-  const envelope = mapGoogleError(error, account, forbiddenHint);
+export function handleGoogleApiError(error: any, account: Account, forbiddenHint?: string, scopeContext?: () => { hint: string; retriable: boolean } | null) {
+  const envelope = mapGoogleError(error, account, forbiddenHint, scopeContext);
   return {
     content: [{ type: 'text' as const, text: JSON.stringify(envelope) }],
     isError: true as const,

--- a/src/tools/accounts-tool.ts
+++ b/src/tools/accounts-tool.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import type { ToolRegistry } from '../registry.js';
 import { getAccountSet, refreshAccountSetIfStale } from '../accounts.js';
+import { buildScopesReport, type ScopesReport } from '../scope-observability.js';
 import { getAdminAccounts, resolveScopesForAccount } from '../auth.js';
 import { hasToken, readToken } from '../token-store.js';
 
@@ -9,6 +10,10 @@ export interface AccountHealthDeps {
   readToken: (alias: string) => { expiry_date?: number; refresh_token?: string; scope?: string } | null;
   fileExists: (p: string) => boolean;
   now: () => number;
+  /** Scopes required by registered tools — feeds doctor's tool-grained
+   * "registered but not requestable" view (B9). account_list stays compact:
+   * its report universe is profile ∪ granted only. */
+  registeredScopes?: () => string[];
 }
 
 const DEFAULT_DEPS: AccountHealthDeps = {
@@ -27,7 +32,7 @@ export interface AccountHealth {
   source: 'config' | 'env';
   sourceNote?: string;
   token: { status: TokenStatus; expiryDate?: string; hint?: string };
-  scopes: { configured: number; granted: number; missing: string[] };
+  scopes: ScopesReport;
 }
 
 export function deriveAccountHealth(alias: string, deps: AccountHealthDeps = DEFAULT_DEPS): AccountHealth {
@@ -45,7 +50,9 @@ export function deriveAccountHealth(alias: string, deps: AccountHealthDeps = DEF
       ? { sourceNote: 'Defined by GOOGLE_ACCOUNTS env (not editable via config.json)' }
       : {}),
   };
-  const noScopes = { configured: configured.length, granted: 0, missing: configured };
+  const profileSet = new Set(configured);
+  const registered = deps.registeredScopes?.() ?? [];
+  const noScopes = buildScopesReport(new Set<string>(), profileSet, registered);
 
   if (!deps.hasToken(alias)) {
     const legacy = deps.fileExists(config.tokenPath);
@@ -73,7 +80,8 @@ export function deriveAccountHealth(alias: string, deps: AccountHealthDeps = DEF
   }
 
   const granted = typeof token?.scope === 'string' ? token.scope.split(' ').filter(Boolean) : [];
-  const missing = configured.filter((s) => !granted.includes(s));
+  const report = buildScopesReport(new Set(granted), profileSet, registered);
+  const missing = report.requestable;
   const expiry = typeof token?.expiry_date === 'number' ? token.expiry_date : undefined;
   const refreshable = typeof token?.refresh_token === 'string' && token.refresh_token.length > 0;
 
@@ -94,7 +102,7 @@ export function deriveAccountHealth(alias: string, deps: AccountHealthDeps = DEF
             ? 'Re-auth to grant the missing scopes'
             : undefined,
     },
-    scopes: { configured: configured.length, granted: granted.length, missing },
+    scopes: report,
   };
 }
 

--- a/src/tools/generated/_shared.ts
+++ b/src/tools/generated/_shared.ts
@@ -30,6 +30,7 @@ interface GeneratedToolConfig {
   inputSchema: z.ZodRawShape;
   cud: Cud;
   annotations: Record<string, unknown>;
+  requiredScopes?: readonly string[];
 }
 
 export function registerGeneratedTool(registry: ToolRegistry, def: GeneratedToolDef, deps: ExecuteDeps = {}): void {
@@ -43,6 +44,7 @@ export function registerGeneratedTool(registry: ToolRegistry, def: GeneratedTool
       inputSchema: def.shape,
       cud: def.cud,
       annotations: { openWorldHint: true },
+      requiredScopes: def.method.scopes,
     },
     async (args: Record<string, unknown>) => {
       const pathParams: Record<string, string | number> = {};

--- a/src/tools/generated/admin.ts
+++ b/src/tools/generated/admin.ts
@@ -5,11 +5,16 @@ import { coerceBoolean, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerAdminGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_admin_datatransfer_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/admin.datatransfer","https://www.googleapis.com/auth/admin.datatransfer.readonly"],
+    ["https://www.googleapis.com/auth/admin.datatransfer"],
+  ];
   registerGeneratedTool(registry, {
     name: "admin_applications_get",
     cud: "read",
     description: "Retrieves information about an application for the given application ID.",
-    method: { id: "datatransfer.applications.get", httpMethod: "GET", path: "admin/datatransfer/v1/applications/{applicationId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["applicationId"] },
+    method: { id: "datatransfer.applications.get", httpMethod: "GET", path: "admin/datatransfer/v1/applications/{applicationId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["applicationId"], scopes: S_admin_datatransfer_v1[0] },
     params: [{"field":"applicationId","api":"applicationId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -22,7 +27,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_applications_list",
     cud: "read",
     description: "Lists the applications available for data transfer for a customer.",
-    method: { id: "datatransfer.applications.list", httpMethod: "GET", path: "admin/datatransfer/v1/applications", baseUrl: "https://admin.googleapis.com/", requiredParams: [] },
+    method: { id: "datatransfer.applications.list", httpMethod: "GET", path: "admin/datatransfer/v1/applications", baseUrl: "https://admin.googleapis.com/", requiredParams: [], scopes: S_admin_datatransfer_v1[0] },
     params: [{"field":"customerId","api":"customerId","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -37,7 +42,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_transfers_get",
     cud: "read",
     description: "Retrieves a data transfer request by its resource ID.",
-    method: { id: "datatransfer.transfers.get", httpMethod: "GET", path: "admin/datatransfer/v1/transfers/{dataTransferId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["dataTransferId"] },
+    method: { id: "datatransfer.transfers.get", httpMethod: "GET", path: "admin/datatransfer/v1/transfers/{dataTransferId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["dataTransferId"], scopes: S_admin_datatransfer_v1[0] },
     params: [{"field":"dataTransferId","api":"dataTransferId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -50,7 +55,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_transfers_insert",
     cud: "create",
     description: "Inserts a data transfer request. See the [Transfer parameters](https://developers.google.com/workspace/admin/data-transfer/v1/parameters) reference for specific",
-    method: { id: "datatransfer.transfers.insert", httpMethod: "POST", path: "admin/datatransfer/v1/transfers", baseUrl: "https://admin.googleapis.com/", requiredParams: [] },
+    method: { id: "datatransfer.transfers.insert", httpMethod: "POST", path: "admin/datatransfer/v1/transfers", baseUrl: "https://admin.googleapis.com/", requiredParams: [], scopes: S_admin_datatransfer_v1[1] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -63,7 +68,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_transfers_list",
     cud: "read",
     description: "Lists the transfers for a customer by source user, destination user, or status.",
-    method: { id: "datatransfer.transfers.list", httpMethod: "GET", path: "admin/datatransfer/v1/transfers", baseUrl: "https://admin.googleapis.com/", requiredParams: [] },
+    method: { id: "datatransfer.transfers.list", httpMethod: "GET", path: "admin/datatransfer/v1/transfers", baseUrl: "https://admin.googleapis.com/", requiredParams: [], scopes: S_admin_datatransfer_v1[0] },
     params: [{"field":"customerId","api":"customerId","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"newOwnerUserId","api":"newOwnerUserId","location":"query"},{"field":"oldOwnerUserId","api":"oldOwnerUserId","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"status","api":"status","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -77,11 +82,44 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
       fields: z.string().optional().describe('Response field mask.'),
     },
   });
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_admin_directory_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/admin.directory.user","https://www.googleapis.com/auth/admin.directory.user.alias","https://www.googleapis.com/auth/admin.directory.user.alias.readonly","https://www.googleapis.com/auth/admin.directory.user.readonly","https://www.googleapis.com/auth/cloud-platform"],
+    ["https://www.googleapis.com/auth/admin.directory.device.chromeos"],
+    ["https://www.googleapis.com/auth/admin.directory.device.chromeos","https://www.googleapis.com/auth/admin.directory.device.chromeos.readonly"],
+    ["https://www.googleapis.com/auth/admin.chrome.printers"],
+    ["https://www.googleapis.com/auth/admin.chrome.printers","https://www.googleapis.com/auth/admin.chrome.printers.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.user.security"],
+    ["https://www.googleapis.com/auth/admin.directory.customer","https://www.googleapis.com/auth/admin.directory.customer.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.customer"],
+    ["https://www.googleapis.com/auth/admin.directory.domain"],
+    ["https://www.googleapis.com/auth/admin.directory.domain","https://www.googleapis.com/auth/admin.directory.domain.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.group"],
+    ["https://www.googleapis.com/auth/admin.directory.group","https://www.googleapis.com/auth/admin.directory.group.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.group","https://www.googleapis.com/auth/admin.directory.group.member"],
+    ["https://www.googleapis.com/auth/admin.directory.group","https://www.googleapis.com/auth/admin.directory.group.member","https://www.googleapis.com/auth/admin.directory.group.member.readonly","https://www.googleapis.com/auth/admin.directory.group.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.device.mobile","https://www.googleapis.com/auth/admin.directory.device.mobile.action"],
+    ["https://www.googleapis.com/auth/admin.directory.device.mobile"],
+    ["https://www.googleapis.com/auth/admin.directory.device.mobile","https://www.googleapis.com/auth/admin.directory.device.mobile.action","https://www.googleapis.com/auth/admin.directory.device.mobile.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.orgunit"],
+    ["https://www.googleapis.com/auth/admin.directory.orgunit","https://www.googleapis.com/auth/admin.directory.orgunit.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.rolemanagement","https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.resource.calendar"],
+    ["https://www.googleapis.com/auth/admin.directory.resource.calendar","https://www.googleapis.com/auth/admin.directory.resource.calendar.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.rolemanagement"],
+    ["https://www.googleapis.com/auth/admin.directory.userschema"],
+    ["https://www.googleapis.com/auth/admin.directory.userschema","https://www.googleapis.com/auth/admin.directory.userschema.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.user","https://www.googleapis.com/auth/admin.directory.user.alias"],
+    ["https://www.googleapis.com/auth/admin.directory.user","https://www.googleapis.com/auth/admin.directory.user.alias","https://www.googleapis.com/auth/admin.directory.user.alias.readonly","https://www.googleapis.com/auth/admin.directory.user.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.user"],
+    ["https://www.googleapis.com/auth/admin.directory.user","https://www.googleapis.com/auth/admin.directory.user.readonly"],
+    ["https://www.googleapis.com/auth/admin.directory.user","https://www.googleapis.com/auth/admin.directory.user.readonly","https://www.googleapis.com/auth/cloud-platform"],
+  ];
   registerGeneratedTool(registry, {
     name: "admin_channels_stop",
     cud: "create",
     description: "Stops watching resources through this channel.",
-    method: { id: "admin.channels.stop", httpMethod: "POST", path: "admin/directory_v1/channels/stop", baseUrl: "https://admin.googleapis.com/", requiredParams: [] },
+    method: { id: "admin.channels.stop", httpMethod: "POST", path: "admin/directory_v1/channels/stop", baseUrl: "https://admin.googleapis.com/", requiredParams: [], scopes: S_admin_directory_v1[0] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -94,7 +132,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customer_devices_chromeos_batch_change_status",
     cud: "create",
     description: "Changes the status of a batch of ChromeOS devices. For more information about changing a ChromeOS device state [Repair, repurpose, or retire ChromeOS devices](h",
-    method: { id: "admin.customer.devices.chromeos.batchChangeStatus", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/chromeos:batchChangeStatus", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "admin.customer.devices.chromeos.batchChangeStatus", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/chromeos:batchChangeStatus", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"], scopes: S_admin_directory_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -108,7 +146,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customer_devices_chromeos_commands_get",
     cud: "read",
     description: "Gets command data a specific command issued to the device.",
-    method: { id: "admin.customer.devices.chromeos.commands.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}/commands/{commandId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId","commandId"] },
+    method: { id: "admin.customer.devices.chromeos.commands.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}/commands/{commandId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId","commandId"], scopes: S_admin_directory_v1[2] },
     params: [{"field":"commandId","api":"commandId","location":"path"},{"field":"customerId","api":"customerId","location":"path"},{"field":"deviceId","api":"deviceId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -123,7 +161,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customer_devices_chromeos_count_chrome_os_devices",
     cud: "read",
     description: "Counts ChromeOS devices matching the request.",
-    method: { id: "admin.customer.devices.chromeos.countChromeOsDevices", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/chromeos:countChromeOsDevices", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "admin.customer.devices.chromeos.countChromeOsDevices", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/chromeos:countChromeOsDevices", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"], scopes: S_admin_directory_v1[2] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"includeChildOrgunits","api":"includeChildOrgunits","location":"query"},{"field":"orgUnitPath","api":"orgUnitPath","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -139,7 +177,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customer_devices_chromeos_issue_command",
     cud: "create",
     description: "Issues a command for the device to execute.",
-    method: { id: "admin.customer.devices.chromeos.issueCommand", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}:issueCommand", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId"] },
+    method: { id: "admin.customer.devices.chromeos.issueCommand", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}:issueCommand", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId"], scopes: S_admin_directory_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"deviceId","api":"deviceId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -154,7 +192,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_printers_batch_create_printers",
     cud: "create",
     description: "Creates printers under given Organization Unit.",
-    method: { id: "admin.customers.chrome.printers.batchCreatePrinters", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printers:batchCreatePrinters", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "admin.customers.chrome.printers.batchCreatePrinters", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printers:batchCreatePrinters", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"], scopes: S_admin_directory_v1[3] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -168,7 +206,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_printers_batch_delete_printers",
     cud: "delete",
     description: "Deletes printers in batch.",
-    method: { id: "admin.customers.chrome.printers.batchDeletePrinters", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printers:batchDeletePrinters", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "admin.customers.chrome.printers.batchDeletePrinters", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printers:batchDeletePrinters", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"], scopes: S_admin_directory_v1[3] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -182,7 +220,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_printers_create",
     cud: "create",
     description: "Creates a printer under given Organization Unit.",
-    method: { id: "admin.customers.chrome.printers.create", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "admin.customers.chrome.printers.create", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"], scopes: S_admin_directory_v1[3] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -196,7 +234,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_printers_delete",
     cud: "delete",
     description: "Deletes a `Printer`.",
-    method: { id: "admin.customers.chrome.printers.delete", httpMethod: "DELETE", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "admin.customers.chrome.printers.delete", httpMethod: "DELETE", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"], scopes: S_admin_directory_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -209,7 +247,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_printers_get",
     cud: "read",
     description: "Returns a `Printer` resource (printer's config).",
-    method: { id: "admin.customers.chrome.printers.get", httpMethod: "GET", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "admin.customers.chrome.printers.get", httpMethod: "GET", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"], scopes: S_admin_directory_v1[4] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -222,7 +260,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_printers_list",
     cud: "read",
     description: "List printers configs.",
-    method: { id: "admin.customers.chrome.printers.list", httpMethod: "GET", path: "admin/directory/v1/{+parent}/chrome/printers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "admin.customers.chrome.printers.list", httpMethod: "GET", path: "admin/directory/v1/{+parent}/chrome/printers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"], scopes: S_admin_directory_v1[4] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"orgUnitId","api":"orgUnitId","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -240,7 +278,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_printers_list_printer_models",
     cud: "read",
     description: "Lists the supported printer models.",
-    method: { id: "admin.customers.chrome.printers.listPrinterModels", httpMethod: "GET", path: "admin/directory/v1/{+parent}/chrome/printers:listPrinterModels", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "admin.customers.chrome.printers.listPrinterModels", httpMethod: "GET", path: "admin/directory/v1/{+parent}/chrome/printers:listPrinterModels", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"], scopes: S_admin_directory_v1[4] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -256,7 +294,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_printers_patch",
     cud: "update",
     description: "Updates a `Printer` resource.",
-    method: { id: "admin.customers.chrome.printers.patch", httpMethod: "PATCH", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "admin.customers.chrome.printers.patch", httpMethod: "PATCH", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"], scopes: S_admin_directory_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"clearMask","api":"clearMask","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -272,7 +310,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_print_servers_batch_create_print_servers",
     cud: "create",
     description: "Creates multiple print servers.",
-    method: { id: "admin.customers.chrome.printServers.batchCreatePrintServers", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printServers:batchCreatePrintServers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "admin.customers.chrome.printServers.batchCreatePrintServers", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printServers:batchCreatePrintServers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"], scopes: S_admin_directory_v1[3] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -286,7 +324,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_print_servers_batch_delete_print_servers",
     cud: "delete",
     description: "Deletes multiple print servers.",
-    method: { id: "admin.customers.chrome.printServers.batchDeletePrintServers", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printServers:batchDeletePrintServers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "admin.customers.chrome.printServers.batchDeletePrintServers", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printServers:batchDeletePrintServers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"], scopes: S_admin_directory_v1[3] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -300,7 +338,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_print_servers_create",
     cud: "create",
     description: "Creates a print server.",
-    method: { id: "admin.customers.chrome.printServers.create", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printServers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "admin.customers.chrome.printServers.create", httpMethod: "POST", path: "admin/directory/v1/{+parent}/chrome/printServers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"], scopes: S_admin_directory_v1[3] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -314,7 +352,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_print_servers_delete",
     cud: "delete",
     description: "Deletes a print server.",
-    method: { id: "admin.customers.chrome.printServers.delete", httpMethod: "DELETE", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "admin.customers.chrome.printServers.delete", httpMethod: "DELETE", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"], scopes: S_admin_directory_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -327,7 +365,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_print_servers_get",
     cud: "read",
     description: "Returns a print server's configuration.",
-    method: { id: "admin.customers.chrome.printServers.get", httpMethod: "GET", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "admin.customers.chrome.printServers.get", httpMethod: "GET", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"], scopes: S_admin_directory_v1[4] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -340,7 +378,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_print_servers_list",
     cud: "read",
     description: "Lists print server configurations.",
-    method: { id: "admin.customers.chrome.printServers.list", httpMethod: "GET", path: "admin/directory/v1/{+parent}/chrome/printServers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "admin.customers.chrome.printServers.list", httpMethod: "GET", path: "admin/directory/v1/{+parent}/chrome/printServers", baseUrl: "https://admin.googleapis.com/", requiredParams: ["parent"], scopes: S_admin_directory_v1[4] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"orgUnitId","api":"orgUnitId","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -358,7 +396,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_chrome_print_servers_patch",
     cud: "update",
     description: "Updates a print server's configuration.",
-    method: { id: "admin.customers.chrome.printServers.patch", httpMethod: "PATCH", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "admin.customers.chrome.printServers.patch", httpMethod: "PATCH", path: "admin/directory/v1/{+name}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["name"], scopes: S_admin_directory_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -373,7 +411,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_asps_delete",
     cud: "delete",
     description: "Deletes an ASP issued by a user.",
-    method: { id: "directory.asps.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}/asps/{codeId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","codeId"] },
+    method: { id: "directory.asps.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}/asps/{codeId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","codeId"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"codeId","api":"codeId","location":"path"},{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -387,7 +425,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_asps_get",
     cud: "read",
     description: "Gets information about an ASP issued by a user.",
-    method: { id: "directory.asps.get", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/asps/{codeId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","codeId"] },
+    method: { id: "directory.asps.get", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/asps/{codeId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","codeId"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"codeId","api":"codeId","location":"path"},{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -401,7 +439,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_asps_list",
     cud: "read",
     description: "Lists the ASPs issued by a user.",
-    method: { id: "directory.asps.list", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/asps", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.asps.list", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/asps", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -414,7 +452,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_chromeosdevices_action",
     cud: "create",
     description: "Use [BatchChangeChromeOsDeviceStatus](https://developers.google.com/workspace/admin/directory/reference/rest/v1/customer.devices.chromeos/batchChangeStatus) ins",
-    method: { id: "directory.chromeosdevices.action", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{resourceId}/action", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","resourceId"] },
+    method: { id: "directory.chromeosdevices.action", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{resourceId}/action", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","resourceId"], scopes: S_admin_directory_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"resourceId","api":"resourceId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -429,7 +467,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_chromeosdevices_get",
     cud: "read",
     description: "Retrieves a Chrome OS device's properties.",
-    method: { id: "directory.chromeosdevices.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId"] },
+    method: { id: "directory.chromeosdevices.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId"], scopes: S_admin_directory_v1[2] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"deviceId","api":"deviceId","location":"path"},{"field":"projection","api":"projection","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -444,7 +482,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_chromeosdevices_list",
     cud: "read",
     description: "Retrieves a paginated list of Chrome OS devices within an account.",
-    method: { id: "directory.chromeosdevices.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/chromeos", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "directory.chromeosdevices.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/chromeos", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"], scopes: S_admin_directory_v1[2] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"includeChildOrgunits","api":"includeChildOrgunits","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"orgUnitPath","api":"orgUnitPath","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"projection","api":"projection","location":"query"},{"field":"query","api":"query","location":"query"},{"field":"sortOrder","api":"sortOrder","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -465,7 +503,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_chromeosdevices_move_devices_to_ou",
     cud: "update",
     description: "Moves or inserts multiple Chrome OS devices to an organizational unit. You can move up to 50 devices at once.",
-    method: { id: "directory.chromeosdevices.moveDevicesToOu", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/moveDevicesToOu", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"] },
+    method: { id: "directory.chromeosdevices.moveDevicesToOu", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/moveDevicesToOu", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"], scopes: S_admin_directory_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"orgUnitPath","api":"orgUnitPath","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -480,7 +518,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_chromeosdevices_patch",
     cud: "update",
     description: "Updates a device's updatable properties, such as `annotatedUser`, `annotatedLocation`, `notes`, `orgUnitPath`, or `annotatedAssetId`. This method supports [patc",
-    method: { id: "directory.chromeosdevices.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId"] },
+    method: { id: "directory.chromeosdevices.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId"], scopes: S_admin_directory_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"deviceId","api":"deviceId","location":"path"},{"field":"projection","api":"projection","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -496,7 +534,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_chromeosdevices_update",
     cud: "update",
     description: "Updates a device's updatable properties, such as `annotatedUser`, `annotatedLocation`, `notes`, `orgUnitPath`, or `annotatedAssetId`.",
-    method: { id: "directory.chromeosdevices.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId"] },
+    method: { id: "directory.chromeosdevices.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customerId}/devices/chromeos/{deviceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","deviceId"], scopes: S_admin_directory_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"deviceId","api":"deviceId","location":"path"},{"field":"projection","api":"projection","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -512,7 +550,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_get",
     cud: "read",
     description: "Retrieves a customer.",
-    method: { id: "directory.customers.get", httpMethod: "GET", path: "admin/directory/v1/customers/{customerKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerKey"] },
+    method: { id: "directory.customers.get", httpMethod: "GET", path: "admin/directory/v1/customers/{customerKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerKey"], scopes: S_admin_directory_v1[6] },
     params: [{"field":"customerKey","api":"customerKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -525,7 +563,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_patch",
     cud: "update",
     description: "Patches a customer.",
-    method: { id: "directory.customers.patch", httpMethod: "PATCH", path: "admin/directory/v1/customers/{customerKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerKey"] },
+    method: { id: "directory.customers.patch", httpMethod: "PATCH", path: "admin/directory/v1/customers/{customerKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerKey"], scopes: S_admin_directory_v1[7] },
     params: [{"field":"customerKey","api":"customerKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -539,7 +577,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customers_update",
     cud: "update",
     description: "Updates a customer.",
-    method: { id: "directory.customers.update", httpMethod: "PUT", path: "admin/directory/v1/customers/{customerKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerKey"] },
+    method: { id: "directory.customers.update", httpMethod: "PUT", path: "admin/directory/v1/customers/{customerKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerKey"], scopes: S_admin_directory_v1[7] },
     params: [{"field":"customerKey","api":"customerKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -553,7 +591,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_domain_aliases_delete",
     cud: "delete",
     description: "Deletes a domain Alias of the customer.",
-    method: { id: "directory.domainAliases.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/domainaliases/{domainAliasName}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","domainAliasName"] },
+    method: { id: "directory.domainAliases.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/domainaliases/{domainAliasName}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","domainAliasName"], scopes: S_admin_directory_v1[8] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"domainAliasName","api":"domainAliasName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -567,7 +605,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_domain_aliases_get",
     cud: "read",
     description: "Retrieves a domain alias of the customer.",
-    method: { id: "directory.domainAliases.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/domainaliases/{domainAliasName}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","domainAliasName"] },
+    method: { id: "directory.domainAliases.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/domainaliases/{domainAliasName}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","domainAliasName"], scopes: S_admin_directory_v1[9] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"domainAliasName","api":"domainAliasName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -581,7 +619,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_domain_aliases_insert",
     cud: "create",
     description: "Inserts a domain alias of the customer.",
-    method: { id: "directory.domainAliases.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/domainaliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.domainAliases.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/domainaliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[8] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -595,7 +633,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_domain_aliases_list",
     cud: "read",
     description: "Lists the domain aliases of the customer.",
-    method: { id: "directory.domainAliases.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/domainaliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.domainAliases.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/domainaliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[9] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"parentDomainName","api":"parentDomainName","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -609,7 +647,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_domains_delete",
     cud: "delete",
     description: "Deletes a domain of the customer.",
-    method: { id: "directory.domains.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/domains/{domainName}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","domainName"] },
+    method: { id: "directory.domains.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/domains/{domainName}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","domainName"], scopes: S_admin_directory_v1[8] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"domainName","api":"domainName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -623,7 +661,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_domains_get",
     cud: "read",
     description: "Retrieves a domain of the customer.",
-    method: { id: "directory.domains.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/domains/{domainName}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","domainName"] },
+    method: { id: "directory.domains.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/domains/{domainName}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","domainName"], scopes: S_admin_directory_v1[9] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"domainName","api":"domainName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -637,7 +675,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_domains_insert",
     cud: "create",
     description: "Inserts a domain of the customer.",
-    method: { id: "directory.domains.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/domains", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.domains.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/domains", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[8] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -651,7 +689,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_domains_list",
     cud: "read",
     description: "Lists the domains of the customer.",
-    method: { id: "directory.domains.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/domains", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.domains.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/domains", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[9] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -664,7 +702,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_groups_aliases_delete",
     cud: "delete",
     description: "Removes an alias.",
-    method: { id: "directory.groups.aliases.delete", httpMethod: "DELETE", path: "admin/directory/v1/groups/{groupKey}/aliases/{alias}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","alias"] },
+    method: { id: "directory.groups.aliases.delete", httpMethod: "DELETE", path: "admin/directory/v1/groups/{groupKey}/aliases/{alias}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","alias"], scopes: S_admin_directory_v1[10] },
     params: [{"field":"alias","api":"alias","location":"path"},{"field":"groupKey","api":"groupKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -678,7 +716,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_groups_aliases_insert",
     cud: "create",
     description: "Adds an alias for the group.",
-    method: { id: "directory.groups.aliases.insert", httpMethod: "POST", path: "admin/directory/v1/groups/{groupKey}/aliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"] },
+    method: { id: "directory.groups.aliases.insert", httpMethod: "POST", path: "admin/directory/v1/groups/{groupKey}/aliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"], scopes: S_admin_directory_v1[10] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -692,7 +730,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_groups_aliases_list",
     cud: "read",
     description: "Lists all aliases for a group.",
-    method: { id: "directory.groups.aliases.list", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}/aliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"] },
+    method: { id: "directory.groups.aliases.list", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}/aliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"], scopes: S_admin_directory_v1[11] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -705,7 +743,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_groups_delete",
     cud: "delete",
     description: "Deletes a group.",
-    method: { id: "directory.groups.delete", httpMethod: "DELETE", path: "admin/directory/v1/groups/{groupKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"] },
+    method: { id: "directory.groups.delete", httpMethod: "DELETE", path: "admin/directory/v1/groups/{groupKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"], scopes: S_admin_directory_v1[10] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -718,7 +756,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_groups_get",
     cud: "read",
     description: "Retrieves a group's properties.",
-    method: { id: "directory.groups.get", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"] },
+    method: { id: "directory.groups.get", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"], scopes: S_admin_directory_v1[11] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -731,7 +769,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_groups_insert",
     cud: "create",
     description: "Creates a group.",
-    method: { id: "directory.groups.insert", httpMethod: "POST", path: "admin/directory/v1/groups", baseUrl: "https://admin.googleapis.com/", requiredParams: [] },
+    method: { id: "directory.groups.insert", httpMethod: "POST", path: "admin/directory/v1/groups", baseUrl: "https://admin.googleapis.com/", requiredParams: [], scopes: S_admin_directory_v1[10] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -744,7 +782,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_groups_patch",
     cud: "update",
     description: "Updates a group's properties. This method supports [patch semantics](https://developers.google.com/workspace/admin/directory/v1/guides/performance#patch).",
-    method: { id: "directory.groups.patch", httpMethod: "PATCH", path: "admin/directory/v1/groups/{groupKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"] },
+    method: { id: "directory.groups.patch", httpMethod: "PATCH", path: "admin/directory/v1/groups/{groupKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"], scopes: S_admin_directory_v1[10] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -758,7 +796,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_groups_update",
     cud: "update",
     description: "Updates a group's properties.",
-    method: { id: "directory.groups.update", httpMethod: "PUT", path: "admin/directory/v1/groups/{groupKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"] },
+    method: { id: "directory.groups.update", httpMethod: "PUT", path: "admin/directory/v1/groups/{groupKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"], scopes: S_admin_directory_v1[10] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -772,7 +810,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_delete",
     cud: "delete",
     description: "Removes a member from a group.",
-    method: { id: "directory.members.delete", httpMethod: "DELETE", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"] },
+    method: { id: "directory.members.delete", httpMethod: "DELETE", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"], scopes: S_admin_directory_v1[12] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"memberKey","api":"memberKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -786,7 +824,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_get",
     cud: "read",
     description: "Retrieves a group member's properties.",
-    method: { id: "directory.members.get", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"] },
+    method: { id: "directory.members.get", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"], scopes: S_admin_directory_v1[13] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"memberKey","api":"memberKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -800,7 +838,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_has_member",
     cud: "read",
     description: "Checks whether the given user is a member of the group. Membership can be direct or nested, but if nested, the `memberKey` and `groupKey` must be entities in th",
-    method: { id: "directory.members.hasMember", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}/hasMember/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"] },
+    method: { id: "directory.members.hasMember", httpMethod: "GET", path: "admin/directory/v1/groups/{groupKey}/hasMember/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"], scopes: S_admin_directory_v1[13] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"memberKey","api":"memberKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -814,7 +852,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_insert",
     cud: "create",
     description: "Adds a user to the specified group.",
-    method: { id: "directory.members.insert", httpMethod: "POST", path: "admin/directory/v1/groups/{groupKey}/members", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"] },
+    method: { id: "directory.members.insert", httpMethod: "POST", path: "admin/directory/v1/groups/{groupKey}/members", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey"], scopes: S_admin_directory_v1[12] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -828,7 +866,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_patch",
     cud: "update",
     description: "Updates the membership properties of a user in the specified group. This method supports [patch semantics](https://developers.google.com/workspace/admin/directo",
-    method: { id: "directory.members.patch", httpMethod: "PATCH", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"] },
+    method: { id: "directory.members.patch", httpMethod: "PATCH", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"], scopes: S_admin_directory_v1[12] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"memberKey","api":"memberKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -843,7 +881,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_members_update",
     cud: "update",
     description: "Updates the membership of a user in the specified group.",
-    method: { id: "directory.members.update", httpMethod: "PUT", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"] },
+    method: { id: "directory.members.update", httpMethod: "PUT", path: "admin/directory/v1/groups/{groupKey}/members/{memberKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["groupKey","memberKey"], scopes: S_admin_directory_v1[12] },
     params: [{"field":"groupKey","api":"groupKey","location":"path"},{"field":"memberKey","api":"memberKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -858,7 +896,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_mobiledevices_action",
     cud: "create",
     description: "Takes an action that affects a mobile device. For example, remotely wiping a device.",
-    method: { id: "directory.mobiledevices.action", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/mobile/{resourceId}/action", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","resourceId"] },
+    method: { id: "directory.mobiledevices.action", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/devices/mobile/{resourceId}/action", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","resourceId"], scopes: S_admin_directory_v1[14] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"resourceId","api":"resourceId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -873,7 +911,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_mobiledevices_delete",
     cud: "delete",
     description: "Removes a mobile device.",
-    method: { id: "directory.mobiledevices.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customerId}/devices/mobile/{resourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","resourceId"] },
+    method: { id: "directory.mobiledevices.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customerId}/devices/mobile/{resourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","resourceId"], scopes: S_admin_directory_v1[15] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"resourceId","api":"resourceId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -887,7 +925,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_mobiledevices_get",
     cud: "read",
     description: "Retrieves a mobile device's properties.",
-    method: { id: "directory.mobiledevices.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/mobile/{resourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","resourceId"] },
+    method: { id: "directory.mobiledevices.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/mobile/{resourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","resourceId"], scopes: S_admin_directory_v1[16] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"resourceId","api":"resourceId","location":"path"},{"field":"projection","api":"projection","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -902,7 +940,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_mobiledevices_list",
     cud: "read",
     description: "Retrieves a paginated list of all user-owned mobile devices for an account. To retrieve a list that includes company-owned devices, use the Cloud Identity [Devi",
-    method: { id: "directory.mobiledevices.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/mobile", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "directory.mobiledevices.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/devices/mobile", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"], scopes: S_admin_directory_v1[16] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"projection","api":"projection","location":"query"},{"field":"query","api":"query","location":"query"},{"field":"sortOrder","api":"sortOrder","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -921,7 +959,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_orgunits_delete",
     cud: "delete",
     description: "Removes an organizational unit.",
-    method: { id: "directory.orgunits.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"] },
+    method: { id: "directory.orgunits.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"], scopes: S_admin_directory_v1[17] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"orgUnitPath","api":"orgUnitPath","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -935,7 +973,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_orgunits_get",
     cud: "read",
     description: "Retrieves an organizational unit.",
-    method: { id: "directory.orgunits.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"] },
+    method: { id: "directory.orgunits.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"], scopes: S_admin_directory_v1[18] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"orgUnitPath","api":"orgUnitPath","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -949,7 +987,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_orgunits_insert",
     cud: "create",
     description: "Adds an organizational unit.",
-    method: { id: "directory.orgunits.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/orgunits", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "directory.orgunits.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/orgunits", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"], scopes: S_admin_directory_v1[17] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -963,7 +1001,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_orgunits_list",
     cud: "read",
     description: "Retrieves a list of all organizational units for an account.",
-    method: { id: "directory.orgunits.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/orgunits", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "directory.orgunits.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/orgunits", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"], scopes: S_admin_directory_v1[18] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"orgUnitPath","api":"orgUnitPath","location":"query"},{"field":"type","api":"type","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -978,7 +1016,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_orgunits_patch",
     cud: "update",
     description: "Updates an organizational unit. This method supports [patch semantics](https://developers.google.com/workspace/admin/directory/v1/guides/performance#patch)",
-    method: { id: "directory.orgunits.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"] },
+    method: { id: "directory.orgunits.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"], scopes: S_admin_directory_v1[17] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"orgUnitPath","api":"orgUnitPath","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -993,7 +1031,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_orgunits_update",
     cud: "update",
     description: "Updates an organizational unit.",
-    method: { id: "directory.orgunits.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"] },
+    method: { id: "directory.orgunits.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customerId}/orgunits/{+orgUnitPath}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","orgUnitPath"], scopes: S_admin_directory_v1[17] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"orgUnitPath","api":"orgUnitPath","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1008,7 +1046,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_privileges_list",
     cud: "read",
     description: "Retrieves a paginated list of all privileges for a customer.",
-    method: { id: "directory.privileges.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roles/ALL/privileges", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.privileges.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roles/ALL/privileges", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[19] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1021,7 +1059,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_buildings_delete",
     cud: "delete",
     description: "Deletes a building.",
-    method: { id: "directory.resources.buildings.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","buildingId"] },
+    method: { id: "directory.resources.buildings.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","buildingId"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"buildingId","api":"buildingId","location":"path"},{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1035,7 +1073,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_buildings_get",
     cud: "read",
     description: "Retrieves a building.",
-    method: { id: "directory.resources.buildings.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","buildingId"] },
+    method: { id: "directory.resources.buildings.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","buildingId"], scopes: S_admin_directory_v1[21] },
     params: [{"field":"buildingId","api":"buildingId","location":"path"},{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1049,7 +1087,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_buildings_insert",
     cud: "create",
     description: "Inserts a building.",
-    method: { id: "directory.resources.buildings.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/resources/buildings", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.resources.buildings.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/resources/buildings", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"coordinatesSource","api":"coordinatesSource","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1064,7 +1102,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_buildings_list",
     cud: "read",
     description: "Retrieves a list of buildings for an account.",
-    method: { id: "directory.resources.buildings.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/buildings", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.resources.buildings.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/buildings", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[21] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1079,7 +1117,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_buildings_patch",
     cud: "update",
     description: "Patches a building.",
-    method: { id: "directory.resources.buildings.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","buildingId"] },
+    method: { id: "directory.resources.buildings.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","buildingId"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"buildingId","api":"buildingId","location":"path"},{"field":"customer","api":"customer","location":"path"},{"field":"coordinatesSource","api":"coordinatesSource","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1095,7 +1133,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_buildings_update",
     cud: "update",
     description: "Updates a building.",
-    method: { id: "directory.resources.buildings.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","buildingId"] },
+    method: { id: "directory.resources.buildings.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/resources/buildings/{buildingId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","buildingId"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"buildingId","api":"buildingId","location":"path"},{"field":"customer","api":"customer","location":"path"},{"field":"coordinatesSource","api":"coordinatesSource","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1111,7 +1149,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_calendars_delete",
     cud: "delete",
     description: "Deletes a calendar resource.",
-    method: { id: "directory.resources.calendars.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/resources/calendars/{calendarResourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","calendarResourceId"] },
+    method: { id: "directory.resources.calendars.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/resources/calendars/{calendarResourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","calendarResourceId"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"calendarResourceId","api":"calendarResourceId","location":"path"},{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1125,7 +1163,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_calendars_get",
     cud: "read",
     description: "Retrieves a calendar resource.",
-    method: { id: "directory.resources.calendars.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/calendars/{calendarResourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","calendarResourceId"] },
+    method: { id: "directory.resources.calendars.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/calendars/{calendarResourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","calendarResourceId"], scopes: S_admin_directory_v1[21] },
     params: [{"field":"calendarResourceId","api":"calendarResourceId","location":"path"},{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1139,7 +1177,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_calendars_insert",
     cud: "create",
     description: "Inserts a calendar resource.",
-    method: { id: "directory.resources.calendars.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/resources/calendars", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.resources.calendars.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/resources/calendars", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1153,7 +1191,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_calendars_list",
     cud: "read",
     description: "Retrieves a list of calendar resources for an account.",
-    method: { id: "directory.resources.calendars.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/calendars", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.resources.calendars.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/calendars", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[21] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"query","api":"query","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1170,7 +1208,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_calendars_patch",
     cud: "update",
     description: "Patches a calendar resource.",
-    method: { id: "directory.resources.calendars.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/resources/calendars/{calendarResourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","calendarResourceId"] },
+    method: { id: "directory.resources.calendars.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/resources/calendars/{calendarResourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","calendarResourceId"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"calendarResourceId","api":"calendarResourceId","location":"path"},{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1185,7 +1223,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_calendars_update",
     cud: "update",
     description: "Updates a calendar resource. This method supports patch semantics, meaning you only need to include the fields you wish to update. Fields that are not present i",
-    method: { id: "directory.resources.calendars.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/resources/calendars/{calendarResourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","calendarResourceId"] },
+    method: { id: "directory.resources.calendars.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/resources/calendars/{calendarResourceId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","calendarResourceId"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"calendarResourceId","api":"calendarResourceId","location":"path"},{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1200,7 +1238,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_features_delete",
     cud: "delete",
     description: "Deletes a feature.",
-    method: { id: "directory.resources.features.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","featureKey"] },
+    method: { id: "directory.resources.features.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","featureKey"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"featureKey","api":"featureKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1214,7 +1252,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_features_get",
     cud: "read",
     description: "Retrieves a feature.",
-    method: { id: "directory.resources.features.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","featureKey"] },
+    method: { id: "directory.resources.features.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","featureKey"], scopes: S_admin_directory_v1[21] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"featureKey","api":"featureKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1228,7 +1266,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_features_insert",
     cud: "create",
     description: "Inserts a feature.",
-    method: { id: "directory.resources.features.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/resources/features", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.resources.features.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/resources/features", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1242,7 +1280,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_features_list",
     cud: "read",
     description: "Retrieves a list of features for an account.",
-    method: { id: "directory.resources.features.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/features", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.resources.features.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/resources/features", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[21] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1257,7 +1295,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_features_patch",
     cud: "update",
     description: "Patches a feature.",
-    method: { id: "directory.resources.features.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","featureKey"] },
+    method: { id: "directory.resources.features.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","featureKey"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"featureKey","api":"featureKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1272,7 +1310,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_features_rename",
     cud: "create",
     description: "Renames a feature.",
-    method: { id: "directory.resources.features.rename", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/resources/features/{oldName}/rename", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","oldName"] },
+    method: { id: "directory.resources.features.rename", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/resources/features/{oldName}/rename", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","oldName"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"oldName","api":"oldName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1287,7 +1325,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_resources_features_update",
     cud: "update",
     description: "Updates a feature.",
-    method: { id: "directory.resources.features.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","featureKey"] },
+    method: { id: "directory.resources.features.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/resources/features/{featureKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","featureKey"], scopes: S_admin_directory_v1[20] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"featureKey","api":"featureKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1302,7 +1340,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_role_assignments_delete",
     cud: "delete",
     description: "Deletes a role assignment.",
-    method: { id: "directory.roleAssignments.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/roleassignments/{roleAssignmentId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleAssignmentId"] },
+    method: { id: "directory.roleAssignments.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/roleassignments/{roleAssignmentId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleAssignmentId"], scopes: S_admin_directory_v1[22] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"roleAssignmentId","api":"roleAssignmentId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1316,7 +1354,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_role_assignments_get",
     cud: "read",
     description: "Retrieves a role assignment.",
-    method: { id: "directory.roleAssignments.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roleassignments/{roleAssignmentId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleAssignmentId"] },
+    method: { id: "directory.roleAssignments.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roleassignments/{roleAssignmentId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleAssignmentId"], scopes: S_admin_directory_v1[19] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"roleAssignmentId","api":"roleAssignmentId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1330,7 +1368,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_role_assignments_insert",
     cud: "create",
     description: "Creates a role assignment.",
-    method: { id: "directory.roleAssignments.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/roleassignments", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.roleAssignments.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/roleassignments", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[22] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1344,7 +1382,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_role_assignments_list",
     cud: "read",
     description: "Retrieves a paginated list of all roleAssignments.",
-    method: { id: "directory.roleAssignments.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roleassignments", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.roleAssignments.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roleassignments", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[19] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"includeIndirectRoleAssignments","api":"includeIndirectRoleAssignments","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"roleId","api":"roleId","location":"query"},{"field":"userKey","api":"userKey","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1362,7 +1400,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_roles_delete",
     cud: "delete",
     description: "Deletes a role.",
-    method: { id: "directory.roles.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"] },
+    method: { id: "directory.roles.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"], scopes: S_admin_directory_v1[22] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"roleId","api":"roleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1376,7 +1414,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_roles_get",
     cud: "read",
     description: "Retrieves a role.",
-    method: { id: "directory.roles.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"] },
+    method: { id: "directory.roles.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"], scopes: S_admin_directory_v1[19] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"roleId","api":"roleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1390,7 +1428,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_roles_insert",
     cud: "create",
     description: "Creates a role.",
-    method: { id: "directory.roles.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/roles", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.roles.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customer}/roles", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[22] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1404,7 +1442,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_roles_list",
     cud: "read",
     description: "Retrieves a paginated list of all the roles in a domain.",
-    method: { id: "directory.roles.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roles", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"] },
+    method: { id: "directory.roles.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customer}/roles", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer"], scopes: S_admin_directory_v1[19] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1419,7 +1457,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_roles_patch",
     cud: "update",
     description: "Patches a role.",
-    method: { id: "directory.roles.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"] },
+    method: { id: "directory.roles.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"], scopes: S_admin_directory_v1[22] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"roleId","api":"roleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1434,7 +1472,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_roles_update",
     cud: "update",
     description: "Updates a role.",
-    method: { id: "directory.roles.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"] },
+    method: { id: "directory.roles.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customer}/roles/{roleId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customer","roleId"], scopes: S_admin_directory_v1[22] },
     params: [{"field":"customer","api":"customer","location":"path"},{"field":"roleId","api":"roleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1449,7 +1487,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_schemas_delete",
     cud: "delete",
     description: "Deletes a schema.",
-    method: { id: "directory.schemas.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customerId}/schemas/{schemaKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","schemaKey"] },
+    method: { id: "directory.schemas.delete", httpMethod: "DELETE", path: "admin/directory/v1/customer/{customerId}/schemas/{schemaKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","schemaKey"], scopes: S_admin_directory_v1[23] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"schemaKey","api":"schemaKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1463,7 +1501,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_schemas_get",
     cud: "read",
     description: "Retrieves a schema.",
-    method: { id: "directory.schemas.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/schemas/{schemaKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","schemaKey"] },
+    method: { id: "directory.schemas.get", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/schemas/{schemaKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","schemaKey"], scopes: S_admin_directory_v1[24] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"schemaKey","api":"schemaKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1477,7 +1515,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_schemas_insert",
     cud: "create",
     description: "Creates a schema.",
-    method: { id: "directory.schemas.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/schemas", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "directory.schemas.insert", httpMethod: "POST", path: "admin/directory/v1/customer/{customerId}/schemas", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"], scopes: S_admin_directory_v1[23] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1491,7 +1529,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_schemas_list",
     cud: "read",
     description: "Retrieves all schemas for a customer.",
-    method: { id: "directory.schemas.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/schemas", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "directory.schemas.list", httpMethod: "GET", path: "admin/directory/v1/customer/{customerId}/schemas", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId"], scopes: S_admin_directory_v1[24] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1504,7 +1542,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_schemas_patch",
     cud: "update",
     description: "Patches a schema.",
-    method: { id: "directory.schemas.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customerId}/schemas/{schemaKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","schemaKey"] },
+    method: { id: "directory.schemas.patch", httpMethod: "PATCH", path: "admin/directory/v1/customer/{customerId}/schemas/{schemaKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","schemaKey"], scopes: S_admin_directory_v1[23] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"schemaKey","api":"schemaKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1519,7 +1557,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_schemas_update",
     cud: "update",
     description: "Updates a schema.",
-    method: { id: "directory.schemas.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customerId}/schemas/{schemaKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","schemaKey"] },
+    method: { id: "directory.schemas.update", httpMethod: "PUT", path: "admin/directory/v1/customer/{customerId}/schemas/{schemaKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["customerId","schemaKey"], scopes: S_admin_directory_v1[23] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"schemaKey","api":"schemaKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1534,7 +1572,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_tokens_delete",
     cud: "delete",
     description: "Deletes all access tokens issued by a user for an application.",
-    method: { id: "directory.tokens.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}/tokens/{clientId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","clientId"] },
+    method: { id: "directory.tokens.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}/tokens/{clientId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","clientId"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"clientId","api":"clientId","location":"path"},{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1548,7 +1586,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_tokens_get",
     cud: "read",
     description: "Gets information about an access token issued by a user.",
-    method: { id: "directory.tokens.get", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/tokens/{clientId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","clientId"] },
+    method: { id: "directory.tokens.get", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/tokens/{clientId}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","clientId"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"clientId","api":"clientId","location":"path"},{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1562,7 +1600,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_tokens_list",
     cud: "read",
     description: "Returns the set of tokens specified user has issued to 3rd party applications.",
-    method: { id: "directory.tokens.list", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/tokens", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.tokens.list", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/tokens", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1575,7 +1613,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_two_step_verification_turn_off",
     cud: "create",
     description: "Turns off 2-Step Verification for user.",
-    method: { id: "directory.twoStepVerification.turnOff", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/twoStepVerification/turnOff", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.twoStepVerification.turnOff", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/twoStepVerification/turnOff", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1588,7 +1626,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_aliases_delete",
     cud: "delete",
     description: "Removes an alias.",
-    method: { id: "directory.users.aliases.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}/aliases/{alias}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","alias"] },
+    method: { id: "directory.users.aliases.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}/aliases/{alias}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","alias"], scopes: S_admin_directory_v1[25] },
     params: [{"field":"alias","api":"alias","location":"path"},{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1602,7 +1640,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_aliases_insert",
     cud: "create",
     description: "Adds an alias.",
-    method: { id: "directory.users.aliases.insert", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/aliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.aliases.insert", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/aliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[25] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1616,7 +1654,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_aliases_list",
     cud: "read",
     description: "Lists all aliases for a user.",
-    method: { id: "directory.users.aliases.list", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/aliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.aliases.list", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/aliases", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[26] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"event","api":"event","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1630,7 +1668,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_aliases_watch",
     cud: "create",
     description: "Watches for changes in users list.",
-    method: { id: "directory.users.aliases.watch", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/aliases/watch", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.aliases.watch", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/aliases/watch", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[26] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"event","api":"event","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1645,7 +1683,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_create_guest",
     cud: "create",
     description: "Create a guest user with access to a [subset of Workspace capabilities](https://support.google.com/a/answer/16558545). This feature is currently in Open Beta.",
-    method: { id: "directory.users.createGuest", httpMethod: "POST", path: "admin/directory/v1/users:createGuest", baseUrl: "https://admin.googleapis.com/", requiredParams: [] },
+    method: { id: "directory.users.createGuest", httpMethod: "POST", path: "admin/directory/v1/users:createGuest", baseUrl: "https://admin.googleapis.com/", requiredParams: [], scopes: S_admin_directory_v1[27] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1658,7 +1696,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_delete",
     cud: "delete",
     description: "Deletes a user.",
-    method: { id: "directory.users.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[27] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1671,7 +1709,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_insert",
     cud: "create",
     description: "Creates a user. Mutate calls immediately following user creation might sometimes fail as the user isn't fully created due to propagation delay in our backends.",
-    method: { id: "directory.users.insert", httpMethod: "POST", path: "admin/directory/v1/users", baseUrl: "https://admin.googleapis.com/", requiredParams: [] },
+    method: { id: "directory.users.insert", httpMethod: "POST", path: "admin/directory/v1/users", baseUrl: "https://admin.googleapis.com/", requiredParams: [], scopes: S_admin_directory_v1[27] },
     params: [{"field":"resolveConflictAccount","api":"resolveConflictAccount","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1685,7 +1723,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_make_admin",
     cud: "create",
     description: "Makes a user a super administrator.",
-    method: { id: "directory.users.makeAdmin", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/makeAdmin", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.makeAdmin", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/makeAdmin", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[27] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1699,7 +1737,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_photos_delete",
     cud: "delete",
     description: "Removes the user's photo.",
-    method: { id: "directory.users.photos.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}/photos/thumbnail", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.photos.delete", httpMethod: "DELETE", path: "admin/directory/v1/users/{userKey}/photos/thumbnail", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[27] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1712,7 +1750,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_photos_get",
     cud: "read",
     description: "Retrieves the user's photo.",
-    method: { id: "directory.users.photos.get", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/photos/thumbnail", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.photos.get", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/photos/thumbnail", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[28] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1725,7 +1763,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_photos_patch",
     cud: "update",
     description: "Adds a photo for the user. This method supports [patch semantics](https://developers.google.com/workspace/admin/directory/v1/guides/performance#patch).",
-    method: { id: "directory.users.photos.patch", httpMethod: "PATCH", path: "admin/directory/v1/users/{userKey}/photos/thumbnail", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.photos.patch", httpMethod: "PATCH", path: "admin/directory/v1/users/{userKey}/photos/thumbnail", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[27] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1739,7 +1777,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_photos_update",
     cud: "update",
     description: "Adds a photo for the user.",
-    method: { id: "directory.users.photos.update", httpMethod: "PUT", path: "admin/directory/v1/users/{userKey}/photos/thumbnail", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.photos.update", httpMethod: "PUT", path: "admin/directory/v1/users/{userKey}/photos/thumbnail", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[27] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1753,7 +1791,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_sign_out",
     cud: "create",
     description: "Signs a user out of all web and device sessions and reset their sign-in cookies. User will have to sign in by authenticating again.",
-    method: { id: "directory.users.signOut", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/signOut", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.signOut", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/signOut", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1766,7 +1804,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_undelete",
     cud: "update",
     description: "Undeletes a deleted user.",
-    method: { id: "directory.users.undelete", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/undelete", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.undelete", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/undelete", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[27] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1780,7 +1818,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_replace",
     cud: "update",
     description: "Updates a user. This method supports patch semantics, meaning that you only need to include the fields you wish to update. Fields that are not present in the re",
-    method: { id: "directory.users.update", httpMethod: "PUT", path: "admin/directory/v1/users/{userKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.users.update", httpMethod: "PUT", path: "admin/directory/v1/users/{userKey}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[27] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1794,7 +1832,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_users_watch",
     cud: "create",
     description: "Watches for changes in users list.",
-    method: { id: "directory.users.watch", httpMethod: "POST", path: "admin/directory/v1/users/watch", baseUrl: "https://admin.googleapis.com/", requiredParams: [] },
+    method: { id: "directory.users.watch", httpMethod: "POST", path: "admin/directory/v1/users/watch", baseUrl: "https://admin.googleapis.com/", requiredParams: [], scopes: S_admin_directory_v1[29] },
     params: [{"field":"customer","api":"customer","location":"query"},{"field":"customFieldMask","api":"customFieldMask","location":"query"},{"field":"domain","api":"domain","location":"query"},{"field":"event","api":"event","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"projection","api":"projection","location":"query"},{"field":"query","api":"query","location":"query"},{"field":"showDeleted","api":"showDeleted","location":"query"},{"field":"sortOrder","api":"sortOrder","location":"query"},{"field":"viewType","api":"viewType","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1819,7 +1857,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_verification_codes_generate",
     cud: "create",
     description: "Generates new backup verification codes for the user.",
-    method: { id: "directory.verificationCodes.generate", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/verificationCodes/generate", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.verificationCodes.generate", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/verificationCodes/generate", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1832,7 +1870,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_verification_codes_invalidate",
     cud: "create",
     description: "Invalidates the current backup verification codes for the user.",
-    method: { id: "directory.verificationCodes.invalidate", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/verificationCodes/invalidate", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.verificationCodes.invalidate", httpMethod: "POST", path: "admin/directory/v1/users/{userKey}/verificationCodes/invalidate", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1845,7 +1883,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_verification_codes_list",
     cud: "read",
     description: "Returns the current set of valid backup verification codes for the specified user.",
-    method: { id: "directory.verificationCodes.list", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/verificationCodes", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"] },
+    method: { id: "directory.verificationCodes.list", httpMethod: "GET", path: "admin/directory/v1/users/{userKey}/verificationCodes", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey"], scopes: S_admin_directory_v1[5] },
     params: [{"field":"userKey","api":"userKey","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1854,11 +1892,16 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
       fields: z.string().optional().describe('Response field mask.'),
     },
   });
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_admin_reports_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/admin.reports.audit.readonly"],
+    ["https://www.googleapis.com/auth/admin.reports.usage.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "admin_activities_watch",
     cud: "create",
     description: "Start receiving notifications for account activities. For more information, see Receiving Push Notifications.",
-    method: { id: "reports.activities.watch", httpMethod: "POST", path: "admin/reports/v1/activity/users/{userKey}/applications/{applicationName}/watch", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","applicationName"] },
+    method: { id: "reports.activities.watch", httpMethod: "POST", path: "admin/reports/v1/activity/users/{userKey}/applications/{applicationName}/watch", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","applicationName"], scopes: S_admin_reports_v1[0] },
     params: [{"field":"applicationName","api":"applicationName","location":"path"},{"field":"userKey","api":"userKey","location":"path"},{"field":"actorIpAddress","api":"actorIpAddress","location":"query"},{"field":"customerId","api":"customerId","location":"query"},{"field":"endTime","api":"endTime","location":"query"},{"field":"eventName","api":"eventName","location":"query"},{"field":"filters","api":"filters","location":"query"},{"field":"groupIdFilter","api":"groupIdFilter","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"orgUnitID","api":"orgUnitID","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"startTime","api":"startTime","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1883,7 +1926,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_customer_usage_reports_get",
     cud: "read",
     description: "Retrieves a report which is a collection of properties and statistics for a specific customer's account. For more information, see the Customers Usage Report gu",
-    method: { id: "reports.customerUsageReports.get", httpMethod: "GET", path: "admin/reports/v1/usage/dates/{date}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["date"] },
+    method: { id: "reports.customerUsageReports.get", httpMethod: "GET", path: "admin/reports/v1/usage/dates/{date}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["date"], scopes: S_admin_reports_v1[1] },
     params: [{"field":"date","api":"date","location":"path"},{"field":"customerId","api":"customerId","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"parameters","api":"parameters","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1899,7 +1942,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_entity_usage_reports_get",
     cud: "read",
     description: "Retrieves a report which is a collection of properties and statistics for entities used by users within the account. For more information, see the Entities Usag",
-    method: { id: "reports.entityUsageReports.get", httpMethod: "GET", path: "admin/reports/v1/usage/{entityType}/{entityKey}/dates/{date}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["entityType","entityKey","date"] },
+    method: { id: "reports.entityUsageReports.get", httpMethod: "GET", path: "admin/reports/v1/usage/{entityType}/{entityKey}/dates/{date}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["entityType","entityKey","date"], scopes: S_admin_reports_v1[1] },
     params: [{"field":"date","api":"date","location":"path"},{"field":"entityKey","api":"entityKey","location":"path"},{"field":"entityType","api":"entityType","location":"path"},{"field":"customerId","api":"customerId","location":"query"},{"field":"filters","api":"filters","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"parameters","api":"parameters","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1919,7 +1962,7 @@ export function registerAdminGeneratedTools(registry: ToolRegistry): void {
     name: "admin_user_usage_report_get",
     cud: "read",
     description: "Retrieves a report which is a collection of properties and statistics for a set of users with the account. For more information, see the User Usage Report guide",
-    method: { id: "reports.userUsageReport.get", httpMethod: "GET", path: "admin/reports/v1/usage/users/{userKey}/dates/{date}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","date"] },
+    method: { id: "reports.userUsageReport.get", httpMethod: "GET", path: "admin/reports/v1/usage/users/{userKey}/dates/{date}", baseUrl: "https://admin.googleapis.com/", requiredParams: ["userKey","date"], scopes: S_admin_reports_v1[1] },
     params: [{"field":"date","api":"date","location":"path"},{"field":"userKey","api":"userKey","location":"path"},{"field":"customerId","api":"customerId","location":"query"},{"field":"filters","api":"filters","location":"query"},{"field":"groupIdFilter","api":"groupIdFilter","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"orgUnitID","api":"orgUnitID","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"parameters","api":"parameters","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/appsmarket.ts
+++ b/src/tools/generated/appsmarket.ts
@@ -4,11 +4,15 @@ import type { ToolRegistry } from '../../registry.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerAppsmarketGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_appsmarket_v2: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/appsmarketplace.license"],
+  ];
   registerGeneratedTool(registry, {
     name: "appsmarket_customer_license_get",
     cud: "read",
     description: "Gets the customer's licensing status to determine if they have access to a given app. For more information, see [Getting app installation and licensing details]",
-    method: { id: "appsmarket.customerLicense.get", httpMethod: "GET", path: "appsmarket/v2/customerLicense/{applicationId}/{customerId}", baseUrl: "https://appsmarket.googleapis.com/", requiredParams: ["applicationId","customerId"] },
+    method: { id: "appsmarket.customerLicense.get", httpMethod: "GET", path: "appsmarket/v2/customerLicense/{applicationId}/{customerId}", baseUrl: "https://appsmarket.googleapis.com/", requiredParams: ["applicationId","customerId"], scopes: S_appsmarket_v2[0] },
     params: [{"field":"applicationId","api":"applicationId","location":"path"},{"field":"customerId","api":"customerId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -22,7 +26,7 @@ export function registerAppsmarketGeneratedTools(registry: ToolRegistry): void {
     name: "appsmarket_user_license_get",
     cud: "read",
     description: "Gets the user's licensing status to determine if they have permission to use a given app. For more information, see [Getting app installation and licensing deta",
-    method: { id: "appsmarket.userLicense.get", httpMethod: "GET", path: "appsmarket/v2/userLicense/{applicationId}/{userId}", baseUrl: "https://appsmarket.googleapis.com/", requiredParams: ["applicationId","userId"] },
+    method: { id: "appsmarket.userLicense.get", httpMethod: "GET", path: "appsmarket/v2/userLicense/{applicationId}/{userId}", baseUrl: "https://appsmarket.googleapis.com/", requiredParams: ["applicationId","userId"], scopes: S_appsmarket_v2[0] },
     params: [{"field":"applicationId","api":"applicationId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/calendar.ts
+++ b/src/tools/generated/calendar.ts
@@ -5,11 +5,29 @@ import { coerceArray, coerceBoolean, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_calendar_v3: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.acls"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.acls","https://www.googleapis.com/auth/calendar.acls.readonly","https://www.googleapis.com/auth/calendar.readonly"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.acls","https://www.googleapis.com/auth/calendar.acls.readonly"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.app.created","https://www.googleapis.com/auth/calendar.calendarlist"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.app.created","https://www.googleapis.com/auth/calendar.calendarlist","https://www.googleapis.com/auth/calendar.calendarlist.readonly","https://www.googleapis.com/auth/calendar.readonly"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.calendarlist"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.calendarlist","https://www.googleapis.com/auth/calendar.calendarlist.readonly","https://www.googleapis.com/auth/calendar.readonly"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.calendars"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.app.created","https://www.googleapis.com/auth/calendar.calendars"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.app.created","https://www.googleapis.com/auth/calendar.calendars","https://www.googleapis.com/auth/calendar.calendars.readonly","https://www.googleapis.com/auth/calendar.readonly"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.acls","https://www.googleapis.com/auth/calendar.acls.readonly","https://www.googleapis.com/auth/calendar.app.created","https://www.googleapis.com/auth/calendar.calendarlist","https://www.googleapis.com/auth/calendar.calendarlist.readonly","https://www.googleapis.com/auth/calendar.events","https://www.googleapis.com/auth/calendar.events.freebusy","https://www.googleapis.com/auth/calendar.events.owned","https://www.googleapis.com/auth/calendar.events.owned.readonly","https://www.googleapis.com/auth/calendar.events.public.readonly","https://www.googleapis.com/auth/calendar.events.readonly","https://www.googleapis.com/auth/calendar.readonly","https://www.googleapis.com/auth/calendar.settings.readonly"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.app.created","https://www.googleapis.com/auth/calendar.calendarlist","https://www.googleapis.com/auth/calendar.calendarlist.readonly","https://www.googleapis.com/auth/calendar.events.freebusy","https://www.googleapis.com/auth/calendar.events.owned","https://www.googleapis.com/auth/calendar.events.owned.readonly","https://www.googleapis.com/auth/calendar.events.public.readonly","https://www.googleapis.com/auth/calendar.readonly"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.app.created","https://www.googleapis.com/auth/calendar.events","https://www.googleapis.com/auth/calendar.events.owned"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.app.created","https://www.googleapis.com/auth/calendar.events","https://www.googleapis.com/auth/calendar.events.freebusy","https://www.googleapis.com/auth/calendar.events.owned","https://www.googleapis.com/auth/calendar.events.owned.readonly","https://www.googleapis.com/auth/calendar.events.public.readonly","https://www.googleapis.com/auth/calendar.events.readonly","https://www.googleapis.com/auth/calendar.readonly"],
+    ["https://www.googleapis.com/auth/calendar","https://www.googleapis.com/auth/calendar.readonly","https://www.googleapis.com/auth/calendar.settings.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "calendar_acl_delete",
     cud: "delete",
     description: "Deletes an access control rule.",
-    method: { id: "calendar.acl.delete", httpMethod: "DELETE", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","ruleId"] },
+    method: { id: "calendar.acl.delete", httpMethod: "DELETE", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","ruleId"], scopes: S_calendar_v3[0] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"ruleId","api":"ruleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -23,7 +41,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_acl_get",
     cud: "read",
     description: "Returns an access control rule.",
-    method: { id: "calendar.acl.get", httpMethod: "GET", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","ruleId"] },
+    method: { id: "calendar.acl.get", httpMethod: "GET", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","ruleId"], scopes: S_calendar_v3[1] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"ruleId","api":"ruleId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -37,7 +55,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_acl_insert",
     cud: "create",
     description: "Creates an access control rule.",
-    method: { id: "calendar.acl.insert", httpMethod: "POST", path: "calendars/{calendarId}/acl", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.acl.insert", httpMethod: "POST", path: "calendars/{calendarId}/acl", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[0] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"sendNotifications","api":"sendNotifications","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -52,7 +70,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_acl_list",
     cud: "read",
     description: "Returns the rules in the access control list for the calendar.",
-    method: { id: "calendar.acl.list", httpMethod: "GET", path: "calendars/{calendarId}/acl", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.acl.list", httpMethod: "GET", path: "calendars/{calendarId}/acl", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[2] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"showDeleted","api":"showDeleted","location":"query"},{"field":"syncToken","api":"syncToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -69,7 +87,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_acl_patch",
     cud: "update",
     description: "Updates an access control rule. This method supports patch semantics.",
-    method: { id: "calendar.acl.patch", httpMethod: "PATCH", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","ruleId"] },
+    method: { id: "calendar.acl.patch", httpMethod: "PATCH", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","ruleId"], scopes: S_calendar_v3[0] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"ruleId","api":"ruleId","location":"path"},{"field":"sendNotifications","api":"sendNotifications","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -85,7 +103,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_acl_update",
     cud: "update",
     description: "Updates an access control rule.",
-    method: { id: "calendar.acl.update", httpMethod: "PUT", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","ruleId"] },
+    method: { id: "calendar.acl.update", httpMethod: "PUT", path: "calendars/{calendarId}/acl/{ruleId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","ruleId"], scopes: S_calendar_v3[0] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"ruleId","api":"ruleId","location":"path"},{"field":"sendNotifications","api":"sendNotifications","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -101,7 +119,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_acl_watch",
     cud: "create",
     description: "Watch for changes to ACL resources.",
-    method: { id: "calendar.acl.watch", httpMethod: "POST", path: "calendars/{calendarId}/acl/watch", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.acl.watch", httpMethod: "POST", path: "calendars/{calendarId}/acl/watch", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[2] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"showDeleted","api":"showDeleted","location":"query"},{"field":"syncToken","api":"syncToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -119,7 +137,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendar_list_delete",
     cud: "delete",
     description: "Removes a calendar from the user's calendar list.",
-    method: { id: "calendar.calendarList.delete", httpMethod: "DELETE", path: "users/me/calendarList/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.calendarList.delete", httpMethod: "DELETE", path: "users/me/calendarList/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[3] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -132,7 +150,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendar_list_get",
     cud: "read",
     description: "Returns a calendar from the user's calendar list.",
-    method: { id: "calendar.calendarList.get", httpMethod: "GET", path: "users/me/calendarList/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.calendarList.get", httpMethod: "GET", path: "users/me/calendarList/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[4] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -145,7 +163,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendar_list_insert",
     cud: "create",
     description: "Inserts an existing calendar into the user's calendar list.",
-    method: { id: "calendar.calendarList.insert", httpMethod: "POST", path: "users/me/calendarList", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [] },
+    method: { id: "calendar.calendarList.insert", httpMethod: "POST", path: "users/me/calendarList", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [], scopes: S_calendar_v3[5] },
     params: [{"field":"colorRgbFormat","api":"colorRgbFormat","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -159,7 +177,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendar_list_patch",
     cud: "update",
     description: "Updates an existing calendar on the user's calendar list. This method supports patch semantics.",
-    method: { id: "calendar.calendarList.patch", httpMethod: "PATCH", path: "users/me/calendarList/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.calendarList.patch", httpMethod: "PATCH", path: "users/me/calendarList/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[3] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"colorRgbFormat","api":"colorRgbFormat","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -174,7 +192,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendar_list_update",
     cud: "update",
     description: "Updates an existing calendar on the user's calendar list.",
-    method: { id: "calendar.calendarList.update", httpMethod: "PUT", path: "users/me/calendarList/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.calendarList.update", httpMethod: "PUT", path: "users/me/calendarList/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[3] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"colorRgbFormat","api":"colorRgbFormat","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -189,7 +207,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendar_list_watch",
     cud: "create",
     description: "Watch for changes to CalendarList resources.",
-    method: { id: "calendar.calendarList.watch", httpMethod: "POST", path: "users/me/calendarList/watch", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [] },
+    method: { id: "calendar.calendarList.watch", httpMethod: "POST", path: "users/me/calendarList/watch", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [], scopes: S_calendar_v3[6] },
     params: [{"field":"maxResults","api":"maxResults","location":"query"},{"field":"minAccessRole","api":"minAccessRole","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"showDeleted","api":"showDeleted","location":"query"},{"field":"showHidden","api":"showHidden","location":"query"},{"field":"showOwnOrganizationOnly","api":"showOwnOrganizationOnly","location":"query"},{"field":"syncToken","api":"syncToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -209,7 +227,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendars_clear",
     cud: "delete",
     description: "Clears a primary calendar. This operation deletes all events associated with the primary calendar of an account.",
-    method: { id: "calendar.calendars.clear", httpMethod: "POST", path: "calendars/{calendarId}/clear", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.calendars.clear", httpMethod: "POST", path: "calendars/{calendarId}/clear", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[7] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -222,7 +240,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendars_delete",
     cud: "delete",
     description: "Deletes a secondary calendar. Use calendars.clear for clearing all events on primary calendars.",
-    method: { id: "calendar.calendars.delete", httpMethod: "DELETE", path: "calendars/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.calendars.delete", httpMethod: "DELETE", path: "calendars/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[8] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -235,7 +253,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendars_get",
     cud: "read",
     description: "Returns metadata for a calendar.",
-    method: { id: "calendar.calendars.get", httpMethod: "GET", path: "calendars/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.calendars.get", httpMethod: "GET", path: "calendars/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[9] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -248,7 +266,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendars_patch",
     cud: "update",
     description: "Updates metadata for a calendar. This method supports patch semantics.",
-    method: { id: "calendar.calendars.patch", httpMethod: "PATCH", path: "calendars/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.calendars.patch", httpMethod: "PATCH", path: "calendars/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[8] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -262,7 +280,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendars_transfer_ownership",
     cud: "create",
     description: "Transfers a secondary calendar between users within a Google Workspace organization. Requires user authentication with Manage Calendars administrator privilege,",
-    method: { id: "calendar.calendars.transferOwnership", httpMethod: "POST", path: "calendars/{calendarId}/transferOwnership", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","newDataOwner","useAdminAccess"] },
+    method: { id: "calendar.calendars.transferOwnership", httpMethod: "POST", path: "calendars/{calendarId}/transferOwnership", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","newDataOwner","useAdminAccess"], scopes: S_calendar_v3[7] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"newDataOwner","api":"newDataOwner","location":"query"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -277,7 +295,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_calendars_update",
     cud: "update",
     description: "Updates metadata for a calendar.",
-    method: { id: "calendar.calendars.update", httpMethod: "PUT", path: "calendars/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.calendars.update", httpMethod: "PUT", path: "calendars/{calendarId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[8] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -291,7 +309,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_channels_stop",
     cud: "create",
     description: "Stop watching resources through this channel",
-    method: { id: "calendar.channels.stop", httpMethod: "POST", path: "channels/stop", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [] },
+    method: { id: "calendar.channels.stop", httpMethod: "POST", path: "channels/stop", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [], scopes: S_calendar_v3[10] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -304,7 +322,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_colors_get",
     cud: "read",
     description: "Returns the color definitions for calendars and events.",
-    method: { id: "calendar.colors.get", httpMethod: "GET", path: "colors", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [] },
+    method: { id: "calendar.colors.get", httpMethod: "GET", path: "colors", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [], scopes: S_calendar_v3[11] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -316,7 +334,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_events_import",
     cud: "create",
     description: "Imports an event. This operation is used to add a private copy of an existing event to a calendar. Only events with an eventType of default may be imported.",
-    method: { id: "calendar.events.import", httpMethod: "POST", path: "calendars/{calendarId}/events/import", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.events.import", httpMethod: "POST", path: "calendars/{calendarId}/events/import", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[12] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"conferenceDataVersion","api":"conferenceDataVersion","location":"query"},{"field":"eventLabelVersion","api":"eventLabelVersion","location":"query"},{"field":"supportsAttachments","api":"supportsAttachments","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -333,7 +351,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_events_update",
     cud: "update",
     description: "Updates an event.",
-    method: { id: "calendar.events.update", httpMethod: "PUT", path: "calendars/{calendarId}/events/{eventId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","eventId"] },
+    method: { id: "calendar.events.update", httpMethod: "PUT", path: "calendars/{calendarId}/events/{eventId}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId","eventId"], scopes: S_calendar_v3[12] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"eventId","api":"eventId","location":"path"},{"field":"alwaysIncludeEmail","api":"alwaysIncludeEmail","location":"query"},{"field":"conferenceDataVersion","api":"conferenceDataVersion","location":"query"},{"field":"eventLabelVersion","api":"eventLabelVersion","location":"query"},{"field":"maxAttendees","api":"maxAttendees","location":"query"},{"field":"sendNotifications","api":"sendNotifications","location":"query"},{"field":"sendUpdates","api":"sendUpdates","location":"query"},{"field":"supportsAttachments","api":"supportsAttachments","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -355,7 +373,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_events_watch",
     cud: "create",
     description: "Watch for changes to Events resources.",
-    method: { id: "calendar.events.watch", httpMethod: "POST", path: "calendars/{calendarId}/events/watch", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"] },
+    method: { id: "calendar.events.watch", httpMethod: "POST", path: "calendars/{calendarId}/events/watch", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["calendarId"], scopes: S_calendar_v3[13] },
     params: [{"field":"calendarId","api":"calendarId","location":"path"},{"field":"alwaysIncludeEmail","api":"alwaysIncludeEmail","location":"query"},{"field":"eventTypes","api":"eventTypes","location":"query"},{"field":"iCalUID","api":"iCalUID","location":"query"},{"field":"maxAttendees","api":"maxAttendees","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"privateExtendedProperty","api":"privateExtendedProperty","location":"query"},{"field":"q","api":"q","location":"query"},{"field":"sharedExtendedProperty","api":"sharedExtendedProperty","location":"query"},{"field":"showDeleted","api":"showDeleted","location":"query"},{"field":"showHiddenInvitations","api":"showHiddenInvitations","location":"query"},{"field":"singleEvents","api":"singleEvents","location":"query"},{"field":"syncToken","api":"syncToken","location":"query"},{"field":"timeMax","api":"timeMax","location":"query"},{"field":"timeMin","api":"timeMin","location":"query"},{"field":"timeZone","api":"timeZone","location":"query"},{"field":"updatedMin","api":"updatedMin","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -387,7 +405,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_settings_get",
     cud: "read",
     description: "Returns a single user setting.",
-    method: { id: "calendar.settings.get", httpMethod: "GET", path: "users/me/settings/{setting}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["setting"] },
+    method: { id: "calendar.settings.get", httpMethod: "GET", path: "users/me/settings/{setting}", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: ["setting"], scopes: S_calendar_v3[14] },
     params: [{"field":"setting","api":"setting","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -400,7 +418,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_settings_list",
     cud: "read",
     description: "Returns all user settings for the authenticated user.",
-    method: { id: "calendar.settings.list", httpMethod: "GET", path: "users/me/settings", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [] },
+    method: { id: "calendar.settings.list", httpMethod: "GET", path: "users/me/settings", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [], scopes: S_calendar_v3[14] },
     params: [{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"syncToken","api":"syncToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -415,7 +433,7 @@ export function registerCalendarGeneratedTools(registry: ToolRegistry): void {
     name: "calendar_settings_watch",
     cud: "create",
     description: "Watch for changes to Settings resources.",
-    method: { id: "calendar.settings.watch", httpMethod: "POST", path: "users/me/settings/watch", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [] },
+    method: { id: "calendar.settings.watch", httpMethod: "POST", path: "users/me/settings/watch", baseUrl: "https://www.googleapis.com/calendar/v3/", requiredParams: [], scopes: S_calendar_v3[14] },
     params: [{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"syncToken","api":"syncToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/chat.ts
+++ b/src/tools/generated/chat.ts
@@ -5,11 +5,45 @@ import { coerceArray, coerceBoolean, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerChatGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_chat_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/chat.customemojis"],
+    ["https://www.googleapis.com/auth/chat.customemojis","https://www.googleapis.com/auth/chat.customemojis.readonly"],
+    ["https://www.googleapis.com/auth/chat.bot","https://www.googleapis.com/auth/chat.messages","https://www.googleapis.com/auth/chat.messages.readonly"],
+    ["https://www.googleapis.com/auth/chat.import","https://www.googleapis.com/auth/chat.messages","https://www.googleapis.com/auth/chat.messages.create"],
+    ["https://www.googleapis.com/auth/chat.import"],
+    ["https://www.googleapis.com/auth/chat.app.spaces","https://www.googleapis.com/auth/chat.app.spaces.create","https://www.googleapis.com/auth/chat.import","https://www.googleapis.com/auth/chat.spaces","https://www.googleapis.com/auth/chat.spaces.create"],
+    ["https://www.googleapis.com/auth/chat.admin.delete","https://www.googleapis.com/auth/chat.app.delete","https://www.googleapis.com/auth/chat.delete","https://www.googleapis.com/auth/chat.import"],
+    ["https://www.googleapis.com/auth/chat.bot","https://www.googleapis.com/auth/chat.spaces","https://www.googleapis.com/auth/chat.spaces.readonly"],
+    ["https://www.googleapis.com/auth/chat.memberships","https://www.googleapis.com/auth/chat.memberships.readonly"],
+    ["https://www.googleapis.com/auth/chat.admin.memberships","https://www.googleapis.com/auth/chat.app.memberships","https://www.googleapis.com/auth/chat.import","https://www.googleapis.com/auth/chat.memberships","https://www.googleapis.com/auth/chat.memberships.app"],
+    ["https://www.googleapis.com/auth/chat.admin.memberships","https://www.googleapis.com/auth/chat.admin.memberships.readonly","https://www.googleapis.com/auth/chat.app.memberships","https://www.googleapis.com/auth/chat.bot","https://www.googleapis.com/auth/chat.memberships","https://www.googleapis.com/auth/chat.memberships.readonly"],
+    ["https://www.googleapis.com/auth/chat.admin.memberships","https://www.googleapis.com/auth/chat.admin.memberships.readonly","https://www.googleapis.com/auth/chat.app.memberships","https://www.googleapis.com/auth/chat.bot","https://www.googleapis.com/auth/chat.import","https://www.googleapis.com/auth/chat.memberships","https://www.googleapis.com/auth/chat.memberships.readonly"],
+    ["https://www.googleapis.com/auth/chat.admin.memberships","https://www.googleapis.com/auth/chat.app.memberships","https://www.googleapis.com/auth/chat.import","https://www.googleapis.com/auth/chat.memberships"],
+    ["https://www.googleapis.com/auth/chat.bot"],
+    ["https://www.googleapis.com/auth/chat.bot","https://www.googleapis.com/auth/chat.import","https://www.googleapis.com/auth/chat.messages"],
+    ["https://www.googleapis.com/auth/chat.app.messages.readonly","https://www.googleapis.com/auth/chat.bot","https://www.googleapis.com/auth/chat.messages","https://www.googleapis.com/auth/chat.messages.readonly"],
+    ["https://www.googleapis.com/auth/chat.import","https://www.googleapis.com/auth/chat.messages","https://www.googleapis.com/auth/chat.messages.reactions","https://www.googleapis.com/auth/chat.messages.reactions.create"],
+    ["https://www.googleapis.com/auth/chat.import","https://www.googleapis.com/auth/chat.messages","https://www.googleapis.com/auth/chat.messages.reactions"],
+    ["https://www.googleapis.com/auth/chat.messages","https://www.googleapis.com/auth/chat.messages.reactions","https://www.googleapis.com/auth/chat.messages.reactions.readonly","https://www.googleapis.com/auth/chat.messages.readonly"],
+    ["https://www.googleapis.com/auth/chat.messages","https://www.googleapis.com/auth/chat.messages.readonly"],
+    ["https://www.googleapis.com/auth/chat.admin.spaces","https://www.googleapis.com/auth/chat.app.spaces","https://www.googleapis.com/auth/chat.import","https://www.googleapis.com/auth/chat.spaces"],
+    ["https://www.googleapis.com/auth/chat.admin.spaces","https://www.googleapis.com/auth/chat.admin.spaces.readonly","https://www.googleapis.com/auth/chat.spaces","https://www.googleapis.com/auth/chat.spaces.readonly"],
+    ["https://www.googleapis.com/auth/chat.spaces","https://www.googleapis.com/auth/chat.spaces.create"],
+    ["https://www.googleapis.com/auth/chat.app.all.memberships.readonly","https://www.googleapis.com/auth/chat.app.all.messages.readonly","https://www.googleapis.com/auth/chat.app.all.spaces.readonly","https://www.googleapis.com/auth/chat.app.memberships","https://www.googleapis.com/auth/chat.app.memberships.readonly","https://www.googleapis.com/auth/chat.app.messages.readonly","https://www.googleapis.com/auth/chat.app.spaces","https://www.googleapis.com/auth/chat.app.spaces.readonly","https://www.googleapis.com/auth/chat.memberships","https://www.googleapis.com/auth/chat.memberships.readonly","https://www.googleapis.com/auth/chat.messages","https://www.googleapis.com/auth/chat.messages.reactions","https://www.googleapis.com/auth/chat.messages.reactions.readonly","https://www.googleapis.com/auth/chat.messages.readonly","https://www.googleapis.com/auth/chat.spaces","https://www.googleapis.com/auth/chat.spaces.readonly"],
+    ["https://www.googleapis.com/auth/chat.users.availability","https://www.googleapis.com/auth/chat.users.availability.readonly"],
+    ["https://www.googleapis.com/auth/chat.users.availability"],
+    ["https://www.googleapis.com/auth/chat.users.sections"],
+    ["https://www.googleapis.com/auth/chat.users.sections","https://www.googleapis.com/auth/chat.users.sections.readonly"],
+    ["https://www.googleapis.com/auth/chat.users.readstate","https://www.googleapis.com/auth/chat.users.readstate.readonly"],
+    ["https://www.googleapis.com/auth/chat.users.spacesettings"],
+    ["https://www.googleapis.com/auth/chat.users.readstate"],
+  ];
   registerGeneratedTool(registry, {
     name: "chat_custom_emojis_create",
     cud: "create",
     description: "Creates a custom emoji. Custom emojis are only available for Google Workspace accounts, and the administrator must turn custom emojis on for the organization. F",
-    method: { id: "chat.customEmojis.create", httpMethod: "POST", path: "v1/customEmojis", baseUrl: "https://chat.googleapis.com/", requiredParams: [] },
+    method: { id: "chat.customEmojis.create", httpMethod: "POST", path: "v1/customEmojis", baseUrl: "https://chat.googleapis.com/", requiredParams: [], scopes: S_chat_v1[0] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -22,7 +56,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_custom_emojis_delete",
     cud: "delete",
     description: "Deletes a custom emoji. By default, users can only delete custom emoji they created. [Emoji managers](https://support.google.com/a/answer/12850085) assigned by",
-    method: { id: "chat.customEmojis.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.customEmojis.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -35,7 +69,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_custom_emojis_get",
     cud: "read",
     description: "Returns details about a custom emoji. Custom emojis are only available for Google Workspace accounts, and the administrator must turn custom emojis on for the o",
-    method: { id: "chat.customEmojis.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.customEmojis.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -48,7 +82,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_custom_emojis_list",
     cud: "read",
     description: "Lists custom emojis visible to the authenticated user. Custom emojis are only available for Google Workspace accounts, and the administrator must turn custom em",
-    method: { id: "chat.customEmojis.list", httpMethod: "GET", path: "v1/customEmojis", baseUrl: "https://chat.googleapis.com/", requiredParams: [] },
+    method: { id: "chat.customEmojis.list", httpMethod: "GET", path: "v1/customEmojis", baseUrl: "https://chat.googleapis.com/", requiredParams: [], scopes: S_chat_v1[1] },
     params: [{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -63,7 +97,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_media_download",
     cud: "read",
     description: "Downloads media. Download is supported on the URI `/v1/media/{+name}?alt=media`.",
-    method: { id: "chat.media.download", httpMethod: "GET", path: "v1/media/{+resourceName}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["resourceName"] },
+    method: { id: "chat.media.download", httpMethod: "GET", path: "v1/media/{+resourceName}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["resourceName"], scopes: S_chat_v1[2] },
     params: [{"field":"resourceName","api":"resourceName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -76,7 +110,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_media_upload",
     cud: "create",
     description: "Uploads an attachment. For an example, see [Upload media as a file attachment](https://developers.google.com/workspace/chat/upload-media-attachments). Requires",
-    method: { id: "chat.media.upload", httpMethod: "POST", path: "v1/{+parent}/attachments:upload", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "chat.media.upload", httpMethod: "POST", path: "v1/{+parent}/attachments:upload", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"], scopes: S_chat_v1[3] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -90,7 +124,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_complete_import",
     cud: "create",
     description: "Completes the [import process](https://developers.google.com/workspace/chat/import-data) for the specified space and makes it visible to users. Requires [user a",
-    method: { id: "chat.spaces.completeImport", httpMethod: "POST", path: "v1/{+name}:completeImport", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.completeImport", httpMethod: "POST", path: "v1/{+name}:completeImport", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[4] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -104,7 +138,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_create",
     cud: "create",
     description: "Creates a space. Can be used to create a named space, or a group chat in `Import mode`. For an example, see [Create a space](https://developers.google.com/works",
-    method: { id: "chat.spaces.create", httpMethod: "POST", path: "v1/spaces", baseUrl: "https://chat.googleapis.com/", requiredParams: [] },
+    method: { id: "chat.spaces.create", httpMethod: "POST", path: "v1/spaces", baseUrl: "https://chat.googleapis.com/", requiredParams: [], scopes: S_chat_v1[5] },
     params: [{"field":"requestId","api":"requestId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -118,7 +152,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_delete",
     cud: "delete",
     description: "Deletes a named space. Always performs a cascading delete, which means that the space's child resources—like messages posted in the space and memberships in the",
-    method: { id: "chat.spaces.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[6] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -132,7 +166,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_find_direct_message",
     cud: "read",
     description: "Returns the existing direct message with the specified user. If no direct message space is found, returns a `404 NOT_FOUND` error. For an example, see [Find a d",
-    method: { id: "chat.spaces.findDirectMessage", httpMethod: "GET", path: "v1/spaces:findDirectMessage", baseUrl: "https://chat.googleapis.com/", requiredParams: [] },
+    method: { id: "chat.spaces.findDirectMessage", httpMethod: "GET", path: "v1/spaces:findDirectMessage", baseUrl: "https://chat.googleapis.com/", requiredParams: [], scopes: S_chat_v1[7] },
     params: [{"field":"name","api":"name","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -145,7 +179,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_find_group_chats",
     cud: "read",
     description: "Returns all spaces with `spaceType == GROUP_CHAT`, whose human memberships contain exactly the calling user, and the users specified in `FindGroupChatsRequest.u",
-    method: { id: "chat.spaces.findGroupChats", httpMethod: "GET", path: "v1/spaces:findGroupChats", baseUrl: "https://chat.googleapis.com/", requiredParams: [] },
+    method: { id: "chat.spaces.findGroupChats", httpMethod: "GET", path: "v1/spaces:findGroupChats", baseUrl: "https://chat.googleapis.com/", requiredParams: [], scopes: S_chat_v1[8] },
     params: [{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"spaceView","api":"spaceView","location":"query"},{"field":"users","api":"users","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -161,7 +195,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_members_create",
     cud: "create",
     description: "Creates a membership for the calling Chat app, a user, or a Google Group. Creating memberships for other Chat apps isn't supported. When creating a membership,",
-    method: { id: "chat.spaces.members.create", httpMethod: "POST", path: "v1/{+parent}/members", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "chat.spaces.members.create", httpMethod: "POST", path: "v1/{+parent}/members", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"], scopes: S_chat_v1[9] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -176,7 +210,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_members_delete",
     cud: "delete",
     description: "Deletes a membership. For an example, see [Remove a user or a Google Chat app from a space](https://developers.google.com/workspace/chat/delete-members). Suppor",
-    method: { id: "chat.spaces.members.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.members.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[9] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -190,7 +224,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_members_get",
     cud: "read",
     description: "Returns details about a membership. For an example, see [Get details about a user's or Google Chat app's membership](https://developers.google.com/workspace/cha",
-    method: { id: "chat.spaces.members.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.members.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[10] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -204,7 +238,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_members_list",
     cud: "read",
     description: "Lists memberships in a space. For an example, see [List users and Google Chat apps in a space](https://developers.google.com/workspace/chat/list-members). Listi",
-    method: { id: "chat.spaces.members.list", httpMethod: "GET", path: "v1/{+parent}/members", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "chat.spaces.members.list", httpMethod: "GET", path: "v1/{+parent}/members", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"], scopes: S_chat_v1[11] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"showGroups","api":"showGroups","location":"query"},{"field":"showInvited","api":"showInvited","location":"query"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -223,7 +257,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_members_patch",
     cud: "update",
     description: "Updates a membership. For an example, see [Update a user's membership in a space](https://developers.google.com/workspace/chat/update-members). Supports the fol",
-    method: { id: "chat.spaces.members.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.members.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[12] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -239,7 +273,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_messages_attachments_get",
     cud: "read",
     description: "Gets the metadata of a message attachment. The attachment data is fetched using the [media API](https://developers.google.com/workspace/chat/api/reference/rest/",
-    method: { id: "chat.spaces.messages.attachments.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.messages.attachments.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[13] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -252,7 +286,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_messages_delete",
     cud: "delete",
     description: "Deletes a message. For an example, see [Delete a message](https://developers.google.com/workspace/chat/delete-messages). Supports the following types of [authen",
-    method: { id: "chat.spaces.messages.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.messages.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[14] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"force","api":"force","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -266,7 +300,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_messages_get",
     cud: "read",
     description: "Returns details about a message. For an example, see [Get details about a message](https://developers.google.com/workspace/chat/get-messages). Supports the foll",
-    method: { id: "chat.spaces.messages.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.messages.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[15] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"markupSyntax","api":"markupSyntax","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -280,7 +314,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_messages_patch",
     cud: "update",
     description: "Updates a message. There's a difference between the `patch` and `update` methods. The `patch` method uses a `patch` request while the `update` method uses a `pu",
-    method: { id: "chat.spaces.messages.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.messages.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[14] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"allowMissing","api":"allowMissing","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -296,7 +330,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_messages_reactions_create",
     cud: "create",
     description: "Creates a reaction and adds it to a message. For an example, see [Add a reaction to a message](https://developers.google.com/workspace/chat/create-reactions). R",
-    method: { id: "chat.spaces.messages.reactions.create", httpMethod: "POST", path: "v1/{+parent}/reactions", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "chat.spaces.messages.reactions.create", httpMethod: "POST", path: "v1/{+parent}/reactions", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"], scopes: S_chat_v1[16] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -310,7 +344,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_messages_reactions_delete",
     cud: "delete",
     description: "Deletes a reaction to a message. For an example, see [Delete a reaction](https://developers.google.com/workspace/chat/delete-reactions). Requires [user authenti",
-    method: { id: "chat.spaces.messages.reactions.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.messages.reactions.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[17] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -323,7 +357,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_messages_reactions_list",
     cud: "read",
     description: "Lists reactions to a message. For an example, see [List reactions for a message](https://developers.google.com/workspace/chat/list-reactions). Requires [user au",
-    method: { id: "chat.spaces.messages.reactions.list", httpMethod: "GET", path: "v1/{+parent}/reactions", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "chat.spaces.messages.reactions.list", httpMethod: "GET", path: "v1/{+parent}/reactions", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"], scopes: S_chat_v1[18] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -339,7 +373,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_messages_search",
     cud: "read",
     description: "Searches for messages in Google Chat that the calling user has access to. Returns a list of messages matching the search criteria. To search across all spaces t",
-    method: { id: "chat.spaces.messages.search", httpMethod: "POST", path: "v1/{+parent}/messages:search", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "chat.spaces.messages.search", httpMethod: "POST", path: "v1/{+parent}/messages:search", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"], scopes: S_chat_v1[19] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -353,7 +387,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_messages_update",
     cud: "update",
     description: "Updates a message. There's a difference between the `patch` and `update` methods. The `patch` method uses a `patch` request while the `update` method uses a `pu",
-    method: { id: "chat.spaces.messages.update", httpMethod: "PUT", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.messages.update", httpMethod: "PUT", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[14] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"allowMissing","api":"allowMissing","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -369,7 +403,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_patch",
     cud: "update",
     description: "Updates a space. For an example, see [Update a space](https://developers.google.com/workspace/chat/update-spaces). If you're updating the `displayName` field an",
-    method: { id: "chat.spaces.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[20] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -385,7 +419,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_search",
     cud: "read",
     description: "Returns a list of spaces in a Google Workspace organization. For an example, see [Search for and manage spaces](https://developers.google.com/workspace/chat/sea",
-    method: { id: "chat.spaces.search", httpMethod: "GET", path: "v1/spaces:search", baseUrl: "https://chat.googleapis.com/", requiredParams: [] },
+    method: { id: "chat.spaces.search", httpMethod: "GET", path: "v1/spaces:search", baseUrl: "https://chat.googleapis.com/", requiredParams: [], scopes: S_chat_v1[21] },
     params: [{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"query","api":"query","location":"query"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -402,7 +436,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_setup",
     cud: "update",
     description: "Creates a space and adds specified users to it. The calling user is automatically added to the space, and shouldn't be specified as a membership in the request.",
-    method: { id: "chat.spaces.setup", httpMethod: "POST", path: "v1/spaces:setup", baseUrl: "https://chat.googleapis.com/", requiredParams: [] },
+    method: { id: "chat.spaces.setup", httpMethod: "POST", path: "v1/spaces:setup", baseUrl: "https://chat.googleapis.com/", requiredParams: [], scopes: S_chat_v1[22] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -415,7 +449,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_space_events_get",
     cud: "read",
     description: "Returns an event from a Google Chat space. The [event payload](https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.spaceEvents#SpaceEvent.",
-    method: { id: "chat.spaces.spaceEvents.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.spaces.spaceEvents.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[23] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -428,7 +462,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_spaces_space_events_list",
     cud: "read",
     description: "Lists events from a Google Chat space. For each event, the [payload](https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.spaceEvents#Space",
-    method: { id: "chat.spaces.spaceEvents.list", httpMethod: "GET", path: "v1/{+parent}/spaceEvents", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "chat.spaces.spaceEvents.list", httpMethod: "GET", path: "v1/{+parent}/spaceEvents", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"], scopes: S_chat_v1[23] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -444,7 +478,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_availability_get",
     cud: "read",
     description: "Returns availability information for a human user in Google Chat. For example, this can be used to check if a user is online or away, or to retrieve their custo",
-    method: { id: "chat.users.availability.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.availability.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[24] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -457,7 +491,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_availability_mark_as_active",
     cud: "create",
     description: "Marks user as `ACTIVE` in Google Chat. Sets the user's availability state to `ACTIVE`. The `ACTIVE` state lasts until the specified expiration, at which point t",
-    method: { id: "chat.users.availability.markAsActive", httpMethod: "POST", path: "v1/{+name}:markAsActive", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.availability.markAsActive", httpMethod: "POST", path: "v1/{+name}:markAsActive", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[25] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -471,7 +505,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_availability_mark_as_away",
     cud: "create",
     description: "Marks user as `AWAY` in Google Chat. Sets the user's state to away and is not affected by the user's activity. This method only updates the authenticated user's",
-    method: { id: "chat.users.availability.markAsAway", httpMethod: "POST", path: "v1/{+name}:markAsAway", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.availability.markAsAway", httpMethod: "POST", path: "v1/{+name}:markAsAway", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[25] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -485,7 +519,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_availability_mark_as_do_not_disturb",
     cud: "create",
     description: "Marks user as `DO_NOT_DISTURB` in Google Chat. Sets a user's availability state to `DO_NOT_DISTURB` until a specified expiration time. When in `DO_NOT_DISTURB`,",
-    method: { id: "chat.users.availability.markAsDoNotDisturb", httpMethod: "POST", path: "v1/{+name}:markAsDoNotDisturb", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.availability.markAsDoNotDisturb", httpMethod: "POST", path: "v1/{+name}:markAsDoNotDisturb", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[25] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -499,7 +533,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_availability_patch",
     cud: "update",
     description: "Updates availability information for a human user. Only the `custom_status` field can be updated through this method. This method only updates the authenticated",
-    method: { id: "chat.users.availability.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.availability.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[25] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -514,7 +548,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_sections_create",
     cud: "create",
     description: "Creates a section in Google Chat. Sections help users group conversations and customize the list of spaces displayed in Chat navigation panel. Only sections of",
-    method: { id: "chat.users.sections.create", httpMethod: "POST", path: "v1/{+parent}/sections", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "chat.users.sections.create", httpMethod: "POST", path: "v1/{+parent}/sections", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"], scopes: S_chat_v1[26] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -528,7 +562,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_sections_delete",
     cud: "delete",
     description: "Deletes a section of type `CUSTOM_SECTION`. If the section contains items, such as spaces, the items are moved to Google Chat's default sections and are not del",
-    method: { id: "chat.users.sections.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.sections.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[26] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -541,7 +575,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_sections_items_list",
     cud: "read",
     description: "Lists items in a section. Only spaces can be section items. For details, see [Create and organize sections in Google Chat](https://support.google.com/chat/answe",
-    method: { id: "chat.users.sections.items.list", httpMethod: "GET", path: "v1/{+parent}/items", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "chat.users.sections.items.list", httpMethod: "GET", path: "v1/{+parent}/items", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"], scopes: S_chat_v1[27] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -557,7 +591,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_sections_items_move",
     cud: "update",
     description: "Moves an item from one section to another. For example, if a section contains spaces, this method can be used to move a space to a different section. For detail",
-    method: { id: "chat.users.sections.items.move", httpMethod: "POST", path: "v1/{+name}:move", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.sections.items.move", httpMethod: "POST", path: "v1/{+name}:move", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[26] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -571,7 +605,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_sections_list",
     cud: "read",
     description: "Lists sections available to the Chat user. Sections help users group their conversations and customize the list of spaces displayed in Chat navigation panel. Fo",
-    method: { id: "chat.users.sections.list", httpMethod: "GET", path: "v1/{+parent}/sections", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "chat.users.sections.list", httpMethod: "GET", path: "v1/{+parent}/sections", baseUrl: "https://chat.googleapis.com/", requiredParams: ["parent"], scopes: S_chat_v1[27] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -586,7 +620,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_sections_patch",
     cud: "update",
     description: "Updates a section. Only sections of type `CUSTOM_SECTION` can be updated. For details, see [Create and organize sections in Google Chat](https://support.google.",
-    method: { id: "chat.users.sections.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.sections.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[26] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -601,7 +635,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_sections_position",
     cud: "create",
     description: "Changes the sort order of a section. For details, see [Create and organize sections in Google Chat](https://support.google.com/chat/answer/16059854). Requires [",
-    method: { id: "chat.users.sections.position", httpMethod: "POST", path: "v1/{+name}:position", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.sections.position", httpMethod: "POST", path: "v1/{+name}:position", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[26] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -615,7 +649,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_spaces_get_space_read_state",
     cud: "read",
     description: "Returns details about a user's read state within a space, used to identify read and unread messages. For an example, see [Get details about a user's space read",
-    method: { id: "chat.users.spaces.getSpaceReadState", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.spaces.getSpaceReadState", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[28] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -628,7 +662,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_spaces_space_notification_setting_get",
     cud: "read",
     description: "Gets the space notification setting. For an example, see [Get the caller's space notification setting](https://developers.google.com/workspace/chat/get-space-no",
-    method: { id: "chat.users.spaces.spaceNotificationSetting.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.spaces.spaceNotificationSetting.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[29] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -641,7 +675,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_spaces_space_notification_setting_patch",
     cud: "update",
     description: "Updates the space notification setting. For an example, see [Update the caller's space notification setting](https://developers.google.com/workspace/chat/update",
-    method: { id: "chat.users.spaces.spaceNotificationSetting.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.spaces.spaceNotificationSetting.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[29] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -656,7 +690,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_spaces_threads_get_thread_read_state",
     cud: "read",
     description: "Returns details about a user's read state within a thread, used to identify read and unread messages. For an example, see [Get details about a user's thread rea",
-    method: { id: "chat.users.spaces.threads.getThreadReadState", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.spaces.threads.getThreadReadState", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[28] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -669,7 +703,7 @@ export function registerChatGeneratedTools(registry: ToolRegistry): void {
     name: "chat_users_spaces_update_space_read_state",
     cud: "update",
     description: "Updates a user's read state within a space, used to identify read and unread messages. For an example, see [Update a user's space read state](https://developers",
-    method: { id: "chat.users.spaces.updateSpaceReadState", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "chat.users.spaces.updateSpaceReadState", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://chat.googleapis.com/", requiredParams: ["name"], scopes: S_chat_v1[30] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/classroom.ts
+++ b/src/tools/generated/classroom.ts
@@ -5,11 +5,38 @@ import { coerceArray, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_classroom_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/classroom.courses"],
+    ["https://www.googleapis.com/auth/classroom.courses","https://www.googleapis.com/auth/classroom.courses.readonly"],
+    ["https://www.googleapis.com/auth/classroom.addons.teacher"],
+    ["https://www.googleapis.com/auth/classroom.addons.student","https://www.googleapis.com/auth/classroom.addons.teacher"],
+    ["https://www.googleapis.com/auth/classroom.announcements"],
+    ["https://www.googleapis.com/auth/classroom.announcements","https://www.googleapis.com/auth/classroom.announcements.readonly"],
+    ["https://www.googleapis.com/auth/classroom.addons.student","https://www.googleapis.com/auth/classroom.addons.teacher","https://www.googleapis.com/auth/classroom.coursework.me","https://www.googleapis.com/auth/classroom.coursework.me.readonly","https://www.googleapis.com/auth/classroom.coursework.students","https://www.googleapis.com/auth/classroom.coursework.students.readonly","https://www.googleapis.com/auth/classroom.student-submissions.me.readonly","https://www.googleapis.com/auth/classroom.student-submissions.students.readonly"],
+    ["https://www.googleapis.com/auth/classroom.coursework.students"],
+    ["https://www.googleapis.com/auth/classroom.coursework.me","https://www.googleapis.com/auth/classroom.coursework.me.readonly","https://www.googleapis.com/auth/classroom.coursework.students","https://www.googleapis.com/auth/classroom.coursework.students.readonly"],
+    ["https://www.googleapis.com/auth/classroom.coursework.me","https://www.googleapis.com/auth/classroom.coursework.me.readonly","https://www.googleapis.com/auth/classroom.coursework.students","https://www.googleapis.com/auth/classroom.coursework.students.readonly","https://www.googleapis.com/auth/classroom.student-submissions.me.readonly","https://www.googleapis.com/auth/classroom.student-submissions.students.readonly"],
+    ["https://www.googleapis.com/auth/classroom.coursework.me","https://www.googleapis.com/auth/classroom.coursework.students"],
+    ["https://www.googleapis.com/auth/classroom.coursework.me"],
+    ["https://www.googleapis.com/auth/classroom.courseworkmaterials"],
+    ["https://www.googleapis.com/auth/classroom.courseworkmaterials","https://www.googleapis.com/auth/classroom.courseworkmaterials.readonly"],
+    ["https://www.googleapis.com/auth/classroom.rosters"],
+    ["https://www.googleapis.com/auth/classroom.rosters","https://www.googleapis.com/auth/classroom.rosters.readonly"],
+    ["https://www.googleapis.com/auth/classroom.profile.emails","https://www.googleapis.com/auth/classroom.profile.photos","https://www.googleapis.com/auth/classroom.rosters"],
+    ["https://www.googleapis.com/auth/classroom.profile.emails","https://www.googleapis.com/auth/classroom.profile.photos","https://www.googleapis.com/auth/classroom.rosters","https://www.googleapis.com/auth/classroom.rosters.readonly"],
+    ["https://www.googleapis.com/auth/classroom.topics"],
+    ["https://www.googleapis.com/auth/classroom.topics","https://www.googleapis.com/auth/classroom.topics.readonly"],
+    ["https://www.googleapis.com/auth/classroom.push-notifications"],
+    ["https://www.googleapis.com/auth/classroom.guardianlinks.students"],
+    ["https://www.googleapis.com/auth/classroom.guardianlinks.students","https://www.googleapis.com/auth/classroom.guardianlinks.students.readonly"],
+    ["https://www.googleapis.com/auth/classroom.guardianlinks.me.readonly","https://www.googleapis.com/auth/classroom.guardianlinks.students","https://www.googleapis.com/auth/classroom.guardianlinks.students.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "classroom_courses_aliases_create",
     cud: "create",
     description: "Creates an alias for a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to create the alias",
-    method: { id: "classroom.courses.aliases.create", httpMethod: "POST", path: "v1/courses/{courseId}/aliases", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.aliases.create", httpMethod: "POST", path: "v1/courses/{courseId}/aliases", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[0] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -23,7 +50,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_aliases_delete",
     cud: "delete",
     description: "Deletes an alias of a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to remove the alias o",
-    method: { id: "classroom.courses.aliases.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/aliases/{alias}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","alias"] },
+    method: { id: "classroom.courses.aliases.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/aliases/{alias}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","alias"], scopes: S_classroom_v1[0] },
     params: [{"field":"alias","api":"alias","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -37,7 +64,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_aliases_list",
     cud: "read",
     description: "Returns a list of aliases for a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access t",
-    method: { id: "classroom.courses.aliases.list", httpMethod: "GET", path: "v1/courses/{courseId}/aliases", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.aliases.list", httpMethod: "GET", path: "v1/courses/{courseId}/aliases", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[1] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -52,7 +79,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_add_on_attachments_create",
     cud: "create",
     description: "Creates an add-on attachment under a post. Requires the add-on to have permission to create new attachments on the post. This method returns the following error",
-    method: { id: "classroom.courses.announcements.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
+    method: { id: "classroom.courses.announcements.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"], scopes: S_classroom_v1[2] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -69,7 +96,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_add_on_attachments_delete",
     cud: "delete",
     description: "Deletes an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.announcements.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
+    method: { id: "classroom.courses.announcements.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"], scopes: S_classroom_v1[2] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -85,7 +112,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_add_on_attachments_get",
     cud: "read",
     description: "Returns an add-on attachment. Requires the add-on requesting the attachment to be the original creator of the attachment. This method returns the following erro",
-    method: { id: "classroom.courses.announcements.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
+    method: { id: "classroom.courses.announcements.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"], scopes: S_classroom_v1[3] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -101,7 +128,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_add_on_attachments_list",
     cud: "read",
     description: "Returns all attachments created by an add-on under the post. Requires the add-on to have active attachments on the post or have permission to create new attachm",
-    method: { id: "classroom.courses.announcements.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
+    method: { id: "classroom.courses.announcements.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"], scopes: S_classroom_v1[3] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -118,7 +145,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_add_on_attachments_patch",
     cud: "update",
     description: "Updates an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.announcements.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
+    method: { id: "classroom.courses.announcements.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/announcements/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"], scopes: S_classroom_v1[2] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -136,7 +163,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_create",
     cud: "create",
     description: "Creates an announcement. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access the requested co",
-    method: { id: "classroom.courses.announcements.create", httpMethod: "POST", path: "v1/courses/{courseId}/announcements", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.announcements.create", httpMethod: "POST", path: "v1/courses/{courseId}/announcements", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[4] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -150,7 +177,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_delete",
     cud: "delete",
     description: "Deletes an announcement. This request must be made by the Developer Console project of the [OAuth client ID](https://support.google.com/cloud/answer/6158849) us",
-    method: { id: "classroom.courses.announcements.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/announcements/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.announcements.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/announcements/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[4] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -164,7 +191,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_get",
     cud: "read",
     description: "Returns an announcement. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access the requested co",
-    method: { id: "classroom.courses.announcements.get", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.announcements.get", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[5] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -178,7 +205,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_get_add_on_context",
     cud: "read",
     description: "Gets metadata for Classroom add-ons in the context of a specific post. To maintain the integrity of its own data and permissions model, an add-on should call th",
-    method: { id: "classroom.courses.announcements.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{itemId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
+    method: { id: "classroom.courses.announcements.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/announcements/{itemId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"], scopes: S_classroom_v1[3] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"attachmentId","api":"attachmentId","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -195,7 +222,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_list",
     cud: "read",
     description: "Returns a list of announcements that the requester is permitted to view. Course students may only view `PUBLISHED` announcements. Course teachers and domain adm",
-    method: { id: "classroom.courses.announcements.list", httpMethod: "GET", path: "v1/courses/{courseId}/announcements", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.announcements.list", httpMethod: "GET", path: "v1/courses/{courseId}/announcements", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[5] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"announcementStates","api":"announcementStates","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -212,7 +239,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_modify_assignees",
     cud: "update",
     description: "Modifies assignee mode and options of an announcement. Only a teacher of the course that contains the announcement may call this method. This method returns the",
-    method: { id: "classroom.courses.announcements.modifyAssignees", httpMethod: "POST", path: "v1/courses/{courseId}/announcements/{id}:modifyAssignees", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.announcements.modifyAssignees", httpMethod: "POST", path: "v1/courses/{courseId}/announcements/{id}:modifyAssignees", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[4] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -227,7 +254,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_announcements_patch",
     cud: "update",
     description: "Updates one or more fields of an announcement. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting developer project did not",
-    method: { id: "classroom.courses.announcements.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/announcements/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.announcements.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/announcements/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[4] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -243,7 +270,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_add_on_attachments_create",
     cud: "create",
     description: "Creates an add-on attachment under a post. Requires the add-on to have permission to create new attachments on the post. This method returns the following error",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"], scopes: S_classroom_v1[2] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -260,7 +287,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_add_on_attachments_delete",
     cud: "delete",
     description: "Deletes an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"], scopes: S_classroom_v1[2] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -276,7 +303,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_add_on_attachments_get",
     cud: "read",
     description: "Returns an add-on attachment. Requires the add-on requesting the attachment to be the original creator of the attachment. This method returns the following erro",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"], scopes: S_classroom_v1[3] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -292,7 +319,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_add_on_attachments_list",
     cud: "read",
     description: "Returns all attachments created by an add-on under the post. Requires the add-on to have active attachments on the post or have permission to create new attachm",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"], scopes: S_classroom_v1[3] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -309,7 +336,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_add_on_attachments_patch",
     cud: "update",
     description: "Updates an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"], scopes: S_classroom_v1[2] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -327,7 +354,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_coursework_addon_submissions_get",
     cud: "read",
     description: "Returns a student submission for an add-on attachment. This method returns the following error codes: * `PERMISSION_DENIED` for access errors. * `INVALID_ARGUME",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.studentSubmissions.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId","submissionId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.studentSubmissions.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId","submissionId"], scopes: S_classroom_v1[6] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"submissionId","api":"submissionId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -344,7 +371,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_coursework_addon_submissions_patch",
     cud: "update",
     description: "Updates data associated with an add-on attachment submission. Requires the add-on to have been the original creator of the attachment and the attachment to have",
-    method: { id: "classroom.courses.courseWork.addOnAttachments.studentSubmissions.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId","submissionId"] },
+    method: { id: "classroom.courses.courseWork.addOnAttachments.studentSubmissions.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId","submissionId"], scopes: S_classroom_v1[2] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"submissionId","api":"submissionId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -363,7 +390,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_create",
     cud: "create",
     description: "Creates course work. The resulting course work (and corresponding student submissions) are associated with the Developer Console project of the [OAuth client ID",
-    method: { id: "classroom.courses.courseWork.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.courseWork.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[7] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -377,7 +404,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_delete",
     cud: "delete",
     description: "Deletes a course work. This request must be made by the Developer Console project of the [OAuth client ID](https://support.google.com/cloud/answer/6158849) used",
-    method: { id: "classroom.courses.courseWork.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWork/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.courseWork.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWork/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[7] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -391,7 +418,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_get",
     cud: "read",
     description: "Returns course work. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access the requested course",
-    method: { id: "classroom.courses.courseWork.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.courseWork.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[8] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -405,7 +432,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_get_add_on_context",
     cud: "read",
     description: "Gets metadata for Classroom add-ons in the context of a specific post. To maintain the integrity of its own data and permissions model, an add-on should call th",
-    method: { id: "classroom.courses.courseWork.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
+    method: { id: "classroom.courses.courseWork.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{itemId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"], scopes: S_classroom_v1[3] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"attachmentId","api":"attachmentId","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -422,7 +449,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_list",
     cud: "read",
     description: "Returns a list of course work that the requester is permitted to view. Course students may only view `PUBLISHED` course work. Course teachers and domain adminis",
-    method: { id: "classroom.courses.courseWork.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.courseWork.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[8] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkStates","api":"courseWorkStates","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -439,7 +466,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_modify_assignees",
     cud: "update",
     description: "Modifies assignee mode and options of a coursework. Only a teacher of the course that contains the coursework may call this method. This method returns the foll",
-    method: { id: "classroom.courses.courseWork.modifyAssignees", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{id}:modifyAssignees", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.courseWork.modifyAssignees", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{id}:modifyAssignees", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[7] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -454,7 +481,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_patch",
     cud: "update",
     description: "Updates one or more fields of a course work. See google.classroom.v1.CourseWork for details of which fields may be updated and who may change them. This request",
-    method: { id: "classroom.courses.courseWork.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.courseWork.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[7] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -470,7 +497,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_rubrics_create",
     cud: "create",
     description: "Creates a rubric. The requesting user and course owner must have rubrics creation capabilities. For details, see [licensing requirements](https://developers.goo",
-    method: { id: "classroom.courses.courseWork.rubrics.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId"] },
+    method: { id: "classroom.courses.courseWork.rubrics.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId"], scopes: S_classroom_v1[7] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -485,7 +512,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_rubrics_delete",
     cud: "delete",
     description: "Deletes a rubric. The requesting user and course owner must have rubrics creation capabilities. For details, see [licensing requirements](https://developers.goo",
-    method: { id: "classroom.courses.courseWork.rubrics.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
+    method: { id: "classroom.courses.courseWork.rubrics.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"], scopes: S_classroom_v1[7] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -500,7 +527,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_rubrics_get",
     cud: "read",
     description: "Returns a rubric. This method returns the following error codes: * `PERMISSION_DENIED` for access errors. * `INVALID_ARGUMENT` if the request is malformed. * `N",
-    method: { id: "classroom.courses.courseWork.rubrics.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
+    method: { id: "classroom.courses.courseWork.rubrics.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"], scopes: S_classroom_v1[8] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -515,7 +542,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_rubrics_list",
     cud: "read",
     description: "Returns a list of rubrics that the requester is permitted to view. This method returns the following error codes: * `PERMISSION_DENIED` for access errors. * `IN",
-    method: { id: "classroom.courses.courseWork.rubrics.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId"] },
+    method: { id: "classroom.courses.courseWork.rubrics.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId"], scopes: S_classroom_v1[8] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -531,7 +558,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_rubrics_patch",
     cud: "update",
     description: "Updates a rubric. See google.classroom.v1.Rubric for details of which fields can be updated. Rubric update capabilities are [limited](/classroom/rubrics/limitat",
-    method: { id: "classroom.courses.courseWork.rubrics.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
+    method: { id: "classroom.courses.courseWork.rubrics.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubrics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"], scopes: S_classroom_v1[7] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -548,7 +575,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_student_submissions_get",
     cud: "read",
     description: "Returns a student submission. * `PERMISSION_DENIED` if the requesting user is not permitted to access the requested course, course work, or student submission o",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"], scopes: S_classroom_v1[9] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -563,7 +590,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_student_submissions_list",
     cud: "read",
     description: "Returns a list of student submissions that the requester is permitted to view, factoring in the OAuth scopes of the request. A hyphen (`-`) may be specified as",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId"], scopes: S_classroom_v1[9] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"late","api":"late","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"states","api":"states","location":"query"},{"field":"userId","api":"userId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -582,7 +609,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_coursework_submissions_modify_attachments",
     cud: "update",
     description: "Modifies attachments of student submission. Attachments may only be added to student submissions belonging to course work objects with a `workType` of `ASSIGNME",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.modifyAttachments", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:modifyAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.modifyAttachments", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:modifyAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"], scopes: S_classroom_v1[10] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -598,7 +625,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_student_submissions_patch",
     cud: "update",
     description: "Updates one or more fields of a student submission. See google.classroom.v1.StudentSubmission for details of which fields may be updated and who may change them",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"], scopes: S_classroom_v1[10] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -615,7 +642,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_student_submissions_reclaim",
     cud: "create",
     description: "Reclaims a student submission on behalf of the student that owns it. Reclaiming a student submission transfers ownership of attached Drive files to the student",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.reclaim", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:reclaim", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.reclaim", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:reclaim", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"], scopes: S_classroom_v1[11] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -631,7 +658,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_student_submissions_return",
     cud: "create",
     description: "Returns a student submission. Returning a student submission transfers ownership of attached Drive files to the student and may also update the submission state",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.return", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:return", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.return", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:return", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"], scopes: S_classroom_v1[7] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -647,7 +674,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_student_submissions_turn_in",
     cud: "create",
     description: "Turns in a student submission. Turning in a student submission transfers ownership of attached Drive files to the teacher and may also update the submission sta",
-    method: { id: "classroom.courses.courseWork.studentSubmissions.turnIn", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:turnIn", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"] },
+    method: { id: "classroom.courses.courseWork.studentSubmissions.turnIn", httpMethod: "POST", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/studentSubmissions/{id}:turnIn", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId","id"], scopes: S_classroom_v1[11] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -663,7 +690,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_update_rubric",
     cud: "update",
     description: "Updates a rubric. See google.classroom.v1.Rubric for details of which fields can be updated. Rubric update capabilities are [limited](/classroom/rubrics/limitat",
-    method: { id: "classroom.courses.courseWork.updateRubric", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubric", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId"] },
+    method: { id: "classroom.courses.courseWork.updateRubric", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWork/{courseWorkId}/rubric", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","courseWorkId"], scopes: S_classroom_v1[7] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkId","api":"courseWorkId","location":"path"},{"field":"id","api":"id","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -680,7 +707,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_coursework_materials_addons_create",
     cud: "create",
     description: "Creates an add-on attachment under a post. Requires the add-on to have permission to create new attachments on the post. This method returns the following error",
-    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"], scopes: S_classroom_v1[2] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -697,7 +724,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_coursework_materials_addons_delete",
     cud: "delete",
     description: "Deletes an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"], scopes: S_classroom_v1[2] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -713,7 +740,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_add_on_attachments_get",
     cud: "read",
     description: "Returns an add-on attachment. Requires the add-on requesting the attachment to be the original creator of the attachment. This method returns the following erro",
-    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"], scopes: S_classroom_v1[3] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -729,7 +756,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_add_on_attachments_list",
     cud: "read",
     description: "Returns all attachments created by an add-on under the post. Requires the add-on to have active attachments on the post or have permission to create new attachm",
-    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"], scopes: S_classroom_v1[3] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -746,7 +773,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_add_on_attachments_patch",
     cud: "update",
     description: "Updates an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId","attachmentId"], scopes: S_classroom_v1[2] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"postId","api":"postId","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -764,7 +791,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_create",
     cud: "create",
     description: "Creates a course work material. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access the reque",
-    method: { id: "classroom.courses.courseWorkMaterials.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWorkMaterials", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.create", httpMethod: "POST", path: "v1/courses/{courseId}/courseWorkMaterials", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[12] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -778,7 +805,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_delete",
     cud: "delete",
     description: "Deletes a course work material. This request must be made by the Developer Console project of the [OAuth client ID](https://support.google.com/cloud/answer/6158",
-    method: { id: "classroom.courses.courseWorkMaterials.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWorkMaterials/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.courseWorkMaterials.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/courseWorkMaterials/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[12] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -792,7 +819,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_get",
     cud: "read",
     description: "Returns a course work material. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access the reque",
-    method: { id: "classroom.courses.courseWorkMaterials.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.courseWorkMaterials.get", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[13] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -806,7 +833,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_get_add_on_context",
     cud: "read",
     description: "Gets metadata for Classroom add-ons in the context of a specific post. To maintain the integrity of its own data and permissions model, an add-on should call th",
-    method: { id: "classroom.courses.courseWorkMaterials.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials/{itemId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","itemId"], scopes: S_classroom_v1[3] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"itemId","api":"itemId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"attachmentId","api":"attachmentId","location":"query"},{"field":"postId","api":"postId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -823,7 +850,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_list",
     cud: "read",
     description: "Returns a list of course work material that the requester is permitted to view. Course students may only view `PUBLISHED` course work material. Course teachers",
-    method: { id: "classroom.courses.courseWorkMaterials.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.courseWorkMaterials.list", httpMethod: "GET", path: "v1/courses/{courseId}/courseWorkMaterials", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[13] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"courseWorkMaterialStates","api":"courseWorkMaterialStates","location":"query"},{"field":"materialDriveId","api":"materialDriveId","location":"query"},{"field":"materialLink","api":"materialLink","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -842,7 +869,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_course_work_materials_patch",
     cud: "update",
     description: "Updates one or more fields of a course work material. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting developer project f",
-    method: { id: "classroom.courses.courseWorkMaterials.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWorkMaterials/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.courseWorkMaterials.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/courseWorkMaterials/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[12] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -858,7 +885,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_create",
     cud: "create",
     description: "Creates a course. The user specified in `ownerId` is the owner of the created course and added as a teacher. A non-admin requesting user can only create a cours",
-    method: { id: "classroom.courses.create", httpMethod: "POST", path: "v1/courses", baseUrl: "https://classroom.googleapis.com/", requiredParams: [] },
+    method: { id: "classroom.courses.create", httpMethod: "POST", path: "v1/courses", baseUrl: "https://classroom.googleapis.com/", requiredParams: [], scopes: S_classroom_v1[0] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -871,7 +898,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_delete",
     cud: "delete",
     description: "Deletes a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to delete the requested course or",
-    method: { id: "classroom.courses.delete", httpMethod: "DELETE", path: "v1/courses/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"] },
+    method: { id: "classroom.courses.delete", httpMethod: "DELETE", path: "v1/courses/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"], scopes: S_classroom_v1[0] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -884,7 +911,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_get",
     cud: "read",
     description: "Returns a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access the requested course or",
-    method: { id: "classroom.courses.get", httpMethod: "GET", path: "v1/courses/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"] },
+    method: { id: "classroom.courses.get", httpMethod: "GET", path: "v1/courses/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"], scopes: S_classroom_v1[1] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -897,7 +924,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_get_grading_period_settings",
     cud: "read",
     description: "Returns the grading period settings in a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user isn't permitted to",
-    method: { id: "classroom.courses.getGradingPeriodSettings", httpMethod: "GET", path: "v1/courses/{courseId}/gradingPeriodSettings", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.getGradingPeriodSettings", httpMethod: "GET", path: "v1/courses/{courseId}/gradingPeriodSettings", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[1] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -910,7 +937,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_list",
     cud: "read",
     description: "Returns a list of courses that the requesting user is permitted to view, restricted to those that match the request. Returned courses are ordered by creation ti",
-    method: { id: "classroom.courses.list", httpMethod: "GET", path: "v1/courses", baseUrl: "https://classroom.googleapis.com/", requiredParams: [] },
+    method: { id: "classroom.courses.list", httpMethod: "GET", path: "v1/courses", baseUrl: "https://classroom.googleapis.com/", requiredParams: [], scopes: S_classroom_v1[1] },
     params: [{"field":"courseStates","api":"courseStates","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"studentId","api":"studentId","location":"query"},{"field":"teacherId","api":"teacherId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -927,7 +954,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_patch",
     cud: "update",
     description: "Updates one or more fields in a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to modify t",
-    method: { id: "classroom.courses.patch", httpMethod: "PATCH", path: "v1/courses/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"] },
+    method: { id: "classroom.courses.patch", httpMethod: "PATCH", path: "v1/courses/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"], scopes: S_classroom_v1[0] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -942,7 +969,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_posts_add_on_attachments_create",
     cud: "create",
     description: "Creates an add-on attachment under a post. Requires the add-on to have permission to create new attachments on the post. This method returns the following error",
-    method: { id: "classroom.courses.posts.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.create", httpMethod: "POST", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId"], scopes: S_classroom_v1[2] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"itemId","api":"itemId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -959,7 +986,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_posts_add_on_attachments_delete",
     cud: "delete",
     description: "Deletes an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.posts.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId"], scopes: S_classroom_v1[2] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"itemId","api":"itemId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -975,7 +1002,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_posts_add_on_attachments_get",
     cud: "read",
     description: "Returns an add-on attachment. Requires the add-on requesting the attachment to be the original creator of the attachment. This method returns the following erro",
-    method: { id: "classroom.courses.posts.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.get", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId"], scopes: S_classroom_v1[3] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"itemId","api":"itemId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -991,7 +1018,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_posts_add_on_attachments_list",
     cud: "read",
     description: "Returns all attachments created by an add-on under the post. Requires the add-on to have active attachments on the post or have permission to create new attachm",
-    method: { id: "classroom.courses.posts.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.list", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId"], scopes: S_classroom_v1[3] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"itemId","api":"itemId","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1008,7 +1035,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_posts_add_on_attachments_patch",
     cud: "update",
     description: "Updates an add-on attachment. Requires the add-on to have been the original creator of the attachment. This method returns the following error codes: * `PERMISS",
-    method: { id: "classroom.courses.posts.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId"], scopes: S_classroom_v1[2] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"itemId","api":"itemId","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1026,7 +1053,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_posts_addon_submissions_get",
     cud: "read",
     description: "Returns a student submission for an add-on attachment. This method returns the following error codes: * `PERMISSION_DENIED` for access errors. * `INVALID_ARGUME",
-    method: { id: "classroom.courses.posts.addOnAttachments.studentSubmissions.get", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId","submissionId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.studentSubmissions.get", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId","submissionId"], scopes: S_classroom_v1[6] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"submissionId","api":"submissionId","location":"path"},{"field":"itemId","api":"itemId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1043,7 +1070,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_posts_addon_submissions_patch",
     cud: "update",
     description: "Updates data associated with an add-on attachment submission. Requires the add-on to have been the original creator of the attachment and the attachment to have",
-    method: { id: "classroom.courses.posts.addOnAttachments.studentSubmissions.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId","submissionId"] },
+    method: { id: "classroom.courses.posts.addOnAttachments.studentSubmissions.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/posts/{postId}/addOnAttachments/{attachmentId}/studentSubmissions/{submissionId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId","attachmentId","submissionId"], scopes: S_classroom_v1[2] },
     params: [{"field":"attachmentId","api":"attachmentId","location":"path"},{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"submissionId","api":"submissionId","location":"path"},{"field":"itemId","api":"itemId","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1062,7 +1089,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_posts_get_add_on_context",
     cud: "read",
     description: "Gets metadata for Classroom add-ons in the context of a specific post. To maintain the integrity of its own data and permissions model, an add-on should call th",
-    method: { id: "classroom.courses.posts.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId"] },
+    method: { id: "classroom.courses.posts.getAddOnContext", httpMethod: "GET", path: "v1/courses/{courseId}/posts/{postId}/addOnContext", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","postId"], scopes: S_classroom_v1[3] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"postId","api":"postId","location":"path"},{"field":"addOnToken","api":"addOnToken","location":"query"},{"field":"attachmentId","api":"attachmentId","location":"query"},{"field":"itemId","api":"itemId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1079,7 +1106,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_student_groups_create",
     cud: "create",
     description: "Creates a student group for a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to create the",
-    method: { id: "classroom.courses.studentGroups.create", httpMethod: "POST", path: "v1/courses/{courseId}/studentGroups", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.studentGroups.create", httpMethod: "POST", path: "v1/courses/{courseId}/studentGroups", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[14] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1093,7 +1120,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_student_groups_delete",
     cud: "delete",
     description: "Deletes a student group. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to delete the requested st",
-    method: { id: "classroom.courses.studentGroups.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/studentGroups/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.studentGroups.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/studentGroups/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[14] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1107,7 +1134,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_student_groups_list",
     cud: "read",
     description: "Returns a list of groups in a course. This method returns the following error codes: * `NOT_FOUND` if the course does not exist.",
-    method: { id: "classroom.courses.studentGroups.list", httpMethod: "GET", path: "v1/courses/{courseId}/studentGroups", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.studentGroups.list", httpMethod: "GET", path: "v1/courses/{courseId}/studentGroups", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[15] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1122,7 +1149,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_student_groups_patch",
     cud: "update",
     description: "Updates one or more fields in a student group. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to m",
-    method: { id: "classroom.courses.studentGroups.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/studentGroups/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.studentGroups.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/studentGroups/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[14] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1138,7 +1165,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_student_groups_student_group_members_create",
     cud: "create",
     description: "Creates a student group member for a student group. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted",
-    method: { id: "classroom.courses.studentGroups.studentGroupMembers.create", httpMethod: "POST", path: "v1/courses/{courseId}/studentGroups/{studentGroupId}/studentGroupMembers", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","studentGroupId"] },
+    method: { id: "classroom.courses.studentGroups.studentGroupMembers.create", httpMethod: "POST", path: "v1/courses/{courseId}/studentGroups/{studentGroupId}/studentGroupMembers", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","studentGroupId"], scopes: S_classroom_v1[14] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"studentGroupId","api":"studentGroupId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1153,7 +1180,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_student_groups_student_group_members_delete",
     cud: "delete",
     description: "Deletes a student group member. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to delete the reque",
-    method: { id: "classroom.courses.studentGroups.studentGroupMembers.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/studentGroups/{studentGroupId}/studentGroupMembers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","studentGroupId","userId"] },
+    method: { id: "classroom.courses.studentGroups.studentGroupMembers.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/studentGroups/{studentGroupId}/studentGroupMembers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","studentGroupId","userId"], scopes: S_classroom_v1[14] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"studentGroupId","api":"studentGroupId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1168,7 +1195,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_student_groups_student_group_members_list",
     cud: "read",
     description: "Returns a list of students in a group. This method returns the following error codes: * `NOT_FOUND` if the course or student group does not exist.",
-    method: { id: "classroom.courses.studentGroups.studentGroupMembers.list", httpMethod: "GET", path: "v1/courses/{courseId}/studentGroups/{studentGroupId}/studentGroupMembers", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","studentGroupId"] },
+    method: { id: "classroom.courses.studentGroups.studentGroupMembers.list", httpMethod: "GET", path: "v1/courses/{courseId}/studentGroups/{studentGroupId}/studentGroupMembers", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","studentGroupId"], scopes: S_classroom_v1[15] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"studentGroupId","api":"studentGroupId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1184,7 +1211,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_students_create",
     cud: "create",
     description: "Adds a user as a student of a course. Domain administrators are permitted to [directly add](https://developers.google.com/workspace/classroom/guides/manage-user",
-    method: { id: "classroom.courses.students.create", httpMethod: "POST", path: "v1/courses/{courseId}/students", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.students.create", httpMethod: "POST", path: "v1/courses/{courseId}/students", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[16] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"enrollmentCode","api":"enrollmentCode","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1199,7 +1226,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_students_delete",
     cud: "delete",
     description: "Deletes a student of a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to delete students o",
-    method: { id: "classroom.courses.students.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/students/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"] },
+    method: { id: "classroom.courses.students.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/students/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"], scopes: S_classroom_v1[14] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1213,7 +1240,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_students_get",
     cud: "read",
     description: "Returns a student of a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to view students of",
-    method: { id: "classroom.courses.students.get", httpMethod: "GET", path: "v1/courses/{courseId}/students/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"] },
+    method: { id: "classroom.courses.students.get", httpMethod: "GET", path: "v1/courses/{courseId}/students/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"], scopes: S_classroom_v1[17] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1227,7 +1254,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_students_list",
     cud: "read",
     description: "Returns a list of students of this course that the requester is permitted to view. This method returns the following error codes: * `NOT_FOUND` if the course do",
-    method: { id: "classroom.courses.students.list", httpMethod: "GET", path: "v1/courses/{courseId}/students", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.students.list", httpMethod: "GET", path: "v1/courses/{courseId}/students", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[17] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1242,7 +1269,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_teachers_create",
     cud: "create",
     description: "Creates a teacher of a course. Domain administrators are permitted to [directly add](https://developers.google.com/workspace/classroom/guides/manage-users) user",
-    method: { id: "classroom.courses.teachers.create", httpMethod: "POST", path: "v1/courses/{courseId}/teachers", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.teachers.create", httpMethod: "POST", path: "v1/courses/{courseId}/teachers", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[16] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1256,7 +1283,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_teachers_delete",
     cud: "delete",
     description: "Removes the specified teacher from the specified course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not perm",
-    method: { id: "classroom.courses.teachers.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/teachers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"] },
+    method: { id: "classroom.courses.teachers.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/teachers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"], scopes: S_classroom_v1[14] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1270,7 +1297,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_teachers_get",
     cud: "read",
     description: "Returns a teacher of a course. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to view teachers of",
-    method: { id: "classroom.courses.teachers.get", httpMethod: "GET", path: "v1/courses/{courseId}/teachers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"] },
+    method: { id: "classroom.courses.teachers.get", httpMethod: "GET", path: "v1/courses/{courseId}/teachers/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","userId"], scopes: S_classroom_v1[17] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1284,7 +1311,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_teachers_list",
     cud: "read",
     description: "Returns a list of teachers of this course that the requester is permitted to view. This method returns the following error codes: * `NOT_FOUND` if the course do",
-    method: { id: "classroom.courses.teachers.list", httpMethod: "GET", path: "v1/courses/{courseId}/teachers", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.teachers.list", httpMethod: "GET", path: "v1/courses/{courseId}/teachers", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[17] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1299,7 +1326,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_topics_create",
     cud: "create",
     description: "Creates a topic. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access the requested course, cr",
-    method: { id: "classroom.courses.topics.create", httpMethod: "POST", path: "v1/courses/{courseId}/topics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.topics.create", httpMethod: "POST", path: "v1/courses/{courseId}/topics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[18] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1313,7 +1340,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_topics_delete",
     cud: "delete",
     description: "Deletes a topic. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not allowed to delete the requested topic or for",
-    method: { id: "classroom.courses.topics.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/topics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.topics.delete", httpMethod: "DELETE", path: "v1/courses/{courseId}/topics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[18] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1327,7 +1354,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_topics_get",
     cud: "read",
     description: "Returns a topic. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access the requested course or",
-    method: { id: "classroom.courses.topics.get", httpMethod: "GET", path: "v1/courses/{courseId}/topics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.topics.get", httpMethod: "GET", path: "v1/courses/{courseId}/topics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[19] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1341,7 +1368,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_topics_list",
     cud: "read",
     description: "Returns the list of topics that the requester is permitted to view. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user",
-    method: { id: "classroom.courses.topics.list", httpMethod: "GET", path: "v1/courses/{courseId}/topics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.topics.list", httpMethod: "GET", path: "v1/courses/{courseId}/topics", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[19] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1356,7 +1383,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_topics_patch",
     cud: "update",
     description: "Updates one or more fields of a topic. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting developer project did not create t",
-    method: { id: "classroom.courses.topics.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/topics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"] },
+    method: { id: "classroom.courses.topics.patch", httpMethod: "PATCH", path: "v1/courses/{courseId}/topics/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId","id"], scopes: S_classroom_v1[18] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"id","api":"id","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1372,7 +1399,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_update",
     cud: "update",
     description: "Updates a course. Note: Unlike other fields, `levels` is not cleared if omitted from the request. The `UpdateCourse` method only modifies `levels` if it is expl",
-    method: { id: "classroom.courses.update", httpMethod: "PUT", path: "v1/courses/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"] },
+    method: { id: "classroom.courses.update", httpMethod: "PUT", path: "v1/courses/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"], scopes: S_classroom_v1[0] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1386,7 +1413,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_courses_update_grading_period_settings",
     cud: "update",
     description: "Updates grading period settings of a course. Individual grading periods can be added, removed, or modified using this method. The requesting user and course own",
-    method: { id: "classroom.courses.updateGradingPeriodSettings", httpMethod: "PATCH", path: "v1/courses/{courseId}/gradingPeriodSettings", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"] },
+    method: { id: "classroom.courses.updateGradingPeriodSettings", httpMethod: "PATCH", path: "v1/courses/{courseId}/gradingPeriodSettings", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["courseId"], scopes: S_classroom_v1[0] },
     params: [{"field":"courseId","api":"courseId","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1401,7 +1428,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_invitations_accept",
     cud: "create",
     description: "Accepts an invitation, removing it and adding the invited user to the teachers or students (as appropriate) of the specified course. Only the invited user may a",
-    method: { id: "classroom.invitations.accept", httpMethod: "POST", path: "v1/invitations/{id}:accept", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"] },
+    method: { id: "classroom.invitations.accept", httpMethod: "POST", path: "v1/invitations/{id}:accept", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"], scopes: S_classroom_v1[14] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1414,7 +1441,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_invitations_create",
     cud: "create",
     description: "Creates an invitation. Only one invitation for a user and course may exist at a time. Delete and re-create an invitation to make changes. This method returns th",
-    method: { id: "classroom.invitations.create", httpMethod: "POST", path: "v1/invitations", baseUrl: "https://classroom.googleapis.com/", requiredParams: [] },
+    method: { id: "classroom.invitations.create", httpMethod: "POST", path: "v1/invitations", baseUrl: "https://classroom.googleapis.com/", requiredParams: [], scopes: S_classroom_v1[14] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1427,7 +1454,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_invitations_delete",
     cud: "delete",
     description: "Deletes an invitation. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to delete the requested invi",
-    method: { id: "classroom.invitations.delete", httpMethod: "DELETE", path: "v1/invitations/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"] },
+    method: { id: "classroom.invitations.delete", httpMethod: "DELETE", path: "v1/invitations/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"], scopes: S_classroom_v1[14] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1440,7 +1467,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_invitations_get",
     cud: "read",
     description: "Returns an invitation. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to view the requested invita",
-    method: { id: "classroom.invitations.get", httpMethod: "GET", path: "v1/invitations/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"] },
+    method: { id: "classroom.invitations.get", httpMethod: "GET", path: "v1/invitations/{id}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["id"], scopes: S_classroom_v1[15] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1453,7 +1480,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_invitations_list",
     cud: "read",
     description: "Returns a list of invitations that the requesting user is permitted to view, restricted to those that match the list request. *Note:* At least one of `user_id`",
-    method: { id: "classroom.invitations.list", httpMethod: "GET", path: "v1/invitations", baseUrl: "https://classroom.googleapis.com/", requiredParams: [] },
+    method: { id: "classroom.invitations.list", httpMethod: "GET", path: "v1/invitations", baseUrl: "https://classroom.googleapis.com/", requiredParams: [], scopes: S_classroom_v1[15] },
     params: [{"field":"courseId","api":"courseId","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"userId","api":"userId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1469,7 +1496,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_registrations_create",
     cud: "create",
     description: "Creates a `Registration`, causing Classroom to start sending notifications from the provided `feed` to the destination provided in `cloudPubSubTopic`. Returns t",
-    method: { id: "classroom.registrations.create", httpMethod: "POST", path: "v1/registrations", baseUrl: "https://classroom.googleapis.com/", requiredParams: [] },
+    method: { id: "classroom.registrations.create", httpMethod: "POST", path: "v1/registrations", baseUrl: "https://classroom.googleapis.com/", requiredParams: [], scopes: S_classroom_v1[20] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1482,7 +1509,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_registrations_delete",
     cud: "delete",
     description: "Deletes a `Registration`, causing Classroom to stop sending notifications for that `Registration`.",
-    method: { id: "classroom.registrations.delete", httpMethod: "DELETE", path: "v1/registrations/{registrationId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["registrationId"] },
+    method: { id: "classroom.registrations.delete", httpMethod: "DELETE", path: "v1/registrations/{registrationId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["registrationId"], scopes: S_classroom_v1[20] },
     params: [{"field":"registrationId","api":"registrationId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1495,7 +1522,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_user_profiles_get",
     cud: "read",
     description: "Returns a user profile. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to access this user profile",
-    method: { id: "classroom.userProfiles.get", httpMethod: "GET", path: "v1/userProfiles/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "classroom.userProfiles.get", httpMethod: "GET", path: "v1/userProfiles/{userId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["userId"], scopes: S_classroom_v1[17] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1508,7 +1535,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_user_profiles_guardian_invitations_create",
     cud: "create",
     description: "Creates a guardian invitation, and sends an email to the guardian asking them to confirm that they are the student's guardian. Once the guardian accepts the inv",
-    method: { id: "classroom.userProfiles.guardianInvitations.create", httpMethod: "POST", path: "v1/userProfiles/{studentId}/guardianInvitations", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId"] },
+    method: { id: "classroom.userProfiles.guardianInvitations.create", httpMethod: "POST", path: "v1/userProfiles/{studentId}/guardianInvitations", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId"], scopes: S_classroom_v1[21] },
     params: [{"field":"studentId","api":"studentId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1522,7 +1549,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_user_profiles_guardian_invitations_get",
     cud: "read",
     description: "Returns a specific guardian invitation. This method returns the following error codes: * `PERMISSION_DENIED` if the requesting user is not permitted to view gua",
-    method: { id: "classroom.userProfiles.guardianInvitations.get", httpMethod: "GET", path: "v1/userProfiles/{studentId}/guardianInvitations/{invitationId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId","invitationId"] },
+    method: { id: "classroom.userProfiles.guardianInvitations.get", httpMethod: "GET", path: "v1/userProfiles/{studentId}/guardianInvitations/{invitationId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId","invitationId"], scopes: S_classroom_v1[22] },
     params: [{"field":"invitationId","api":"invitationId","location":"path"},{"field":"studentId","api":"studentId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1536,7 +1563,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_user_profiles_guardian_invitations_list",
     cud: "read",
     description: "Returns a list of guardian invitations that the requesting user is permitted to view, filtered by the parameters provided. This method returns the following err",
-    method: { id: "classroom.userProfiles.guardianInvitations.list", httpMethod: "GET", path: "v1/userProfiles/{studentId}/guardianInvitations", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId"] },
+    method: { id: "classroom.userProfiles.guardianInvitations.list", httpMethod: "GET", path: "v1/userProfiles/{studentId}/guardianInvitations", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId"], scopes: S_classroom_v1[22] },
     params: [{"field":"studentId","api":"studentId","location":"path"},{"field":"invitedEmailAddress","api":"invitedEmailAddress","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"states","api":"states","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1553,7 +1580,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_user_profiles_guardian_invitations_patch",
     cud: "update",
     description: "Modifies a guardian invitation. Currently, the only valid modification is to change the `state` from `PENDING` to `COMPLETE`. This has the effect of withdrawing",
-    method: { id: "classroom.userProfiles.guardianInvitations.patch", httpMethod: "PATCH", path: "v1/userProfiles/{studentId}/guardianInvitations/{invitationId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId","invitationId"] },
+    method: { id: "classroom.userProfiles.guardianInvitations.patch", httpMethod: "PATCH", path: "v1/userProfiles/{studentId}/guardianInvitations/{invitationId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId","invitationId"], scopes: S_classroom_v1[21] },
     params: [{"field":"invitationId","api":"invitationId","location":"path"},{"field":"studentId","api":"studentId","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -1569,7 +1596,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_user_profiles_guardians_delete",
     cud: "delete",
     description: "Deletes a guardian. The guardian will no longer receive guardian notifications and the guardian will no longer be accessible via the API. This method returns th",
-    method: { id: "classroom.userProfiles.guardians.delete", httpMethod: "DELETE", path: "v1/userProfiles/{studentId}/guardians/{guardianId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId","guardianId"] },
+    method: { id: "classroom.userProfiles.guardians.delete", httpMethod: "DELETE", path: "v1/userProfiles/{studentId}/guardians/{guardianId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId","guardianId"], scopes: S_classroom_v1[21] },
     params: [{"field":"guardianId","api":"guardianId","location":"path"},{"field":"studentId","api":"studentId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1583,7 +1610,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_user_profiles_guardians_get",
     cud: "read",
     description: "Returns a specific guardian. This method returns the following error codes: * `PERMISSION_DENIED` if no user that matches the provided `student_id` is visible t",
-    method: { id: "classroom.userProfiles.guardians.get", httpMethod: "GET", path: "v1/userProfiles/{studentId}/guardians/{guardianId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId","guardianId"] },
+    method: { id: "classroom.userProfiles.guardians.get", httpMethod: "GET", path: "v1/userProfiles/{studentId}/guardians/{guardianId}", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId","guardianId"], scopes: S_classroom_v1[23] },
     params: [{"field":"guardianId","api":"guardianId","location":"path"},{"field":"studentId","api":"studentId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -1597,7 +1624,7 @@ export function registerClassroomGeneratedTools(registry: ToolRegistry): void {
     name: "classroom_user_profiles_guardians_list",
     cud: "read",
     description: "Returns a list of guardians that the requesting user is permitted to view, restricted to those that match the request. To list guardians for any student that th",
-    method: { id: "classroom.userProfiles.guardians.list", httpMethod: "GET", path: "v1/userProfiles/{studentId}/guardians", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId"] },
+    method: { id: "classroom.userProfiles.guardians.list", httpMethod: "GET", path: "v1/userProfiles/{studentId}/guardians", baseUrl: "https://classroom.googleapis.com/", requiredParams: ["studentId"], scopes: S_classroom_v1[23] },
     params: [{"field":"studentId","api":"studentId","location":"path"},{"field":"invitedEmailAddress","api":"invitedEmailAddress","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/cloudidentity.ts
+++ b/src/tools/generated/cloudidentity.ts
@@ -5,6 +5,18 @@ import { coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerCloudidentityGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_cloudidentity_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/cloud-identity.devices"],
+    ["https://www.googleapis.com/auth/cloud-identity.devices","https://www.googleapis.com/auth/cloud-identity.devices.readonly"],
+    ["https://www.googleapis.com/auth/cloud-identity.devices.lookup"],
+    ["https://www.googleapis.com/auth/cloud-identity.groups","https://www.googleapis.com/auth/cloud-platform"],
+    ["https://www.googleapis.com/auth/cloud-identity.groups","https://www.googleapis.com/auth/cloud-identity.groups.readonly","https://www.googleapis.com/auth/cloud-platform"],
+    ["https://www.googleapis.com/auth/cloud-identity.inboundsso","https://www.googleapis.com/auth/cloud-platform"],
+    ["https://www.googleapis.com/auth/cloud-identity.inboundsso","https://www.googleapis.com/auth/cloud-identity.inboundsso.readonly","https://www.googleapis.com/auth/cloud-platform"],
+    ["https://www.googleapis.com/auth/cloud-identity.policies"],
+    ["https://www.googleapis.com/auth/cloud-identity.policies","https://www.googleapis.com/auth/cloud-identity.policies.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "cloudidentity_customers_userinvitations_cancel",
     cud: "create",
@@ -80,7 +92,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_cancel_wipe",
     cud: "create",
     description: "Cancels an unfinished device wipe. This operation can be used to cancel device wipe in the gap between the wipe operation returning success and the device being",
-    method: { id: "cloudidentity.devices.cancelWipe", httpMethod: "POST", path: "v1/{+name}:cancelWipe", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.cancelWipe", httpMethod: "POST", path: "v1/{+name}:cancelWipe", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -94,7 +106,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_create",
     cud: "create",
     description: "Creates a device. Only company-owned device may be created. **Note**: This method is available only to customers who have one of the following SKUs: Enterprise",
-    method: { id: "cloudidentity.devices.create", httpMethod: "POST", path: "v1/devices", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.devices.create", httpMethod: "POST", path: "v1/devices", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[0] },
     params: [{"field":"customer","api":"customer","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -108,7 +120,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_delete",
     cud: "delete",
     description: "Deletes the specified device.",
-    method: { id: "cloudidentity.devices.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"customer","api":"customer","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -122,7 +134,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_approve",
     cud: "create",
     description: "Approves device to access user data.",
-    method: { id: "cloudidentity.devices.deviceUsers.approve", httpMethod: "POST", path: "v1/{+name}:approve", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.deviceUsers.approve", httpMethod: "POST", path: "v1/{+name}:approve", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -136,7 +148,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_block",
     cud: "create",
     description: "Blocks device from accessing user data",
-    method: { id: "cloudidentity.devices.deviceUsers.block", httpMethod: "POST", path: "v1/{+name}:block", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.deviceUsers.block", httpMethod: "POST", path: "v1/{+name}:block", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -150,7 +162,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_cancel_wipe",
     cud: "create",
     description: "Cancels an unfinished user account wipe. This operation can be used to cancel device wipe in the gap between the wipe operation returning success and the device",
-    method: { id: "cloudidentity.devices.deviceUsers.cancelWipe", httpMethod: "POST", path: "v1/{+name}:cancelWipe", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.deviceUsers.cancelWipe", httpMethod: "POST", path: "v1/{+name}:cancelWipe", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -164,7 +176,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_client_states_get",
     cud: "read",
     description: "Gets the client state for the device user",
-    method: { id: "cloudidentity.devices.deviceUsers.clientStates.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.deviceUsers.clientStates.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"customer","api":"customer","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -178,7 +190,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_client_states_list",
     cud: "read",
     description: "Lists the client states for the given search query.",
-    method: { id: "cloudidentity.devices.deviceUsers.clientStates.list", httpMethod: "GET", path: "v1/{+parent}/clientStates", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.devices.deviceUsers.clientStates.list", httpMethod: "GET", path: "v1/{+parent}/clientStates", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[1] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"customer","api":"customer","location":"query"},{"field":"filter","api":"filter","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -195,7 +207,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_client_states_patch",
     cud: "update",
     description: "Updates the client state for the device user **Note**: This method is available only to customers who have one of the following SKUs: Enterprise Standard, Enter",
-    method: { id: "cloudidentity.devices.deviceUsers.clientStates.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.deviceUsers.clientStates.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"customer","api":"customer","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -211,7 +223,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_delete",
     cud: "delete",
     description: "Deletes the specified DeviceUser. This also revokes the user's access to device data.",
-    method: { id: "cloudidentity.devices.deviceUsers.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.deviceUsers.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"customer","api":"customer","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -225,7 +237,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_get",
     cud: "read",
     description: "Retrieves the specified DeviceUser",
-    method: { id: "cloudidentity.devices.deviceUsers.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.deviceUsers.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"customer","api":"customer","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -239,7 +251,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_list",
     cud: "read",
     description: "Lists/Searches DeviceUsers.",
-    method: { id: "cloudidentity.devices.deviceUsers.list", httpMethod: "GET", path: "v1/{+parent}/deviceUsers", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.devices.deviceUsers.list", httpMethod: "GET", path: "v1/{+parent}/deviceUsers", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[1] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"customer","api":"customer","location":"query"},{"field":"filter","api":"filter","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -257,7 +269,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_lookup",
     cud: "read",
     description: "Looks up resource names of the DeviceUsers associated with the caller's credentials, as well as the properties provided in the request. This method must be call",
-    method: { id: "cloudidentity.devices.deviceUsers.lookup", httpMethod: "GET", path: "v1/{+parent}:lookup", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.devices.deviceUsers.lookup", httpMethod: "GET", path: "v1/{+parent}:lookup", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[2] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"androidId","api":"androidId","location":"query"},{"field":"iosDeviceId","api":"iosDeviceId","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"partner","api":"partner","location":"query"},{"field":"rawResourceId","api":"rawResourceId","location":"query"},{"field":"userId","api":"userId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -277,7 +289,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_device_users_wipe",
     cud: "create",
     description: "Wipes the user's account on a device. Other data on the device that is not associated with the user's work account is not affected. For example, if a Gmail app",
-    method: { id: "cloudidentity.devices.deviceUsers.wipe", httpMethod: "POST", path: "v1/{+name}:wipe", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.deviceUsers.wipe", httpMethod: "POST", path: "v1/{+name}:wipe", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -291,7 +303,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_get",
     cud: "read",
     description: "Retrieves the specified device.",
-    method: { id: "cloudidentity.devices.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"customer","api":"customer","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -305,7 +317,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_list",
     cud: "read",
     description: "Lists/Searches devices.",
-    method: { id: "cloudidentity.devices.list", httpMethod: "GET", path: "v1/devices", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.devices.list", httpMethod: "GET", path: "v1/devices", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[1] },
     params: [{"field":"customer","api":"customer","location":"query"},{"field":"filter","api":"filter","location":"query"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"view","api":"view","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -323,7 +335,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_devices_wipe",
     cud: "create",
     description: "Wipes all data on the specified device.",
-    method: { id: "cloudidentity.devices.wipe", httpMethod: "POST", path: "v1/{+name}:wipe", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.devices.wipe", httpMethod: "POST", path: "v1/{+name}:wipe", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -337,7 +349,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_create",
     cud: "create",
     description: "Creates a Group.",
-    method: { id: "cloudidentity.groups.create", httpMethod: "POST", path: "v1/groups", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.groups.create", httpMethod: "POST", path: "v1/groups", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[3] },
     params: [{"field":"initialGroupConfig","api":"initialGroupConfig","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -351,7 +363,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_delete",
     cud: "delete",
     description: "Deletes a `Group`.",
-    method: { id: "cloudidentity.groups.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.groups.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -364,7 +376,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_get",
     cud: "read",
     description: "Retrieves a `Group`.",
-    method: { id: "cloudidentity.groups.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.groups.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -377,7 +389,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_get_security_settings",
     cud: "read",
     description: "Get Security Settings",
-    method: { id: "cloudidentity.groups.getSecuritySettings", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.groups.getSecuritySettings", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"readMask","api":"readMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -391,7 +403,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_list",
     cud: "read",
     description: "Lists the `Group` resources under a customer or namespace.",
-    method: { id: "cloudidentity.groups.list", httpMethod: "GET", path: "v1/groups", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.groups.list", httpMethod: "GET", path: "v1/groups", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"parent","api":"parent","location":"query"},{"field":"view","api":"view","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -407,7 +419,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_lookup",
     cud: "read",
     description: "Looks up the [resource name](https://cloud.google.com/apis/design/resource_names) of a `Group` by its `EntityKey`.",
-    method: { id: "cloudidentity.groups.lookup", httpMethod: "GET", path: "v1/groups:lookup", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.groups.lookup", httpMethod: "GET", path: "v1/groups:lookup", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"groupKey.id","api":"groupKey.id","location":"query"},{"field":"groupKey.namespace","api":"groupKey.namespace","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -421,7 +433,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_check_transitive_membership",
     cud: "read",
     description: "Check a potential member for membership in a group. **Note:** This feature is only available to Google Workspace Enterprise Standard, Enterprise Plus, and Enter",
-    method: { id: "cloudidentity.groups.memberships.checkTransitiveMembership", httpMethod: "GET", path: "v1/{+parent}/memberships:checkTransitiveMembership", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.groups.memberships.checkTransitiveMembership", httpMethod: "GET", path: "v1/{+parent}/memberships:checkTransitiveMembership", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"query","api":"query","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -435,7 +447,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_create",
     cud: "create",
     description: "Creates a `Membership`.",
-    method: { id: "cloudidentity.groups.memberships.create", httpMethod: "POST", path: "v1/{+parent}/memberships", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.groups.memberships.create", httpMethod: "POST", path: "v1/{+parent}/memberships", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[3] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -449,7 +461,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_delete",
     cud: "delete",
     description: "Deletes a `Membership`.",
-    method: { id: "cloudidentity.groups.memberships.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.groups.memberships.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -462,7 +474,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_get",
     cud: "read",
     description: "Retrieves a `Membership`.",
-    method: { id: "cloudidentity.groups.memberships.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.groups.memberships.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -475,7 +487,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_get_membership_graph",
     cud: "read",
     description: "Get a membership graph of just a member or both a member and a group. **Note:** This feature is only available to Google Workspace Enterprise Standard, Enterpri",
-    method: { id: "cloudidentity.groups.memberships.getMembershipGraph", httpMethod: "GET", path: "v1/{+parent}/memberships:getMembershipGraph", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.groups.memberships.getMembershipGraph", httpMethod: "GET", path: "v1/{+parent}/memberships:getMembershipGraph", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"query","api":"query","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -489,7 +501,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_list",
     cud: "read",
     description: "Lists the `Membership`s within a `Group`.",
-    method: { id: "cloudidentity.groups.memberships.list", httpMethod: "GET", path: "v1/{+parent}/memberships", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.groups.memberships.list", httpMethod: "GET", path: "v1/{+parent}/memberships", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"view","api":"view","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -505,7 +517,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_lookup",
     cud: "read",
     description: "Looks up the [resource name](https://cloud.google.com/apis/design/resource_names) of a `Membership` by its `EntityKey`.",
-    method: { id: "cloudidentity.groups.memberships.lookup", httpMethod: "GET", path: "v1/{+parent}/memberships:lookup", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.groups.memberships.lookup", httpMethod: "GET", path: "v1/{+parent}/memberships:lookup", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"memberKey.id","api":"memberKey.id","location":"query"},{"field":"memberKey.namespace","api":"memberKey.namespace","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -520,7 +532,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_modify_membership_roles",
     cud: "update",
     description: "Modifies the `MembershipRole`s of a `Membership`.",
-    method: { id: "cloudidentity.groups.memberships.modifyMembershipRoles", httpMethod: "POST", path: "v1/{+name}:modifyMembershipRoles", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.groups.memberships.modifyMembershipRoles", httpMethod: "POST", path: "v1/{+name}:modifyMembershipRoles", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -534,7 +546,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_search_direct_groups",
     cud: "read",
     description: "Searches direct groups of a member. Groups for which the actor does not have the permission to view memberships are silently filtered out.",
-    method: { id: "cloudidentity.groups.memberships.searchDirectGroups", httpMethod: "GET", path: "v1/{+parent}/memberships:searchDirectGroups", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.groups.memberships.searchDirectGroups", httpMethod: "GET", path: "v1/{+parent}/memberships:searchDirectGroups", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"orderBy","api":"orderBy","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"query","api":"query","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -551,7 +563,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_search_transitive_groups",
     cud: "read",
     description: "Search transitive groups of a member. **Note:** This feature is only available to Google Workspace Enterprise Standard, Enterprise Plus, and Enterprise for Educ",
-    method: { id: "cloudidentity.groups.memberships.searchTransitiveGroups", httpMethod: "GET", path: "v1/{+parent}/memberships:searchTransitiveGroups", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.groups.memberships.searchTransitiveGroups", httpMethod: "GET", path: "v1/{+parent}/memberships:searchTransitiveGroups", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"query","api":"query","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -567,7 +579,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_memberships_search_transitive_memberships",
     cud: "read",
     description: "Search transitive memberships of a group. **Note:** This feature is only available to Google Workspace Enterprise Standard, Enterprise Plus, and Enterprise for",
-    method: { id: "cloudidentity.groups.memberships.searchTransitiveMemberships", httpMethod: "GET", path: "v1/{+parent}/memberships:searchTransitiveMemberships", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.groups.memberships.searchTransitiveMemberships", httpMethod: "GET", path: "v1/{+parent}/memberships:searchTransitiveMemberships", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -582,7 +594,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_patch",
     cud: "update",
     description: "Updates a `Group`.",
-    method: { id: "cloudidentity.groups.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.groups.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -597,7 +609,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_search",
     cud: "read",
     description: "Searches for `Group` resources matching a specified query.",
-    method: { id: "cloudidentity.groups.search", httpMethod: "GET", path: "v1/groups:search", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.groups.search", httpMethod: "GET", path: "v1/groups:search", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[4] },
     params: [{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"query","api":"query","location":"query"},{"field":"view","api":"view","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -613,7 +625,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_groups_update_security_settings",
     cud: "update",
     description: "Update Security Settings",
-    method: { id: "cloudidentity.groups.updateSecuritySettings", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.groups.updateSecuritySettings", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -628,7 +640,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_oidc_sso_profiles_create",
     cud: "create",
     description: "Creates an InboundOidcSsoProfile for a customer. When the target customer has enabled [Multi-party approval for sensitive actions](https://support.google.com/a/",
-    method: { id: "cloudidentity.inboundOidcSsoProfiles.create", httpMethod: "POST", path: "v1/inboundOidcSsoProfiles", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.inboundOidcSsoProfiles.create", httpMethod: "POST", path: "v1/inboundOidcSsoProfiles", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -641,7 +653,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_oidc_sso_profiles_delete",
     cud: "delete",
     description: "Deletes an InboundOidcSsoProfile.",
-    method: { id: "cloudidentity.inboundOidcSsoProfiles.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundOidcSsoProfiles.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -654,7 +666,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_oidc_sso_profiles_get",
     cud: "read",
     description: "Gets an InboundOidcSsoProfile.",
-    method: { id: "cloudidentity.inboundOidcSsoProfiles.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundOidcSsoProfiles.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[6] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -667,7 +679,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_oidc_sso_profiles_list",
     cud: "read",
     description: "Lists InboundOidcSsoProfile objects for a Google enterprise customer.",
-    method: { id: "cloudidentity.inboundOidcSsoProfiles.list", httpMethod: "GET", path: "v1/inboundOidcSsoProfiles", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.inboundOidcSsoProfiles.list", httpMethod: "GET", path: "v1/inboundOidcSsoProfiles", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[6] },
     params: [{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -682,7 +694,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_oidc_sso_profiles_patch",
     cud: "update",
     description: "Updates an InboundOidcSsoProfile. When the target customer has enabled [Multi-party approval for sensitive actions](https://support.google.com/a/answer/13790448",
-    method: { id: "cloudidentity.inboundOidcSsoProfiles.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundOidcSsoProfiles.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -697,7 +709,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_saml_sso_profiles_create",
     cud: "create",
     description: "Creates an InboundSamlSsoProfile for a customer. When the target customer has enabled [Multi-party approval for sensitive actions](https://support.google.com/a/",
-    method: { id: "cloudidentity.inboundSamlSsoProfiles.create", httpMethod: "POST", path: "v1/inboundSamlSsoProfiles", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.inboundSamlSsoProfiles.create", httpMethod: "POST", path: "v1/inboundSamlSsoProfiles", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -710,7 +722,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_saml_sso_profiles_delete",
     cud: "delete",
     description: "Deletes an InboundSamlSsoProfile.",
-    method: { id: "cloudidentity.inboundSamlSsoProfiles.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundSamlSsoProfiles.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -723,7 +735,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_saml_sso_profiles_get",
     cud: "read",
     description: "Gets an InboundSamlSsoProfile.",
-    method: { id: "cloudidentity.inboundSamlSsoProfiles.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundSamlSsoProfiles.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[6] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -736,7 +748,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_saml_sso_profiles_idp_credentials_add",
     cud: "create",
     description: "Adds an IdpCredential. Up to 2 credentials are allowed. When the target customer has enabled [Multi-party approval for sensitive actions](https://support.google",
-    method: { id: "cloudidentity.inboundSamlSsoProfiles.idpCredentials.add", httpMethod: "POST", path: "v1/{+parent}/idpCredentials:add", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.inboundSamlSsoProfiles.idpCredentials.add", httpMethod: "POST", path: "v1/{+parent}/idpCredentials:add", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -750,7 +762,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_saml_sso_profiles_idp_credentials_delete",
     cud: "delete",
     description: "Deletes an IdpCredential.",
-    method: { id: "cloudidentity.inboundSamlSsoProfiles.idpCredentials.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundSamlSsoProfiles.idpCredentials.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -763,7 +775,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_saml_sso_profiles_idp_credentials_get",
     cud: "read",
     description: "Gets an IdpCredential.",
-    method: { id: "cloudidentity.inboundSamlSsoProfiles.idpCredentials.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundSamlSsoProfiles.idpCredentials.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[6] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -776,7 +788,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_saml_sso_profiles_idp_credentials_list",
     cud: "read",
     description: "Returns a list of IdpCredentials in an InboundSamlSsoProfile.",
-    method: { id: "cloudidentity.inboundSamlSsoProfiles.idpCredentials.list", httpMethod: "GET", path: "v1/{+parent}/idpCredentials", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudidentity.inboundSamlSsoProfiles.idpCredentials.list", httpMethod: "GET", path: "v1/{+parent}/idpCredentials", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudidentity_v1[6] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -791,7 +803,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_saml_sso_profiles_list",
     cud: "read",
     description: "Lists InboundSamlSsoProfiles for a customer.",
-    method: { id: "cloudidentity.inboundSamlSsoProfiles.list", httpMethod: "GET", path: "v1/inboundSamlSsoProfiles", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.inboundSamlSsoProfiles.list", httpMethod: "GET", path: "v1/inboundSamlSsoProfiles", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[6] },
     params: [{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -806,7 +818,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_saml_sso_profiles_patch",
     cud: "update",
     description: "Updates an InboundSamlSsoProfile. When the target customer has enabled [Multi-party approval for sensitive actions](https://support.google.com/a/answer/13790448",
-    method: { id: "cloudidentity.inboundSamlSsoProfiles.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundSamlSsoProfiles.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -821,7 +833,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_sso_assignments_create",
     cud: "create",
     description: "Creates an InboundSsoAssignment for users and devices in a `Customer` under a given `Group` or `OrgUnit`.",
-    method: { id: "cloudidentity.inboundSsoAssignments.create", httpMethod: "POST", path: "v1/inboundSsoAssignments", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.inboundSsoAssignments.create", httpMethod: "POST", path: "v1/inboundSsoAssignments", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -834,7 +846,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_sso_assignments_delete",
     cud: "delete",
     description: "Deletes an InboundSsoAssignment. To disable SSO, Create (or Update) an assignment that has `sso_mode` == `SSO_OFF`.",
-    method: { id: "cloudidentity.inboundSsoAssignments.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundSsoAssignments.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -847,7 +859,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_sso_assignments_get",
     cud: "read",
     description: "Gets an InboundSsoAssignment.",
-    method: { id: "cloudidentity.inboundSsoAssignments.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundSsoAssignments.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[6] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -860,7 +872,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_sso_assignments_list",
     cud: "read",
     description: "Lists the InboundSsoAssignments for a `Customer`.",
-    method: { id: "cloudidentity.inboundSsoAssignments.list", httpMethod: "GET", path: "v1/inboundSsoAssignments", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.inboundSsoAssignments.list", httpMethod: "GET", path: "v1/inboundSsoAssignments", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[6] },
     params: [{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -875,7 +887,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_inbound_sso_assignments_patch",
     cud: "update",
     description: "Updates an InboundSsoAssignment. The body of this request is the `inbound_sso_assignment` field and the `update_mask` is relative to that. For example: a PATCH",
-    method: { id: "cloudidentity.inboundSsoAssignments.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.inboundSsoAssignments.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -890,7 +902,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_policies_create",
     cud: "create",
     description: "Create a policy.",
-    method: { id: "cloudidentity.policies.create", httpMethod: "POST", path: "v1/policies", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.policies.create", httpMethod: "POST", path: "v1/policies", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[7] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -903,7 +915,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_policies_delete",
     cud: "delete",
     description: "Delete a policy.",
-    method: { id: "cloudidentity.policies.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.policies.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[7] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -916,7 +928,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_policies_get",
     cud: "read",
     description: "Get a policy.",
-    method: { id: "cloudidentity.policies.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.policies.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[8] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -929,7 +941,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_policies_list",
     cud: "read",
     description: "List policies.",
-    method: { id: "cloudidentity.policies.list", httpMethod: "GET", path: "v1/policies", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudidentity.policies.list", httpMethod: "GET", path: "v1/policies", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: [], scopes: S_cloudidentity_v1[8] },
     params: [{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -944,7 +956,7 @@ export function registerCloudidentityGeneratedTools(registry: ToolRegistry): voi
     name: "cloudidentity_policies_patch",
     cud: "update",
     description: "Update a policy.",
-    method: { id: "cloudidentity.policies.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudidentity.policies.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://cloudidentity.googleapis.com/", requiredParams: ["name"], scopes: S_cloudidentity_v1[7] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/cloudsearch.ts
+++ b/src/tools/generated/cloudsearch.ts
@@ -5,11 +5,21 @@ import { coerceBoolean, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_cloudsearch_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/cloud_search","https://www.googleapis.com/auth/cloud_search.debug"],
+    ["https://www.googleapis.com/auth/cloud_search","https://www.googleapis.com/auth/cloud_search.settings","https://www.googleapis.com/auth/cloud_search.settings.indexing"],
+    ["https://www.googleapis.com/auth/cloud_search","https://www.googleapis.com/auth/cloud_search.indexing"],
+    ["https://www.googleapis.com/auth/cloud_search","https://www.googleapis.com/auth/cloud_search.debug","https://www.googleapis.com/auth/cloud_search.indexing","https://www.googleapis.com/auth/cloud_search.settings","https://www.googleapis.com/auth/cloud_search.settings.indexing","https://www.googleapis.com/auth/cloud_search.settings.query"],
+    ["https://www.googleapis.com/auth/cloud_search","https://www.googleapis.com/auth/cloud_search.query"],
+    ["https://www.googleapis.com/auth/cloud_search","https://www.googleapis.com/auth/cloud_search.settings","https://www.googleapis.com/auth/cloud_search.settings.query"],
+    ["https://www.googleapis.com/auth/cloud_search","https://www.googleapis.com/auth/cloud_search.stats","https://www.googleapis.com/auth/cloud_search.stats.indexing"],
+  ];
   registerGeneratedTool(registry, {
     name: "cloudsearch_debug_datasources_items_check_access",
     cud: "create",
     description: "Checks whether an item is accessible by specified principal. Principal must be a user; groups and domain values aren't supported. **Note:** This API requires an",
-    method: { id: "cloudsearch.debug.datasources.items.checkAccess", httpMethod: "POST", path: "v1/debug/{+name}:checkAccess", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.debug.datasources.items.checkAccess", httpMethod: "POST", path: "v1/debug/{+name}:checkAccess", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -24,7 +34,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_debug_datasources_items_search_by_view_url",
     cud: "read",
     description: "Fetches the item whose viewUrl exactly matches that of the URL provided in the request. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.debug.datasources.items.searchByViewUrl", httpMethod: "POST", path: "v1/debug/{+name}/items:searchByViewUrl", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.debug.datasources.items.searchByViewUrl", httpMethod: "POST", path: "v1/debug/{+name}/items:searchByViewUrl", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -38,7 +48,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_debug_datasources_items_unmappedids_list",
     cud: "read",
     description: "List all unmapped identities for a specific item. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.debug.datasources.items.unmappedids.list", httpMethod: "GET", path: "v1/debug/{+parent}/unmappedids", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudsearch.debug.datasources.items.unmappedids.list", httpMethod: "GET", path: "v1/debug/{+parent}/unmappedids", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudsearch_v1[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -54,7 +64,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_debug_identitysources_items_list_forunmappedidentity",
     cud: "read",
     description: "Lists names of items associated with an unmapped identity. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.debug.identitysources.items.listForunmappedidentity", httpMethod: "GET", path: "v1/debug/{+parent}/items:forunmappedidentity", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudsearch.debug.identitysources.items.listForunmappedidentity", httpMethod: "GET", path: "v1/debug/{+parent}/items:forunmappedidentity", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudsearch_v1[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"groupResourceName","api":"groupResourceName","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"userResourceName","api":"userResourceName","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -72,7 +82,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_debug_identitysources_unmappedids_list",
     cud: "read",
     description: "Lists unmapped user identities for an identity source. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.debug.identitysources.unmappedids.list", httpMethod: "GET", path: "v1/debug/{+parent}/unmappedids", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "cloudsearch.debug.identitysources.unmappedids.list", httpMethod: "GET", path: "v1/debug/{+parent}/unmappedids", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["parent"], scopes: S_cloudsearch_v1[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"resolutionStatusCode","api":"resolutionStatusCode","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -89,7 +99,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_delete_schema",
     cud: "delete",
     description: "Deletes the schema of a data source. **Note:** This API requires an admin or service account to execute.",
-    method: { id: "cloudsearch.indexing.datasources.deleteSchema", httpMethod: "DELETE", path: "v1/indexing/{+name}/schema", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.deleteSchema", httpMethod: "DELETE", path: "v1/indexing/{+name}/schema", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -103,7 +113,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_get_schema",
     cud: "read",
     description: "Gets the schema of a data source. **Note:** This API requires an admin or service account to execute.",
-    method: { id: "cloudsearch.indexing.datasources.getSchema", httpMethod: "GET", path: "v1/indexing/{+name}/schema", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.getSchema", httpMethod: "GET", path: "v1/indexing/{+name}/schema", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -117,7 +127,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_items_delete",
     cud: "delete",
     description: "Deletes Item resource for the specified resource name. This API requires an admin or service account to execute. The service account used is the one whitelisted",
-    method: { id: "cloudsearch.indexing.datasources.items.delete", httpMethod: "DELETE", path: "v1/indexing/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.items.delete", httpMethod: "DELETE", path: "v1/indexing/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[2] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"connectorName","api":"connectorName","location":"query"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"mode","api":"mode","location":"query"},{"field":"version","api":"version","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -134,7 +144,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_items_delete_queue_items",
     cud: "delete",
     description: "Deletes all items in a queue. This method is useful for deleting stale items. This API requires an admin or service account to execute. The service account used",
-    method: { id: "cloudsearch.indexing.datasources.items.deleteQueueItems", httpMethod: "POST", path: "v1/indexing/{+name}/items:deleteQueueItems", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.items.deleteQueueItems", httpMethod: "POST", path: "v1/indexing/{+name}/items:deleteQueueItems", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[2] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -148,7 +158,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_items_get",
     cud: "read",
     description: "Gets Item resource by item name. This API requires an admin or service account to execute. The service account used is the one whitelisted in the corresponding",
-    method: { id: "cloudsearch.indexing.datasources.items.get", httpMethod: "GET", path: "v1/indexing/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.items.get", httpMethod: "GET", path: "v1/indexing/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[2] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"connectorName","api":"connectorName","location":"query"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -163,7 +173,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_items_index",
     cud: "create",
     description: "Updates Item ACL, metadata, and content. It will insert the Item if it does not exist. This method does not support partial updates. Fields with no provided val",
-    method: { id: "cloudsearch.indexing.datasources.items.index", httpMethod: "POST", path: "v1/indexing/{+name}:index", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.items.index", httpMethod: "POST", path: "v1/indexing/{+name}:index", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[2] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -177,7 +187,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_items_list",
     cud: "read",
     description: "Lists all or a subset of Item resources. This API requires an admin or service account to execute. The service account used is the one whitelisted in the corres",
-    method: { id: "cloudsearch.indexing.datasources.items.list", httpMethod: "GET", path: "v1/indexing/{+name}/items", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.items.list", httpMethod: "GET", path: "v1/indexing/{+name}/items", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[2] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"brief","api":"brief","location":"query"},{"field":"connectorName","api":"connectorName","location":"query"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -195,7 +205,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_items_poll",
     cud: "create",
     description: "Polls for unreserved items from the indexing queue and marks a set as reserved, starting with items that have the oldest timestamp from the highest priority Ite",
-    method: { id: "cloudsearch.indexing.datasources.items.poll", httpMethod: "POST", path: "v1/indexing/{+name}/items:poll", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.items.poll", httpMethod: "POST", path: "v1/indexing/{+name}/items:poll", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[2] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -209,7 +219,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_items_push",
     cud: "create",
     description: "Pushes an item onto a queue for later polling and updating. This API requires an admin or service account to execute. The service account used is the one whitel",
-    method: { id: "cloudsearch.indexing.datasources.items.push", httpMethod: "POST", path: "v1/indexing/{+name}:push", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.items.push", httpMethod: "POST", path: "v1/indexing/{+name}:push", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[2] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -223,7 +233,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_items_unreserve",
     cud: "create",
     description: "Unreserves all items from a queue, making them all eligible to be polled. This method is useful for resetting the indexing queue after a connector has been rest",
-    method: { id: "cloudsearch.indexing.datasources.items.unreserve", httpMethod: "POST", path: "v1/indexing/{+name}/items:unreserve", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.items.unreserve", httpMethod: "POST", path: "v1/indexing/{+name}/items:unreserve", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[2] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -237,7 +247,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_items_upload",
     cud: "create",
     description: "Creates an upload session for uploading item content. For items smaller than 100 KB, it's easier to embed the content inline within an index request. This API r",
-    method: { id: "cloudsearch.indexing.datasources.items.upload", httpMethod: "POST", path: "v1/indexing/{+name}:upload", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.items.upload", httpMethod: "POST", path: "v1/indexing/{+name}:upload", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[2] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -251,7 +261,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_indexing_datasources_update_schema",
     cud: "update",
     description: "Updates the schema of a data source. This method does not perform incremental updates to the schema. Instead, this method updates the schema by overwriting the",
-    method: { id: "cloudsearch.indexing.datasources.updateSchema", httpMethod: "PUT", path: "v1/indexing/{+name}/schema", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.indexing.datasources.updateSchema", httpMethod: "PUT", path: "v1/indexing/{+name}/schema", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -265,7 +275,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_initialize_customer",
     cud: "create",
     description: "Enables `third party` support in Google Cloud Search. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.initializeCustomer", httpMethod: "POST", path: "v1:initializeCustomer", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.initializeCustomer", httpMethod: "POST", path: "v1:initializeCustomer", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -278,7 +288,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_media_upload",
     cud: "create",
     description: "Uploads media for indexing. The upload endpoint supports direct and resumable upload protocols and is intended for large items that can not be [inlined during i",
-    method: { id: "cloudsearch.media.upload", httpMethod: "POST", path: "v1/media/{+resourceName}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["resourceName"] },
+    method: { id: "cloudsearch.media.upload", httpMethod: "POST", path: "v1/media/{+resourceName}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["resourceName"], scopes: S_cloudsearch_v1[2] },
     params: [{"field":"resourceName","api":"resourceName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -292,7 +302,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_operations_get",
     cud: "read",
     description: "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.",
-    method: { id: "cloudsearch.operations.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.operations.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -305,7 +315,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_operations_lro_list",
     cud: "read",
     description: "Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns `UNIMPLEMENTED`.",
-    method: { id: "cloudsearch.operations.lro.list", httpMethod: "GET", path: "v1/{+name}/lro", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.operations.lro.list", httpMethod: "GET", path: "v1/{+name}/lro", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"returnPartialSuccess","api":"returnPartialSuccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -322,7 +332,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_query_remove_activity",
     cud: "delete",
     description: "Provides functionality to remove logged activity for a user. Currently to be used only for Chat 1p clients **Note:** This API requires a standard end user accou",
-    method: { id: "cloudsearch.query.removeActivity", httpMethod: "POST", path: "v1/query:removeActivity", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.query.removeActivity", httpMethod: "POST", path: "v1/query:removeActivity", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[4] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -335,7 +345,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_query_search",
     cud: "read",
     description: "The Cloud Search Query API provides the search method, which returns the most relevant results from a user query. The results can come from Google Workspace app",
-    method: { id: "cloudsearch.query.search", httpMethod: "POST", path: "v1/query/search", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.query.search", httpMethod: "POST", path: "v1/query/search", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[4] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -348,7 +358,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_query_sources_list",
     cud: "read",
     description: "Returns list of sources that user can use for Search and Suggest APIs. **Note:** This API requires a standard end user account to execute. A service account can",
-    method: { id: "cloudsearch.query.sources.list", httpMethod: "GET", path: "v1/query/sources", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.query.sources.list", httpMethod: "GET", path: "v1/query/sources", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[4] },
     params: [{"field":"pageToken","api":"pageToken","location":"query"},{"field":"requestOptions.clientDisplayLanguageCode","api":"requestOptions.clientDisplayLanguageCode","location":"query"},{"field":"requestOptions.countryCode","api":"requestOptions.countryCode","location":"query"},{"field":"requestOptions.debugOptions.enableDebugging","api":"requestOptions.debugOptions.enableDebugging","location":"query"},{"field":"requestOptions.languageCode","api":"requestOptions.languageCode","location":"query"},{"field":"requestOptions.searchApplicationId","api":"requestOptions.searchApplicationId","location":"query"},{"field":"requestOptions.timeZone","api":"requestOptions.timeZone","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -367,7 +377,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_query_suggest",
     cud: "create",
     description: "Provides suggestions for autocompleting the query. **Note:** This API requires a standard end user account to execute. A service account can't perform Query API",
-    method: { id: "cloudsearch.query.suggest", httpMethod: "POST", path: "v1/query/suggest", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.query.suggest", httpMethod: "POST", path: "v1/query/suggest", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[4] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -380,7 +390,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_datasources_create",
     cud: "create",
     description: "Creates a datasource. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.datasources.create", httpMethod: "POST", path: "v1/settings/datasources", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.settings.datasources.create", httpMethod: "POST", path: "v1/settings/datasources", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -393,7 +403,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_datasources_delete",
     cud: "delete",
     description: "Deletes a datasource. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.datasources.delete", httpMethod: "DELETE", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.settings.datasources.delete", httpMethod: "DELETE", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -407,7 +417,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_datasources_get",
     cud: "read",
     description: "Gets a datasource. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.datasources.get", httpMethod: "GET", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.settings.datasources.get", httpMethod: "GET", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -421,7 +431,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_datasources_list",
     cud: "read",
     description: "Lists datasources. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.datasources.list", httpMethod: "GET", path: "v1/settings/datasources", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.settings.datasources.list", httpMethod: "GET", path: "v1/settings/datasources", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -436,7 +446,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_datasources_patch",
     cud: "update",
     description: "Updates a datasource. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.datasources.patch", httpMethod: "PATCH", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.settings.datasources.patch", httpMethod: "PATCH", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -452,7 +462,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_datasources_update",
     cud: "update",
     description: "Updates a datasource. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.datasources.update", httpMethod: "PUT", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.settings.datasources.update", httpMethod: "PUT", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -466,7 +476,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_get_customer",
     cud: "read",
     description: "Get customer settings. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.getCustomer", httpMethod: "GET", path: "v1/settings/customer", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.settings.getCustomer", httpMethod: "GET", path: "v1/settings/customer", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -478,7 +488,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_searchapplications_create",
     cud: "create",
     description: "Creates a search application. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.searchapplications.create", httpMethod: "POST", path: "v1/settings/searchapplications", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.settings.searchapplications.create", httpMethod: "POST", path: "v1/settings/searchapplications", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[5] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -491,7 +501,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_searchapplications_delete",
     cud: "delete",
     description: "Deletes a search application. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.searchapplications.delete", httpMethod: "DELETE", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.settings.searchapplications.delete", httpMethod: "DELETE", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -505,7 +515,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_searchapplications_get",
     cud: "read",
     description: "Gets the specified search application. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.searchapplications.get", httpMethod: "GET", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.settings.searchapplications.get", httpMethod: "GET", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -519,7 +529,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_searchapplications_list",
     cud: "read",
     description: "Lists all search applications. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.searchapplications.list", httpMethod: "GET", path: "v1/settings/searchapplications", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.settings.searchapplications.list", httpMethod: "GET", path: "v1/settings/searchapplications", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[5] },
     params: [{"field":"debugOptions.enableDebugging","api":"debugOptions.enableDebugging","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -534,7 +544,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_searchapplications_patch",
     cud: "update",
     description: "Updates a search application. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.searchapplications.patch", httpMethod: "PATCH", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.settings.searchapplications.patch", httpMethod: "PATCH", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -549,7 +559,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_searchapplications_reset",
     cud: "create",
     description: "Resets a search application to default settings. This will return an empty response. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.searchapplications.reset", httpMethod: "POST", path: "v1/settings/{+name}:reset", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.settings.searchapplications.reset", httpMethod: "POST", path: "v1/settings/{+name}:reset", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -563,7 +573,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_searchapplications_update",
     cud: "update",
     description: "Updates a search application. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.searchapplications.update", httpMethod: "PUT", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.settings.searchapplications.update", httpMethod: "PUT", path: "v1/settings/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[5] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -578,7 +588,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_settings_update_customer",
     cud: "update",
     description: "Update customer settings. **Note:** This API requires an admin account to execute.",
-    method: { id: "cloudsearch.settings.updateCustomer", httpMethod: "PATCH", path: "v1/settings/customer", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.settings.updateCustomer", httpMethod: "PATCH", path: "v1/settings/customer", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[1] },
     params: [{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -592,7 +602,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_stats_get_index",
     cud: "read",
     description: "Gets indexed item statistics aggreggated across all data sources. This API only returns statistics for previous dates; it doesn't return statistics for the curr",
-    method: { id: "cloudsearch.stats.getIndex", httpMethod: "GET", path: "v1/stats/index", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.stats.getIndex", httpMethod: "GET", path: "v1/stats/index", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[6] },
     params: [{"field":"fromDate.day","api":"fromDate.day","location":"query"},{"field":"fromDate.month","api":"fromDate.month","location":"query"},{"field":"fromDate.year","api":"fromDate.year","location":"query"},{"field":"toDate.day","api":"toDate.day","location":"query"},{"field":"toDate.month","api":"toDate.month","location":"query"},{"field":"toDate.year","api":"toDate.year","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -610,7 +620,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_stats_get_query",
     cud: "read",
     description: "Get the query statistics for customer. **Note:** This API requires a standard end user account to execute.",
-    method: { id: "cloudsearch.stats.getQuery", httpMethod: "GET", path: "v1/stats/query", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.stats.getQuery", httpMethod: "GET", path: "v1/stats/query", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[6] },
     params: [{"field":"fromDate.day","api":"fromDate.day","location":"query"},{"field":"fromDate.month","api":"fromDate.month","location":"query"},{"field":"fromDate.year","api":"fromDate.year","location":"query"},{"field":"toDate.day","api":"toDate.day","location":"query"},{"field":"toDate.month","api":"toDate.month","location":"query"},{"field":"toDate.year","api":"toDate.year","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -628,7 +638,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_stats_get_searchapplication",
     cud: "read",
     description: "Get search application stats for customer. **Note:** This API requires a standard end user account to execute.",
-    method: { id: "cloudsearch.stats.getSearchapplication", httpMethod: "GET", path: "v1/stats/searchapplication", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.stats.getSearchapplication", httpMethod: "GET", path: "v1/stats/searchapplication", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[6] },
     params: [{"field":"endDate.day","api":"endDate.day","location":"query"},{"field":"endDate.month","api":"endDate.month","location":"query"},{"field":"endDate.year","api":"endDate.year","location":"query"},{"field":"startDate.day","api":"startDate.day","location":"query"},{"field":"startDate.month","api":"startDate.month","location":"query"},{"field":"startDate.year","api":"startDate.year","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -646,7 +656,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_stats_get_session",
     cud: "read",
     description: "Get the # of search sessions, % of successful sessions with a click query statistics for customer. **Note:** This API requires a standard end user account to ex",
-    method: { id: "cloudsearch.stats.getSession", httpMethod: "GET", path: "v1/stats/session", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.stats.getSession", httpMethod: "GET", path: "v1/stats/session", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[6] },
     params: [{"field":"fromDate.day","api":"fromDate.day","location":"query"},{"field":"fromDate.month","api":"fromDate.month","location":"query"},{"field":"fromDate.year","api":"fromDate.year","location":"query"},{"field":"toDate.day","api":"toDate.day","location":"query"},{"field":"toDate.month","api":"toDate.month","location":"query"},{"field":"toDate.year","api":"toDate.year","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -664,7 +674,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_stats_get_user",
     cud: "read",
     description: "Get the users statistics for customer. **Note:** This API requires a standard end user account to execute.",
-    method: { id: "cloudsearch.stats.getUser", httpMethod: "GET", path: "v1/stats/user", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [] },
+    method: { id: "cloudsearch.stats.getUser", httpMethod: "GET", path: "v1/stats/user", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: [], scopes: S_cloudsearch_v1[6] },
     params: [{"field":"fromDate.day","api":"fromDate.day","location":"query"},{"field":"fromDate.month","api":"fromDate.month","location":"query"},{"field":"fromDate.year","api":"fromDate.year","location":"query"},{"field":"toDate.day","api":"toDate.day","location":"query"},{"field":"toDate.month","api":"toDate.month","location":"query"},{"field":"toDate.year","api":"toDate.year","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -682,7 +692,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_stats_index_datasources_get",
     cud: "read",
     description: "Gets indexed item statistics for a single data source. **Note:** This API requires a standard end user account to execute.",
-    method: { id: "cloudsearch.stats.index.datasources.get", httpMethod: "GET", path: "v1/stats/index/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.stats.index.datasources.get", httpMethod: "GET", path: "v1/stats/index/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[6] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fromDate.day","api":"fromDate.day","location":"query"},{"field":"fromDate.month","api":"fromDate.month","location":"query"},{"field":"fromDate.year","api":"fromDate.year","location":"query"},{"field":"toDate.day","api":"toDate.day","location":"query"},{"field":"toDate.month","api":"toDate.month","location":"query"},{"field":"toDate.year","api":"toDate.year","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -701,7 +711,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_stats_query_searchapplications_get",
     cud: "read",
     description: "Get the query statistics for search application. **Note:** This API requires a standard end user account to execute.",
-    method: { id: "cloudsearch.stats.query.searchapplications.get", httpMethod: "GET", path: "v1/stats/query/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.stats.query.searchapplications.get", httpMethod: "GET", path: "v1/stats/query/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[6] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fromDate.day","api":"fromDate.day","location":"query"},{"field":"fromDate.month","api":"fromDate.month","location":"query"},{"field":"fromDate.year","api":"fromDate.year","location":"query"},{"field":"toDate.day","api":"toDate.day","location":"query"},{"field":"toDate.month","api":"toDate.month","location":"query"},{"field":"toDate.year","api":"toDate.year","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -720,7 +730,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_stats_session_searchapplications_get",
     cud: "read",
     description: "Get the # of search sessions, % of successful sessions with a click query statistics for search application. **Note:** This API requires a standard end user acc",
-    method: { id: "cloudsearch.stats.session.searchapplications.get", httpMethod: "GET", path: "v1/stats/session/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.stats.session.searchapplications.get", httpMethod: "GET", path: "v1/stats/session/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[6] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fromDate.day","api":"fromDate.day","location":"query"},{"field":"fromDate.month","api":"fromDate.month","location":"query"},{"field":"fromDate.year","api":"fromDate.year","location":"query"},{"field":"toDate.day","api":"toDate.day","location":"query"},{"field":"toDate.month","api":"toDate.month","location":"query"},{"field":"toDate.year","api":"toDate.year","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -739,7 +749,7 @@ export function registerCloudsearchGeneratedTools(registry: ToolRegistry): void 
     name: "cloudsearch_stats_user_searchapplications_get",
     cud: "read",
     description: "Get the users statistics for search application. **Note:** This API requires a standard end user account to execute.",
-    method: { id: "cloudsearch.stats.user.searchapplications.get", httpMethod: "GET", path: "v1/stats/user/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "cloudsearch.stats.user.searchapplications.get", httpMethod: "GET", path: "v1/stats/user/{+name}", baseUrl: "https://cloudsearch.googleapis.com/", requiredParams: ["name"], scopes: S_cloudsearch_v1[6] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fromDate.day","api":"fromDate.day","location":"query"},{"field":"fromDate.month","api":"fromDate.month","location":"query"},{"field":"fromDate.year","api":"fromDate.year","location":"query"},{"field":"toDate.day","api":"toDate.day","location":"query"},{"field":"toDate.month","api":"toDate.month","location":"query"},{"field":"toDate.year","api":"toDate.year","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/contacts.ts
+++ b/src/tools/generated/contacts.ts
@@ -5,11 +5,19 @@ import { coerceArray, coerceBoolean, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerContactsGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_people_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/contacts","https://www.googleapis.com/auth/contacts.readonly"],
+    ["https://www.googleapis.com/auth/contacts"],
+    ["https://www.googleapis.com/auth/contacts","https://www.googleapis.com/auth/contacts.other.readonly"],
+    ["https://www.googleapis.com/auth/contacts.other.readonly"],
+    ["https://www.googleapis.com/auth/directory.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "contacts_contact_groups_batch_get",
     cud: "read",
     description: "Get a list of contact groups owned by the authenticated user by specifying a list of contact group resource names.",
-    method: { id: "people.contactGroups.batchGet", httpMethod: "GET", path: "v1/contactGroups:batchGet", baseUrl: "https://people.googleapis.com/", requiredParams: [] },
+    method: { id: "people.contactGroups.batchGet", httpMethod: "GET", path: "v1/contactGroups:batchGet", baseUrl: "https://people.googleapis.com/", requiredParams: [], scopes: S_people_v1[0] },
     params: [{"field":"groupFields","api":"groupFields","location":"query"},{"field":"maxMembers","api":"maxMembers","location":"query"},{"field":"resourceNames","api":"resourceNames","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -24,7 +32,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_contact_groups_delete",
     cud: "delete",
     description: "Delete an existing contact group owned by the authenticated user by specifying a contact group resource name. Mutate requests for the same user should be sent s",
-    method: { id: "people.contactGroups.delete", httpMethod: "DELETE", path: "v1/{+resourceName}", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"] },
+    method: { id: "people.contactGroups.delete", httpMethod: "DELETE", path: "v1/{+resourceName}", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"], scopes: S_people_v1[1] },
     params: [{"field":"resourceName","api":"resourceName","location":"path"},{"field":"deleteContacts","api":"deleteContacts","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -38,7 +46,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_contact_groups_members_modify",
     cud: "update",
     description: "Modify the members of a contact group owned by the authenticated user. The only system contact groups that can have members added are `contactGroups/myContacts`",
-    method: { id: "people.contactGroups.members.modify", httpMethod: "POST", path: "v1/{+resourceName}/members:modify", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"] },
+    method: { id: "people.contactGroups.members.modify", httpMethod: "POST", path: "v1/{+resourceName}/members:modify", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"], scopes: S_people_v1[1] },
     params: [{"field":"resourceName","api":"resourceName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -52,7 +60,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_contact_groups_update",
     cud: "update",
     description: "Update the name of an existing contact group owned by the authenticated user. Updated contact group names must be unique to the users contact groups. Attempting",
-    method: { id: "people.contactGroups.update", httpMethod: "PUT", path: "v1/{+resourceName}", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"] },
+    method: { id: "people.contactGroups.update", httpMethod: "PUT", path: "v1/{+resourceName}", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"], scopes: S_people_v1[1] },
     params: [{"field":"resourceName","api":"resourceName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -66,7 +74,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_other_contacts_copy_other_contact_to_my_contacts_group",
     cud: "create",
     description: "Copies an \"Other contact\" to a new contact in the user's \"myContacts\" group Mutate requests for the same user should be sent sequentially to avoid increased lat",
-    method: { id: "people.otherContacts.copyOtherContactToMyContactsGroup", httpMethod: "POST", path: "v1/{+resourceName}:copyOtherContactToMyContactsGroup", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"] },
+    method: { id: "people.otherContacts.copyOtherContactToMyContactsGroup", httpMethod: "POST", path: "v1/{+resourceName}:copyOtherContactToMyContactsGroup", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"], scopes: S_people_v1[2] },
     params: [{"field":"resourceName","api":"resourceName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -80,7 +88,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_other_contacts_list",
     cud: "read",
     description: "List all \"Other contacts\", that is contacts that are not in a contact group. \"Other contacts\" are typically auto created contacts from interactions. Sync tokens",
-    method: { id: "people.otherContacts.list", httpMethod: "GET", path: "v1/otherContacts", baseUrl: "https://people.googleapis.com/", requiredParams: [] },
+    method: { id: "people.otherContacts.list", httpMethod: "GET", path: "v1/otherContacts", baseUrl: "https://people.googleapis.com/", requiredParams: [], scopes: S_people_v1[3] },
     params: [{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"readMask","api":"readMask","location":"query"},{"field":"requestSyncToken","api":"requestSyncToken","location":"query"},{"field":"sources","api":"sources","location":"query"},{"field":"syncToken","api":"syncToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -98,7 +106,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_other_contacts_search",
     cud: "read",
     description: "Provides a list of contacts in the authenticated user's other contacts that matches the search query. The query matches on a contact's `names`, `emailAddresses`",
-    method: { id: "people.otherContacts.search", httpMethod: "GET", path: "v1/otherContacts:search", baseUrl: "https://people.googleapis.com/", requiredParams: [] },
+    method: { id: "people.otherContacts.search", httpMethod: "GET", path: "v1/otherContacts:search", baseUrl: "https://people.googleapis.com/", requiredParams: [], scopes: S_people_v1[3] },
     params: [{"field":"pageSize","api":"pageSize","location":"query"},{"field":"query","api":"query","location":"query"},{"field":"readMask","api":"readMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -113,7 +121,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_people_batch_create_contacts",
     cud: "create",
     description: "Create a batch of new contacts and return the PersonResponses for the newly Mutate requests for the same user should be sent sequentially to avoid increased lat",
-    method: { id: "people.people.batchCreateContacts", httpMethod: "POST", path: "v1/people:batchCreateContacts", baseUrl: "https://people.googleapis.com/", requiredParams: [] },
+    method: { id: "people.people.batchCreateContacts", httpMethod: "POST", path: "v1/people:batchCreateContacts", baseUrl: "https://people.googleapis.com/", requiredParams: [], scopes: S_people_v1[1] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -126,7 +134,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_people_batch_delete_contacts",
     cud: "delete",
     description: "Delete a batch of contacts. Any non-contact data will not be deleted. Mutate requests for the same user should be sent sequentially to avoid increased latency a",
-    method: { id: "people.people.batchDeleteContacts", httpMethod: "POST", path: "v1/people:batchDeleteContacts", baseUrl: "https://people.googleapis.com/", requiredParams: [] },
+    method: { id: "people.people.batchDeleteContacts", httpMethod: "POST", path: "v1/people:batchDeleteContacts", baseUrl: "https://people.googleapis.com/", requiredParams: [], scopes: S_people_v1[1] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -139,7 +147,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_people_batch_update_contacts",
     cud: "create",
     description: "Update a batch of contacts and return a map of resource names to PersonResponses for the updated contacts. Mutate requests for the same user should be sent sequ",
-    method: { id: "people.people.batchUpdateContacts", httpMethod: "POST", path: "v1/people:batchUpdateContacts", baseUrl: "https://people.googleapis.com/", requiredParams: [] },
+    method: { id: "people.people.batchUpdateContacts", httpMethod: "POST", path: "v1/people:batchUpdateContacts", baseUrl: "https://people.googleapis.com/", requiredParams: [], scopes: S_people_v1[1] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -152,7 +160,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_people_delete_contact_photo",
     cud: "delete",
     description: "Delete a contact's photo. Mutate requests for the same user should be done sequentially to avoid // lock contention.",
-    method: { id: "people.people.deleteContactPhoto", httpMethod: "DELETE", path: "v1/{+resourceName}:deleteContactPhoto", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"] },
+    method: { id: "people.people.deleteContactPhoto", httpMethod: "DELETE", path: "v1/{+resourceName}:deleteContactPhoto", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"], scopes: S_people_v1[1] },
     params: [{"field":"resourceName","api":"resourceName","location":"path"},{"field":"personFields","api":"personFields","location":"query"},{"field":"sources","api":"sources","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -167,7 +175,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_people_list_directory_people",
     cud: "read",
     description: "Provides a list of domain profiles and domain contacts in the authenticated user's domain directory. When the `sync_token` is specified, resources deleted since",
-    method: { id: "people.people.listDirectoryPeople", httpMethod: "GET", path: "v1/people:listDirectoryPeople", baseUrl: "https://people.googleapis.com/", requiredParams: [] },
+    method: { id: "people.people.listDirectoryPeople", httpMethod: "GET", path: "v1/people:listDirectoryPeople", baseUrl: "https://people.googleapis.com/", requiredParams: [], scopes: S_people_v1[4] },
     params: [{"field":"mergeSources","api":"mergeSources","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"readMask","api":"readMask","location":"query"},{"field":"requestSyncToken","api":"requestSyncToken","location":"query"},{"field":"sources","api":"sources","location":"query"},{"field":"syncToken","api":"syncToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -186,7 +194,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_people_search_directory_people",
     cud: "read",
     description: "Provides a list of domain profiles and domain contacts in the authenticated user's domain directory that match the search query.",
-    method: { id: "people.people.searchDirectoryPeople", httpMethod: "GET", path: "v1/people:searchDirectoryPeople", baseUrl: "https://people.googleapis.com/", requiredParams: [] },
+    method: { id: "people.people.searchDirectoryPeople", httpMethod: "GET", path: "v1/people:searchDirectoryPeople", baseUrl: "https://people.googleapis.com/", requiredParams: [], scopes: S_people_v1[4] },
     params: [{"field":"mergeSources","api":"mergeSources","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"query","api":"query","location":"query"},{"field":"readMask","api":"readMask","location":"query"},{"field":"sources","api":"sources","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -204,7 +212,7 @@ export function registerContactsGeneratedTools(registry: ToolRegistry): void {
     name: "contacts_people_update_contact_photo",
     cud: "update",
     description: "Update a contact's photo. Mutate requests for the same user should be sent sequentially to avoid increased latency and failures.",
-    method: { id: "people.people.updateContactPhoto", httpMethod: "PATCH", path: "v1/{+resourceName}:updateContactPhoto", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"] },
+    method: { id: "people.people.updateContactPhoto", httpMethod: "PATCH", path: "v1/{+resourceName}:updateContactPhoto", baseUrl: "https://people.googleapis.com/", requiredParams: ["resourceName"], scopes: S_people_v1[1] },
     params: [{"field":"resourceName","api":"resourceName","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/drive.ts
+++ b/src/tools/generated/drive.ts
@@ -5,11 +5,27 @@ import { coerceBoolean, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerDriveGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_drive_v3: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.metadata","https://www.googleapis.com/auth/drive.metadata.readonly","https://www.googleapis.com/auth/drive.readonly"],
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.metadata"],
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.appdata","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.metadata","https://www.googleapis.com/auth/drive.metadata.readonly","https://www.googleapis.com/auth/drive.readonly"],
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.appdata","https://www.googleapis.com/auth/drive.apps.readonly","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.metadata","https://www.googleapis.com/auth/drive.metadata.readonly","https://www.googleapis.com/auth/drive.readonly"],
+    ["https://www.googleapis.com/auth/drive.apps.readonly"],
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.appdata","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.meet.readonly","https://www.googleapis.com/auth/drive.metadata","https://www.googleapis.com/auth/drive.metadata.readonly","https://www.googleapis.com/auth/drive.photos.readonly","https://www.googleapis.com/auth/drive.readonly"],
+    ["https://www.googleapis.com/auth/drive"],
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.readonly"],
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.appdata","https://www.googleapis.com/auth/drive.file"],
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.meet.readonly","https://www.googleapis.com/auth/drive.metadata","https://www.googleapis.com/auth/drive.metadata.readonly","https://www.googleapis.com/auth/drive.readonly"],
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.meet.readonly","https://www.googleapis.com/auth/drive.readonly"],
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.meet.readonly","https://www.googleapis.com/auth/drive.metadata","https://www.googleapis.com/auth/drive.metadata.readonly","https://www.googleapis.com/auth/drive.photos.readonly","https://www.googleapis.com/auth/drive.readonly"],
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "drive_accessproposals_get",
     cud: "read",
     description: "Retrieves an access proposal by ID. For more information, see [Manage pending access proposals](https://developers.google.com/workspace/drive/api/guides/pending",
-    method: { id: "drive.accessproposals.get", httpMethod: "GET", path: "files/{fileId}/accessproposals/{proposalId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","proposalId"] },
+    method: { id: "drive.accessproposals.get", httpMethod: "GET", path: "files/{fileId}/accessproposals/{proposalId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","proposalId"], scopes: S_drive_v3[0] },
     params: [{"field":"fileId","api":"fileId","location":"path"},{"field":"proposalId","api":"proposalId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -23,7 +39,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_approvals_approve",
     cud: "create",
     description: "Approves an approval. For more information, see [Manage approvals](https://developers.google.com/workspace/drive/api/guides/approvals). This is used to update t",
-    method: { id: "drive.approvals.approve", httpMethod: "POST", path: "files/{fileId}/approvals/{approvalId}:approve", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"] },
+    method: { id: "drive.approvals.approve", httpMethod: "POST", path: "files/{fileId}/approvals/{approvalId}:approve", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"], scopes: S_drive_v3[1] },
     params: [{"field":"approvalId","api":"approvalId","location":"path"},{"field":"fileId","api":"fileId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -38,7 +54,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_approvals_cancel",
     cud: "create",
     description: "Cancels an approval. For more information, see [Manage approvals](https://developers.google.com/workspace/drive/api/guides/approvals). Updates the approval Stat",
-    method: { id: "drive.approvals.cancel", httpMethod: "POST", path: "files/{fileId}/approvals/{approvalId}:cancel", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"] },
+    method: { id: "drive.approvals.cancel", httpMethod: "POST", path: "files/{fileId}/approvals/{approvalId}:cancel", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"], scopes: S_drive_v3[1] },
     params: [{"field":"approvalId","api":"approvalId","location":"path"},{"field":"fileId","api":"fileId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -53,7 +69,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_approvals_comment",
     cud: "create",
     description: "Comments on an approval. For more information, see [Manage approvals](https://developers.google.com/workspace/drive/api/guides/approvals). This sends a notifica",
-    method: { id: "drive.approvals.comment", httpMethod: "POST", path: "files/{fileId}/approvals/{approvalId}:comment", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"] },
+    method: { id: "drive.approvals.comment", httpMethod: "POST", path: "files/{fileId}/approvals/{approvalId}:comment", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"], scopes: S_drive_v3[1] },
     params: [{"field":"approvalId","api":"approvalId","location":"path"},{"field":"fileId","api":"fileId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -68,7 +84,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_approvals_decline",
     cud: "create",
     description: "Declines an approval. For more information, see [Manage approvals](https://developers.google.com/workspace/drive/api/guides/approvals). This is used to update t",
-    method: { id: "drive.approvals.decline", httpMethod: "POST", path: "files/{fileId}/approvals/{approvalId}:decline", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"] },
+    method: { id: "drive.approvals.decline", httpMethod: "POST", path: "files/{fileId}/approvals/{approvalId}:decline", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"], scopes: S_drive_v3[1] },
     params: [{"field":"approvalId","api":"approvalId","location":"path"},{"field":"fileId","api":"fileId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -83,7 +99,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_approvals_get",
     cud: "read",
     description: "Gets an approval by ID. For more information, see [Manage approvals](https://developers.google.com/workspace/drive/api/guides/approvals).",
-    method: { id: "drive.approvals.get", httpMethod: "GET", path: "files/{fileId}/approvals/{approvalId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"] },
+    method: { id: "drive.approvals.get", httpMethod: "GET", path: "files/{fileId}/approvals/{approvalId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"], scopes: S_drive_v3[2] },
     params: [{"field":"approvalId","api":"approvalId","location":"path"},{"field":"fileId","api":"fileId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -97,7 +113,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_approvals_list",
     cud: "read",
     description: "Lists the approvals on a file. For more information, see [Manage approvals](https://developers.google.com/workspace/drive/api/guides/approvals).",
-    method: { id: "drive.approvals.list", httpMethod: "GET", path: "files/{fileId}/approvals", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"] },
+    method: { id: "drive.approvals.list", httpMethod: "GET", path: "files/{fileId}/approvals", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"], scopes: S_drive_v3[2] },
     params: [{"field":"fileId","api":"fileId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -112,7 +128,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_approvals_reassign",
     cud: "create",
     description: "Reassigns the reviewers on an approval. For more information, see [Manage approvals](https://developers.google.com/workspace/drive/api/guides/approvals). Adds o",
-    method: { id: "drive.approvals.reassign", httpMethod: "POST", path: "files/{fileId}/approvals/{approvalId}:reassign", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"] },
+    method: { id: "drive.approvals.reassign", httpMethod: "POST", path: "files/{fileId}/approvals/{approvalId}:reassign", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","approvalId"], scopes: S_drive_v3[1] },
     params: [{"field":"approvalId","api":"approvalId","location":"path"},{"field":"fileId","api":"fileId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -127,7 +143,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_approvals_start",
     cud: "create",
     description: "Starts an approval on a file. For more information, see [Manage approvals](https://developers.google.com/workspace/drive/api/guides/approvals).",
-    method: { id: "drive.approvals.start", httpMethod: "POST", path: "files/{fileId}/approvals:start", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"] },
+    method: { id: "drive.approvals.start", httpMethod: "POST", path: "files/{fileId}/approvals:start", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"], scopes: S_drive_v3[1] },
     params: [{"field":"fileId","api":"fileId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -141,7 +157,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_apps_get",
     cud: "read",
     description: "Gets a specific app. For more information, see [Return user info](https://developers.google.com/workspace/drive/api/guides/user-info).",
-    method: { id: "drive.apps.get", httpMethod: "GET", path: "apps/{appId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["appId"] },
+    method: { id: "drive.apps.get", httpMethod: "GET", path: "apps/{appId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["appId"], scopes: S_drive_v3[3] },
     params: [{"field":"appId","api":"appId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -154,7 +170,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_apps_list",
     cud: "read",
     description: "Lists a user's installed apps. For more information, see [Return user info](https://developers.google.com/workspace/drive/api/guides/user-info).",
-    method: { id: "drive.apps.list", httpMethod: "GET", path: "apps", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [] },
+    method: { id: "drive.apps.list", httpMethod: "GET", path: "apps", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [], scopes: S_drive_v3[4] },
     params: [{"field":"appFilterExtensions","api":"appFilterExtensions","location":"query"},{"field":"appFilterMimeTypes","api":"appFilterMimeTypes","location":"query"},{"field":"languageCode","api":"languageCode","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -169,7 +185,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_changes_get_start_page_token",
     cud: "read",
     description: "Gets the starting pageToken for listing future changes. For more information, see [Retrieve changes](https://developers.google.com/workspace/drive/api/guides/ma",
-    method: { id: "drive.changes.getStartPageToken", httpMethod: "GET", path: "changes/startPageToken", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [] },
+    method: { id: "drive.changes.getStartPageToken", httpMethod: "GET", path: "changes/startPageToken", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [], scopes: S_drive_v3[5] },
     params: [{"field":"driveId","api":"driveId","location":"query"},{"field":"supportsAllDrives","api":"supportsAllDrives","location":"query"},{"field":"supportsTeamDrives","api":"supportsTeamDrives","location":"query"},{"field":"teamDriveId","api":"teamDriveId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -185,7 +201,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_changes_list",
     cud: "read",
     description: "Lists the changes for a user or shared drive. For more information, see [Retrieve changes](https://developers.google.com/workspace/drive/api/guides/manage-chang",
-    method: { id: "drive.changes.list", httpMethod: "GET", path: "changes", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["pageToken"] },
+    method: { id: "drive.changes.list", httpMethod: "GET", path: "changes", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["pageToken"], scopes: S_drive_v3[5] },
     params: [{"field":"pageToken","api":"pageToken","location":"query"},{"field":"driveId","api":"driveId","location":"query"},{"field":"includeCorpusRemovals","api":"includeCorpusRemovals","location":"query"},{"field":"includeItemsFromAllDrives","api":"includeItemsFromAllDrives","location":"query"},{"field":"includeLabels","api":"includeLabels","location":"query"},{"field":"includePermissionsForView","api":"includePermissionsForView","location":"query"},{"field":"includeRemoved","api":"includeRemoved","location":"query"},{"field":"includeTeamDriveItems","api":"includeTeamDriveItems","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"restrictToMyDrive","api":"restrictToMyDrive","location":"query"},{"field":"spaces","api":"spaces","location":"query"},{"field":"supportsAllDrives","api":"supportsAllDrives","location":"query"},{"field":"supportsTeamDrives","api":"supportsTeamDrives","location":"query"},{"field":"teamDriveId","api":"teamDriveId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -211,7 +227,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_changes_watch",
     cud: "create",
     description: "Subscribes to changes for a user. For more information, see [Notifications for resource changes](https://developers.google.com/workspace/drive/api/guides/push).",
-    method: { id: "drive.changes.watch", httpMethod: "POST", path: "changes/watch", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["pageToken"] },
+    method: { id: "drive.changes.watch", httpMethod: "POST", path: "changes/watch", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["pageToken"], scopes: S_drive_v3[5] },
     params: [{"field":"pageToken","api":"pageToken","location":"query"},{"field":"driveId","api":"driveId","location":"query"},{"field":"includeCorpusRemovals","api":"includeCorpusRemovals","location":"query"},{"field":"includeItemsFromAllDrives","api":"includeItemsFromAllDrives","location":"query"},{"field":"includeLabels","api":"includeLabels","location":"query"},{"field":"includePermissionsForView","api":"includePermissionsForView","location":"query"},{"field":"includeRemoved","api":"includeRemoved","location":"query"},{"field":"includeTeamDriveItems","api":"includeTeamDriveItems","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"restrictToMyDrive","api":"restrictToMyDrive","location":"query"},{"field":"spaces","api":"spaces","location":"query"},{"field":"supportsAllDrives","api":"supportsAllDrives","location":"query"},{"field":"supportsTeamDrives","api":"supportsTeamDrives","location":"query"},{"field":"teamDriveId","api":"teamDriveId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -238,7 +254,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_channels_stop",
     cud: "create",
     description: "Stops watching resources through this channel. For more information, see [Notifications for resource changes](https://developers.google.com/workspace/drive/api/",
-    method: { id: "drive.channels.stop", httpMethod: "POST", path: "channels/stop", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [] },
+    method: { id: "drive.channels.stop", httpMethod: "POST", path: "channels/stop", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [], scopes: S_drive_v3[5] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -251,7 +267,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_drives_create",
     cud: "create",
     description: "Creates a shared drive. For more information, see [Manage shared drives](https://developers.google.com/workspace/drive/api/guides/manage-shareddrives).",
-    method: { id: "drive.drives.create", httpMethod: "POST", path: "drives", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["requestId"] },
+    method: { id: "drive.drives.create", httpMethod: "POST", path: "drives", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["requestId"], scopes: S_drive_v3[6] },
     params: [{"field":"requestId","api":"requestId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -265,7 +281,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_drives_delete",
     cud: "delete",
     description: "Permanently deletes a shared drive for which the user is an `organizer`. The shared drive cannot contain any untrashed items. For more information, see [Manage",
-    method: { id: "drive.drives.delete", httpMethod: "DELETE", path: "drives/{driveId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["driveId"] },
+    method: { id: "drive.drives.delete", httpMethod: "DELETE", path: "drives/{driveId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["driveId"], scopes: S_drive_v3[6] },
     params: [{"field":"driveId","api":"driveId","location":"path"},{"field":"allowItemDeletion","api":"allowItemDeletion","location":"query"},{"field":"useDomainAdminAccess","api":"useDomainAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -280,7 +296,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_drives_hide",
     cud: "create",
     description: "Hides a shared drive from the default view. For more information, see [Manage shared drives](https://developers.google.com/workspace/drive/api/guides/manage-sha",
-    method: { id: "drive.drives.hide", httpMethod: "POST", path: "drives/{driveId}/hide", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["driveId"] },
+    method: { id: "drive.drives.hide", httpMethod: "POST", path: "drives/{driveId}/hide", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["driveId"], scopes: S_drive_v3[6] },
     params: [{"field":"driveId","api":"driveId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -293,7 +309,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_drives_unhide",
     cud: "create",
     description: "Restores a shared drive to the default view. For more information, see [Manage shared drives](https://developers.google.com/workspace/drive/api/guides/manage-sh",
-    method: { id: "drive.drives.unhide", httpMethod: "POST", path: "drives/{driveId}/unhide", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["driveId"] },
+    method: { id: "drive.drives.unhide", httpMethod: "POST", path: "drives/{driveId}/unhide", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["driveId"], scopes: S_drive_v3[6] },
     params: [{"field":"driveId","api":"driveId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -306,7 +322,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_drives_update",
     cud: "update",
     description: "Updates the metadata for a shared drive. For more information, see [Manage shared drives](https://developers.google.com/workspace/drive/api/guides/manage-shared",
-    method: { id: "drive.drives.update", httpMethod: "PATCH", path: "drives/{driveId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["driveId"] },
+    method: { id: "drive.drives.update", httpMethod: "PATCH", path: "drives/{driveId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["driveId"], scopes: S_drive_v3[6] },
     params: [{"field":"driveId","api":"driveId","location":"path"},{"field":"useDomainAdminAccess","api":"useDomainAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -321,7 +337,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_files_download",
     cud: "read",
     description: "Downloads the content of a file. For more information, see [Download and export files](https://developers.google.com/workspace/drive/api/guides/manage-downloads",
-    method: { id: "drive.files.download", httpMethod: "POST", path: "files/{fileId}/download", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"] },
+    method: { id: "drive.files.download", httpMethod: "POST", path: "files/{fileId}/download", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"], scopes: S_drive_v3[7] },
     params: [{"field":"fileId","api":"fileId","location":"path"},{"field":"mimeType","api":"mimeType","location":"query"},{"field":"revisionId","api":"revisionId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -336,7 +352,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_files_generate_cse_token",
     cud: "read",
     description: "Generates a CSE token which can be used to create or update CSE files.",
-    method: { id: "drive.files.generateCseToken", httpMethod: "GET", path: "files/generateCseToken", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [] },
+    method: { id: "drive.files.generateCseToken", httpMethod: "GET", path: "files/generateCseToken", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [], scopes: S_drive_v3[6] },
     params: [{"field":"fileId","api":"fileId","location":"query"},{"field":"parent","api":"parent","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -350,7 +366,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_files_generate_ids",
     cud: "read",
     description: "Generates a set of file IDs which can be provided in create or copy requests. For more information, see [Create and manage files](https://developers.google.com/",
-    method: { id: "drive.files.generateIds", httpMethod: "GET", path: "files/generateIds", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [] },
+    method: { id: "drive.files.generateIds", httpMethod: "GET", path: "files/generateIds", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [], scopes: S_drive_v3[8] },
     params: [{"field":"count","api":"count","location":"query"},{"field":"space","api":"space","location":"query"},{"field":"type","api":"type","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -365,7 +381,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_files_list_labels",
     cud: "read",
     description: "Lists the labels on a file. For more information, see [List labels on a file](https://developers.google.com/workspace/drive/api/guides/list-labels).",
-    method: { id: "drive.files.listLabels", httpMethod: "GET", path: "files/{fileId}/listLabels", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"] },
+    method: { id: "drive.files.listLabels", httpMethod: "GET", path: "files/{fileId}/listLabels", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"], scopes: S_drive_v3[9] },
     params: [{"field":"fileId","api":"fileId","location":"path"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -380,7 +396,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_files_modify_labels",
     cud: "update",
     description: "Modifies the set of labels applied to a file. For more information, see [Set a label field on a file](https://developers.google.com/workspace/drive/api/guides/s",
-    method: { id: "drive.files.modifyLabels", httpMethod: "POST", path: "files/{fileId}/modifyLabels", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"] },
+    method: { id: "drive.files.modifyLabels", httpMethod: "POST", path: "files/{fileId}/modifyLabels", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"], scopes: S_drive_v3[1] },
     params: [{"field":"fileId","api":"fileId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -394,7 +410,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_files_watch",
     cud: "create",
     description: "Subscribes to changes to a file. For more information, see [Notifications for resource changes](https://developers.google.com/workspace/drive/api/guides/push).",
-    method: { id: "drive.files.watch", httpMethod: "POST", path: "files/{fileId}/watch", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"] },
+    method: { id: "drive.files.watch", httpMethod: "POST", path: "files/{fileId}/watch", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId"], scopes: S_drive_v3[5] },
     params: [{"field":"fileId","api":"fileId","location":"path"},{"field":"acknowledgeAbuse","api":"acknowledgeAbuse","location":"query"},{"field":"includeLabels","api":"includeLabels","location":"query"},{"field":"includePermissionsForView","api":"includePermissionsForView","location":"query"},{"field":"supportsAllDrives","api":"supportsAllDrives","location":"query"},{"field":"supportsTeamDrives","api":"supportsTeamDrives","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -413,7 +429,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_operations_get",
     cud: "read",
     description: "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.",
-    method: { id: "drive.operations.get", httpMethod: "GET", path: "operations/{name}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["name"] },
+    method: { id: "drive.operations.get", httpMethod: "GET", path: "operations/{name}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["name"], scopes: S_drive_v3[10] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -426,7 +442,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_permissions_get",
     cud: "read",
     description: "Gets a permission by ID. For more information, see [Share files, folders, and drives](https://developers.google.com/workspace/drive/api/guides/manage-sharing).",
-    method: { id: "drive.permissions.get", httpMethod: "GET", path: "files/{fileId}/permissions/{permissionId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","permissionId"] },
+    method: { id: "drive.permissions.get", httpMethod: "GET", path: "files/{fileId}/permissions/{permissionId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","permissionId"], scopes: S_drive_v3[11] },
     params: [{"field":"fileId","api":"fileId","location":"path"},{"field":"permissionId","api":"permissionId","location":"path"},{"field":"supportsAllDrives","api":"supportsAllDrives","location":"query"},{"field":"supportsTeamDrives","api":"supportsTeamDrives","location":"query"},{"field":"useDomainAdminAccess","api":"useDomainAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -443,7 +459,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_replies_get",
     cud: "read",
     description: "Gets a reply by ID. For more information, see [Manage comments and replies](https://developers.google.com/workspace/drive/api/guides/manage-comments).",
-    method: { id: "drive.replies.get", httpMethod: "GET", path: "files/{fileId}/comments/{commentId}/replies/{replyId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","commentId","replyId"] },
+    method: { id: "drive.replies.get", httpMethod: "GET", path: "files/{fileId}/comments/{commentId}/replies/{replyId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","commentId","replyId"], scopes: S_drive_v3[10] },
     params: [{"field":"commentId","api":"commentId","location":"path"},{"field":"fileId","api":"fileId","location":"path"},{"field":"replyId","api":"replyId","location":"path"},{"field":"includeDeleted","api":"includeDeleted","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -459,7 +475,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_revisions_get",
     cud: "read",
     description: "Gets a revision's metadata or content by ID. For more information, see [Manage file revisions](https://developers.google.com/workspace/drive/api/guides/manage-r",
-    method: { id: "drive.revisions.get", httpMethod: "GET", path: "files/{fileId}/revisions/{revisionId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","revisionId"] },
+    method: { id: "drive.revisions.get", httpMethod: "GET", path: "files/{fileId}/revisions/{revisionId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["fileId","revisionId"], scopes: S_drive_v3[5] },
     params: [{"field":"fileId","api":"fileId","location":"path"},{"field":"revisionId","api":"revisionId","location":"path"},{"field":"acknowledgeAbuse","api":"acknowledgeAbuse","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -474,7 +490,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_teamdrives_create",
     cud: "create",
     description: "Deprecated: Use `drives.create` instead.",
-    method: { id: "drive.teamdrives.create", httpMethod: "POST", path: "teamdrives", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["requestId"] },
+    method: { id: "drive.teamdrives.create", httpMethod: "POST", path: "teamdrives", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["requestId"], scopes: S_drive_v3[6] },
     params: [{"field":"requestId","api":"requestId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -488,7 +504,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_teamdrives_delete",
     cud: "delete",
     description: "Deprecated: Use `drives.delete` instead.",
-    method: { id: "drive.teamdrives.delete", httpMethod: "DELETE", path: "teamdrives/{teamDriveId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["teamDriveId"] },
+    method: { id: "drive.teamdrives.delete", httpMethod: "DELETE", path: "teamdrives/{teamDriveId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["teamDriveId"], scopes: S_drive_v3[6] },
     params: [{"field":"teamDriveId","api":"teamDriveId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -501,7 +517,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_teamdrives_get",
     cud: "read",
     description: "Deprecated: Use `drives.get` instead.",
-    method: { id: "drive.teamdrives.get", httpMethod: "GET", path: "teamdrives/{teamDriveId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["teamDriveId"] },
+    method: { id: "drive.teamdrives.get", httpMethod: "GET", path: "teamdrives/{teamDriveId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["teamDriveId"], scopes: S_drive_v3[12] },
     params: [{"field":"teamDriveId","api":"teamDriveId","location":"path"},{"field":"useDomainAdminAccess","api":"useDomainAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -515,7 +531,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_teamdrives_list",
     cud: "read",
     description: "Deprecated: Use `drives.list` instead.",
-    method: { id: "drive.teamdrives.list", httpMethod: "GET", path: "teamdrives", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [] },
+    method: { id: "drive.teamdrives.list", httpMethod: "GET", path: "teamdrives", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: [], scopes: S_drive_v3[12] },
     params: [{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"q","api":"q","location":"query"},{"field":"useDomainAdminAccess","api":"useDomainAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -531,7 +547,7 @@ export function registerDriveGeneratedTools(registry: ToolRegistry): void {
     name: "drive_teamdrives_update",
     cud: "update",
     description: "Deprecated: Use `drives.update` instead.",
-    method: { id: "drive.teamdrives.update", httpMethod: "PATCH", path: "teamdrives/{teamDriveId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["teamDriveId"] },
+    method: { id: "drive.teamdrives.update", httpMethod: "PATCH", path: "teamdrives/{teamDriveId}", baseUrl: "https://www.googleapis.com/drive/v3/", requiredParams: ["teamDriveId"], scopes: S_drive_v3[6] },
     params: [{"field":"teamDriveId","api":"teamDriveId","location":"path"},{"field":"useDomainAdminAccess","api":"useDomainAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/driveactivity.ts
+++ b/src/tools/generated/driveactivity.ts
@@ -5,11 +5,15 @@ import { coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerDriveactivityGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_driveactivity_v2: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/drive.activity","https://www.googleapis.com/auth/drive.activity.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "driveactivity_activity_query",
     cud: "read",
     description: "Query past activity in Google Drive.",
-    method: { id: "driveactivity.activity.query", httpMethod: "POST", path: "v2/activity:query", baseUrl: "https://driveactivity.googleapis.com/", requiredParams: [] },
+    method: { id: "driveactivity.activity.query", httpMethod: "POST", path: "v2/activity:query", baseUrl: "https://driveactivity.googleapis.com/", requiredParams: [], scopes: S_driveactivity_v2[0] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/drivelabels.ts
+++ b/src/tools/generated/drivelabels.ts
@@ -5,11 +5,16 @@ import { coerceBoolean, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_drivelabels_v2: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/drive.admin.labels","https://www.googleapis.com/auth/drive.labels"],
+    ["https://www.googleapis.com/auth/drive.admin.labels","https://www.googleapis.com/auth/drive.admin.labels.readonly","https://www.googleapis.com/auth/drive.labels","https://www.googleapis.com/auth/drive.labels.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "drivelabels_labels_create",
     cud: "create",
     description: "Creates a label. For more information, see [Create and publish a label](https://developers.google.com/workspace/drive/labels/guides/create-label).",
-    method: { id: "drivelabels.labels.create", httpMethod: "POST", path: "v2/labels", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: [] },
+    method: { id: "drivelabels.labels.create", httpMethod: "POST", path: "v2/labels", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: [], scopes: S_drivelabels_v2[0] },
     params: [{"field":"languageCode","api":"languageCode","location":"query"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -24,7 +29,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_delete",
     cud: "delete",
     description: "Permanently deletes a label and related metadata on Drive items. For more information, see [Disable, enable, and delete a label](https://developers.google.com/w",
-    method: { id: "drivelabels.labels.delete", httpMethod: "DELETE", path: "v2/{+name}", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "drivelabels.labels.delete", httpMethod: "DELETE", path: "v2/{+name}", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"writeControl.requiredRevisionId","api":"writeControl.requiredRevisionId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -39,7 +44,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_delta",
     cud: "create",
     description: "Updates a single label by applying a set of update requests resulting in a new draft revision. For more information, see [Update a label](https://developers.goo",
-    method: { id: "drivelabels.labels.delta", httpMethod: "POST", path: "v2/{+name}:delta", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "drivelabels.labels.delta", httpMethod: "POST", path: "v2/{+name}:delta", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -53,7 +58,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_disable",
     cud: "create",
     description: "Disable a published label. For more information, see [Disable, enable, and delete a label](https://developers.google.com/workspace/drive/labels/guides/disable-d",
-    method: { id: "drivelabels.labels.disable", httpMethod: "POST", path: "v2/{+name}:disable", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "drivelabels.labels.disable", httpMethod: "POST", path: "v2/{+name}:disable", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -67,7 +72,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_enable",
     cud: "create",
     description: "Enable a disabled label and restore it to its published state. For more information, see [Disable, enable, and delete a label](https://developers.google.com/wor",
-    method: { id: "drivelabels.labels.enable", httpMethod: "POST", path: "v2/{+name}:enable", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "drivelabels.labels.enable", httpMethod: "POST", path: "v2/{+name}:enable", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -81,7 +86,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_get",
     cud: "read",
     description: "Get a label by its resource name. For more information, see [Search for labels](https://developers.google.com/workspace/drive/labels/guides/search-label). Resou",
-    method: { id: "drivelabels.labels.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "drivelabels.labels.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"], scopes: S_drivelabels_v2[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"languageCode","api":"languageCode","location":"query"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"view","api":"view","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -97,7 +102,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_list",
     cud: "read",
     description: "List labels. For more information, see [Search for labels](https://developers.google.com/workspace/drive/labels/guides/search-label).",
-    method: { id: "drivelabels.labels.list", httpMethod: "GET", path: "v2/labels", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: [] },
+    method: { id: "drivelabels.labels.list", httpMethod: "GET", path: "v2/labels", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: [], scopes: S_drivelabels_v2[1] },
     params: [{"field":"customer","api":"customer","location":"query"},{"field":"languageCode","api":"languageCode","location":"query"},{"field":"minimumRole","api":"minimumRole","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"publishedOnly","api":"publishedOnly","location":"query"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"view","api":"view","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -117,7 +122,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_locks_list",
     cud: "read",
     description: "Lists the label locks on a label.",
-    method: { id: "drivelabels.labels.locks.list", httpMethod: "GET", path: "v2/{+parent}/locks", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.locks.list", httpMethod: "GET", path: "v2/{+parent}/locks", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[1] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -132,7 +137,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_permissions_batch_delete",
     cud: "delete",
     description: "Deletes label permissions. Permissions affect the label resource as a whole, aren't revisioned, and don't require publishing.",
-    method: { id: "drivelabels.labels.permissions.batchDelete", httpMethod: "POST", path: "v2/{+parent}/permissions:batchDelete", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.permissions.batchDelete", httpMethod: "POST", path: "v2/{+parent}/permissions:batchDelete", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -146,7 +151,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_permissions_batch_update",
     cud: "create",
     description: "Updates label permissions. If a permission for the indicated principal doesn't exist, a label permission is created, otherwise the existing permission is update",
-    method: { id: "drivelabels.labels.permissions.batchUpdate", httpMethod: "POST", path: "v2/{+parent}/permissions:batchUpdate", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.permissions.batchUpdate", httpMethod: "POST", path: "v2/{+parent}/permissions:batchUpdate", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -160,7 +165,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_permissions_create",
     cud: "create",
     description: "Updates a label's permissions. If a permission for the indicated principal doesn't exist, a label permission is created, otherwise the existing permission is up",
-    method: { id: "drivelabels.labels.permissions.create", httpMethod: "POST", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.permissions.create", httpMethod: "POST", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -175,7 +180,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_permissions_delete",
     cud: "delete",
     description: "Deletes a label's permission. Permissions affect the label resource as a whole, aren't revisioned, and don't require publishing.",
-    method: { id: "drivelabels.labels.permissions.delete", httpMethod: "DELETE", path: "v2/{+name}", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "drivelabels.labels.permissions.delete", httpMethod: "DELETE", path: "v2/{+name}", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -189,7 +194,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_permissions_list",
     cud: "read",
     description: "Lists a label's permissions.",
-    method: { id: "drivelabels.labels.permissions.list", httpMethod: "GET", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.permissions.list", httpMethod: "GET", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[1] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -205,7 +210,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_publish",
     cud: "update",
     description: "Publish all draft changes to the label. Once published, the label may not return to its draft state. For more information, see [Create and publish a label](http",
-    method: { id: "drivelabels.labels.publish", httpMethod: "POST", path: "v2/{+name}:publish", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "drivelabels.labels.publish", httpMethod: "POST", path: "v2/{+name}:publish", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -219,7 +224,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_revisions_locks_list",
     cud: "read",
     description: "Lists the label locks on a label.",
-    method: { id: "drivelabels.labels.revisions.locks.list", httpMethod: "GET", path: "v2/{+parent}/locks", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.revisions.locks.list", httpMethod: "GET", path: "v2/{+parent}/locks", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[1] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -234,7 +239,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_revisions_permissions_batch_delete",
     cud: "delete",
     description: "Deletes label permissions. Permissions affect the label resource as a whole, aren't revisioned, and don't require publishing.",
-    method: { id: "drivelabels.labels.revisions.permissions.batchDelete", httpMethod: "POST", path: "v2/{+parent}/permissions:batchDelete", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.revisions.permissions.batchDelete", httpMethod: "POST", path: "v2/{+parent}/permissions:batchDelete", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -248,7 +253,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_revisions_permissions_batch_update",
     cud: "create",
     description: "Updates label permissions. If a permission for the indicated principal doesn't exist, a label permission is created, otherwise the existing permission is update",
-    method: { id: "drivelabels.labels.revisions.permissions.batchUpdate", httpMethod: "POST", path: "v2/{+parent}/permissions:batchUpdate", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.revisions.permissions.batchUpdate", httpMethod: "POST", path: "v2/{+parent}/permissions:batchUpdate", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -262,7 +267,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_revisions_permissions_create",
     cud: "create",
     description: "Updates a label's permissions. If a permission for the indicated principal doesn't exist, a label permission is created, otherwise the existing permission is up",
-    method: { id: "drivelabels.labels.revisions.permissions.create", httpMethod: "POST", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.revisions.permissions.create", httpMethod: "POST", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -277,7 +282,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_revisions_permissions_delete",
     cud: "delete",
     description: "Deletes a label's permission. Permissions affect the label resource as a whole, aren't revisioned, and don't require publishing.",
-    method: { id: "drivelabels.labels.revisions.permissions.delete", httpMethod: "DELETE", path: "v2/{+name}", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "drivelabels.labels.revisions.permissions.delete", httpMethod: "DELETE", path: "v2/{+name}", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -291,7 +296,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_revisions_permissions_list",
     cud: "read",
     description: "Lists a label's permissions.",
-    method: { id: "drivelabels.labels.revisions.permissions.list", httpMethod: "GET", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.revisions.permissions.list", httpMethod: "GET", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[1] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -307,7 +312,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_revisions_update_permissions",
     cud: "update",
     description: "Updates a label's permissions. If a permission for the indicated principal doesn't exist, a label permission is created, otherwise the existing permission is up",
-    method: { id: "drivelabels.labels.revisions.updatePermissions", httpMethod: "PATCH", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.revisions.updatePermissions", httpMethod: "PATCH", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -322,7 +327,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_update_label_copy_mode",
     cud: "update",
     description: "Updates a label's `CopyMode`. Changes to this policy aren't revisioned, don't require publishing, and take effect immediately.",
-    method: { id: "drivelabels.labels.updateLabelCopyMode", httpMethod: "POST", path: "v2/{+name}:updateLabelCopyMode", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "drivelabels.labels.updateLabelCopyMode", httpMethod: "POST", path: "v2/{+name}:updateLabelCopyMode", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -350,7 +355,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_labels_update_permissions",
     cud: "update",
     description: "Updates a label's permissions. If a permission for the indicated principal doesn't exist, a label permission is created, otherwise the existing permission is up",
-    method: { id: "drivelabels.labels.updatePermissions", httpMethod: "PATCH", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "drivelabels.labels.updatePermissions", httpMethod: "PATCH", path: "v2/{+parent}/permissions", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["parent"], scopes: S_drivelabels_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"useAdminAccess","api":"useAdminAccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -365,7 +370,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_limits_get_label",
     cud: "read",
     description: "Get the constraints on the structure of a label; such as, the maximum number of fields allowed and maximum length of the label title.",
-    method: { id: "drivelabels.limits.getLabel", httpMethod: "GET", path: "v2/limits/label", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: [] },
+    method: { id: "drivelabels.limits.getLabel", httpMethod: "GET", path: "v2/limits/label", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: [], scopes: S_drivelabels_v2[1] },
     params: [{"field":"name","api":"name","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -378,7 +383,7 @@ export function registerDrivelabelsGeneratedTools(registry: ToolRegistry): void 
     name: "drivelabels_users_get_capabilities",
     cud: "read",
     description: "Gets the user capabilities.",
-    method: { id: "drivelabels.users.getCapabilities", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "drivelabels.users.getCapabilities", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://drivelabels.googleapis.com/", requiredParams: ["name"], scopes: S_drivelabels_v2[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"customer","api":"customer","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/forms.ts
+++ b/src/tools/generated/forms.ts
@@ -5,11 +5,15 @@ import { coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerFormsGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_forms_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.readonly","https://www.googleapis.com/auth/forms.body","https://www.googleapis.com/auth/forms.body.readonly","https://www.googleapis.com/auth/forms.responses.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "forms_forms_watches_create",
     cud: "create",
     description: "Create a new watch. If a watch ID is provided, it must be unused. For each invoking project, the per form limit is one watch per Watch.EventType. A watch expire",
-    method: { id: "forms.forms.watches.create", httpMethod: "POST", path: "v1/forms/{formId}/watches", baseUrl: "https://forms.googleapis.com/", requiredParams: ["formId"] },
+    method: { id: "forms.forms.watches.create", httpMethod: "POST", path: "v1/forms/{formId}/watches", baseUrl: "https://forms.googleapis.com/", requiredParams: ["formId"], scopes: S_forms_v1[0] },
     params: [{"field":"formId","api":"formId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -23,7 +27,7 @@ export function registerFormsGeneratedTools(registry: ToolRegistry): void {
     name: "forms_forms_watches_delete",
     cud: "delete",
     description: "Delete a watch.",
-    method: { id: "forms.forms.watches.delete", httpMethod: "DELETE", path: "v1/forms/{formId}/watches/{watchId}", baseUrl: "https://forms.googleapis.com/", requiredParams: ["formId","watchId"] },
+    method: { id: "forms.forms.watches.delete", httpMethod: "DELETE", path: "v1/forms/{formId}/watches/{watchId}", baseUrl: "https://forms.googleapis.com/", requiredParams: ["formId","watchId"], scopes: S_forms_v1[0] },
     params: [{"field":"formId","api":"formId","location":"path"},{"field":"watchId","api":"watchId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -37,7 +41,7 @@ export function registerFormsGeneratedTools(registry: ToolRegistry): void {
     name: "forms_forms_watches_renew",
     cud: "create",
     description: "Renew an existing watch for seven days. The state of the watch after renewal is `ACTIVE`, and the `expire_time` is seven days from the renewal. Renewing a watch",
-    method: { id: "forms.forms.watches.renew", httpMethod: "POST", path: "v1/forms/{formId}/watches/{watchId}:renew", baseUrl: "https://forms.googleapis.com/", requiredParams: ["formId","watchId"] },
+    method: { id: "forms.forms.watches.renew", httpMethod: "POST", path: "v1/forms/{formId}/watches/{watchId}:renew", baseUrl: "https://forms.googleapis.com/", requiredParams: ["formId","watchId"], scopes: S_forms_v1[0] },
     params: [{"field":"formId","api":"formId","location":"path"},{"field":"watchId","api":"watchId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/gmail.ts
+++ b/src/tools/generated/gmail.ts
@@ -5,11 +5,26 @@ import { coerceArray, coerceBoolean, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerGmailGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_gmail_v1: readonly (readonly string[])[] = [
+    ["https://mail.google.com/","https://www.googleapis.com/auth/gmail.addons.current.action.compose","https://www.googleapis.com/auth/gmail.compose","https://www.googleapis.com/auth/gmail.modify"],
+    ["https://mail.google.com/","https://www.googleapis.com/auth/gmail.labels","https://www.googleapis.com/auth/gmail.metadata","https://www.googleapis.com/auth/gmail.modify","https://www.googleapis.com/auth/gmail.readonly"],
+    ["https://mail.google.com/","https://www.googleapis.com/auth/gmail.labels","https://www.googleapis.com/auth/gmail.modify"],
+    ["https://mail.google.com/","https://www.googleapis.com/auth/gmail.insert","https://www.googleapis.com/auth/gmail.modify"],
+    ["https://mail.google.com/","https://www.googleapis.com/auth/gmail.modify"],
+    ["https://www.googleapis.com/auth/gmail.settings.basic","https://www.googleapis.com/auth/gmail.settings.sharing"],
+    ["https://mail.google.com/","https://www.googleapis.com/auth/gmail.modify","https://www.googleapis.com/auth/gmail.readonly","https://www.googleapis.com/auth/gmail.settings.basic","https://www.googleapis.com/auth/gmail.settings.sharing"],
+    ["https://www.googleapis.com/auth/gmail.settings.sharing"],
+    ["https://mail.google.com/","https://www.googleapis.com/auth/gmail.modify","https://www.googleapis.com/auth/gmail.readonly","https://www.googleapis.com/auth/gmail.settings.basic"],
+    ["https://www.googleapis.com/auth/gmail.settings.basic"],
+    ["https://mail.google.com/","https://www.googleapis.com/auth/gmail.metadata","https://www.googleapis.com/auth/gmail.modify","https://www.googleapis.com/auth/gmail.readonly"],
+    ["https://mail.google.com/"],
+  ];
   registerGeneratedTool(registry, {
     name: "gmail_users_drafts_delete",
     cud: "delete",
     description: "Immediately and permanently deletes the specified draft. Does not simply trash it. For more information, see [Create and send draft emails](https://developers.g",
-    method: { id: "gmail.users.drafts.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/drafts/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.drafts.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/drafts/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[0] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -23,7 +38,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_drafts_update",
     cud: "update",
     description: "Replaces a draft's content. For more information, see [Create and send draft emails](https://developers.google.com/workspace/gmail/api/guides/drafts).",
-    method: { id: "gmail.users.drafts.update", httpMethod: "PUT", path: "gmail/v1/users/{userId}/drafts/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.drafts.update", httpMethod: "PUT", path: "gmail/v1/users/{userId}/drafts/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[0] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -38,7 +53,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_labels_get",
     cud: "read",
     description: "Gets the specified label. For more information, see [Manage labels](https://developers.google.com/workspace/gmail/api/guides/labels).",
-    method: { id: "gmail.users.labels.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/labels/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.labels.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/labels/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[1] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -52,7 +67,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_labels_patch",
     cud: "update",
     description: "Patch the specified label. For more information, see [Manage labels](https://developers.google.com/workspace/gmail/api/guides/labels).",
-    method: { id: "gmail.users.labels.patch", httpMethod: "PATCH", path: "gmail/v1/users/{userId}/labels/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.labels.patch", httpMethod: "PATCH", path: "gmail/v1/users/{userId}/labels/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[2] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -67,7 +82,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_labels_update",
     cud: "update",
     description: "Updates the specified label. For more information, see [Manage labels](https://developers.google.com/workspace/gmail/api/guides/labels).",
-    method: { id: "gmail.users.labels.update", httpMethod: "PUT", path: "gmail/v1/users/{userId}/labels/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.labels.update", httpMethod: "PUT", path: "gmail/v1/users/{userId}/labels/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[2] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -82,7 +97,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_messages_import",
     cud: "create",
     description: "Imports a message into only this user's mailbox, with standard email delivery scanning and classification similar to receiving via SMTP. This method doesn't per",
-    method: { id: "gmail.users.messages.import", httpMethod: "POST", path: "gmail/v1/users/{userId}/messages/import", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.messages.import", httpMethod: "POST", path: "gmail/v1/users/{userId}/messages/import", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[3] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"deleted","api":"deleted","location":"query"},{"field":"internalDateSource","api":"internalDateSource","location":"query"},{"field":"neverMarkSpam","api":"neverMarkSpam","location":"query"},{"field":"processForCalendar","api":"processForCalendar","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -100,7 +115,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_messages_insert",
     cud: "create",
     description: "Directly inserts a message into only this user's mailbox similar to `IMAP APPEND`, bypassing most scanning and classification. Does not send a message. For more",
-    method: { id: "gmail.users.messages.insert", httpMethod: "POST", path: "gmail/v1/users/{userId}/messages", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.messages.insert", httpMethod: "POST", path: "gmail/v1/users/{userId}/messages", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[3] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"deleted","api":"deleted","location":"query"},{"field":"internalDateSource","api":"internalDateSource","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -116,7 +131,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_messages_untrash",
     cud: "update",
     description: "Removes the specified message from the trash.",
-    method: { id: "gmail.users.messages.untrash", httpMethod: "POST", path: "gmail/v1/users/{userId}/messages/{id}/untrash", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.messages.untrash", httpMethod: "POST", path: "gmail/v1/users/{userId}/messages/{id}/untrash", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[4] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -130,7 +145,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_identities_create",
     cud: "create",
     description: "Creates and configures a client-side encryption identity that's authorized to send mail from the user account. Google publishes the S/MIME certificate to a shar",
-    method: { id: "gmail.users.settings.cse.identities.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/cse/identities", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.cse.identities.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/cse/identities", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[5] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -144,7 +159,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_identities_delete",
     cud: "delete",
     description: "Deletes a client-side encryption identity. The authenticated user can no longer use the identity to send encrypted messages. You cannot restore the identity aft",
-    method: { id: "gmail.users.settings.cse.identities.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","cseEmailAddress"] },
+    method: { id: "gmail.users.settings.cse.identities.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","cseEmailAddress"], scopes: S_gmail_v1[5] },
     params: [{"field":"cseEmailAddress","api":"cseEmailAddress","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -158,7 +173,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_identities_get",
     cud: "read",
     description: "Retrieves a client-side encryption identity configuration. For administrators managing identities and keypairs for users in their organization, requests require",
-    method: { id: "gmail.users.settings.cse.identities.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","cseEmailAddress"] },
+    method: { id: "gmail.users.settings.cse.identities.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","cseEmailAddress"], scopes: S_gmail_v1[6] },
     params: [{"field":"cseEmailAddress","api":"cseEmailAddress","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -172,7 +187,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_identities_list",
     cud: "read",
     description: "Lists the client-side encrypted identities for an authenticated user. For administrators managing identities and keypairs for users in their organization, reque",
-    method: { id: "gmail.users.settings.cse.identities.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/cse/identities", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.cse.identities.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/cse/identities", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[6] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -187,7 +202,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_identities_patch",
     cud: "update",
     description: "Associates a different key pair with an existing client-side encryption identity. The updated key pair must validate against Google's [S/MIME certificate profil",
-    method: { id: "gmail.users.settings.cse.identities.patch", httpMethod: "PATCH", path: "gmail/v1/users/{userId}/settings/cse/identities/{emailAddress}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","emailAddress"] },
+    method: { id: "gmail.users.settings.cse.identities.patch", httpMethod: "PATCH", path: "gmail/v1/users/{userId}/settings/cse/identities/{emailAddress}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","emailAddress"], scopes: S_gmail_v1[5] },
     params: [{"field":"emailAddress","api":"emailAddress","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -202,7 +217,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_keypairs_create",
     cud: "create",
     description: "Creates and uploads a client-side encryption S/MIME public key certificate chain and private key metadata for the authenticated user. For administrators managin",
-    method: { id: "gmail.users.settings.cse.keypairs.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/cse/keypairs", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.cse.keypairs.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/cse/keypairs", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[5] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"chainValidation","api":"chainValidation","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -217,7 +232,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_keypairs_disable",
     cud: "create",
     description: "Turns off a client-side encryption key pair. The authenticated user can no longer use the key pair to decrypt incoming CSE message texts or sign outgoing CSE ma",
-    method: { id: "gmail.users.settings.cse.keypairs.disable", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:disable", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","keyPairId"] },
+    method: { id: "gmail.users.settings.cse.keypairs.disable", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:disable", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","keyPairId"], scopes: S_gmail_v1[5] },
     params: [{"field":"keyPairId","api":"keyPairId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -232,7 +247,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_keypairs_enable",
     cud: "create",
     description: "Turns on a client-side encryption key pair that was turned off. The key pair becomes active again for any associated client-side encryption identities. For admi",
-    method: { id: "gmail.users.settings.cse.keypairs.enable", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:enable", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","keyPairId"] },
+    method: { id: "gmail.users.settings.cse.keypairs.enable", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:enable", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","keyPairId"], scopes: S_gmail_v1[5] },
     params: [{"field":"keyPairId","api":"keyPairId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -247,7 +262,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_keypairs_get",
     cud: "read",
     description: "Retrieves an existing client-side encryption key pair. For administrators managing identities and keypairs for users in their organization, requests require aut",
-    method: { id: "gmail.users.settings.cse.keypairs.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","keyPairId"] },
+    method: { id: "gmail.users.settings.cse.keypairs.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","keyPairId"], scopes: S_gmail_v1[6] },
     params: [{"field":"keyPairId","api":"keyPairId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -261,7 +276,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_keypairs_list",
     cud: "read",
     description: "Lists client-side encryption key pairs for an authenticated user. For administrators managing identities and keypairs for users in their organization, requests",
-    method: { id: "gmail.users.settings.cse.keypairs.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/cse/keypairs", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.cse.keypairs.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/cse/keypairs", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[6] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -276,7 +291,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_cse_keypairs_obliterate",
     cud: "delete",
     description: "Deletes a client-side encryption key pair permanently and immediately. You can only permanently delete key pairs that have been turned off for more than 30 days",
-    method: { id: "gmail.users.settings.cse.keypairs.obliterate", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:obliterate", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","keyPairId"] },
+    method: { id: "gmail.users.settings.cse.keypairs.obliterate", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:obliterate", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","keyPairId"], scopes: S_gmail_v1[5] },
     params: [{"field":"keyPairId","api":"keyPairId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -291,7 +306,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_delegates_create",
     cud: "create",
     description: "Adds a delegate with its verification status set directly to `accepted`, without sending any verification email. The delegate user must be a member of the same",
-    method: { id: "gmail.users.settings.delegates.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/delegates", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.delegates.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/delegates", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[7] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -305,7 +320,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_delegates_delete",
     cud: "delete",
     description: "Removes the specified delegate (which can be of any verification status), and revokes any verification that may have been required for using it. For more inform",
-    method: { id: "gmail.users.settings.delegates.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/delegates/{delegateEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","delegateEmail"] },
+    method: { id: "gmail.users.settings.delegates.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/delegates/{delegateEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","delegateEmail"], scopes: S_gmail_v1[7] },
     params: [{"field":"delegateEmail","api":"delegateEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -319,7 +334,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_delegates_get",
     cud: "read",
     description: "Gets the specified delegate. For more information, see [Manage delegates](https://developers.google.com/workspace/gmail/api/guides/delegate_settings). A delegat",
-    method: { id: "gmail.users.settings.delegates.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/delegates/{delegateEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","delegateEmail"] },
+    method: { id: "gmail.users.settings.delegates.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/delegates/{delegateEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","delegateEmail"], scopes: S_gmail_v1[8] },
     params: [{"field":"delegateEmail","api":"delegateEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -333,7 +348,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_delegates_list",
     cud: "read",
     description: "Lists the delegates for the specified account. For more information, see [Manage delegates](https://developers.google.com/workspace/gmail/api/guides/delegate_se",
-    method: { id: "gmail.users.settings.delegates.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/delegates", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.delegates.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/delegates", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[8] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -346,7 +361,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_filters_create",
     cud: "create",
     description: "Creates a filter. Note: you can only create a maximum of 1,000 filters. For more information, see [Manage Gmail filters](https://developers.google.com/workspace",
-    method: { id: "gmail.users.settings.filters.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/filters", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.filters.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/filters", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[9] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -360,7 +375,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_filters_delete",
     cud: "delete",
     description: "Immediately and permanently deletes the specified filter. For more information, see [Manage Gmail filters](https://developers.google.com/workspace/gmail/api/gui",
-    method: { id: "gmail.users.settings.filters.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/filters/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.settings.filters.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/filters/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[9] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -374,7 +389,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_filters_get",
     cud: "read",
     description: "Gets a filter. For more information, see [Manage Gmail filters](https://developers.google.com/workspace/gmail/api/guides/filter_settings).",
-    method: { id: "gmail.users.settings.filters.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/filters/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.settings.filters.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/filters/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[8] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -388,7 +403,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_filters_list",
     cud: "read",
     description: "Lists the message filters of a Gmail user. For more information, see [Manage Gmail filters](https://developers.google.com/workspace/gmail/api/guides/filter_sett",
-    method: { id: "gmail.users.settings.filters.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/filters", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.filters.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/filters", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[8] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -401,7 +416,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_forwarding_addresses_create",
     cud: "create",
     description: "Creates a forwarding address. If ownership verification is required, a message will be sent to the recipient and the resource's verification status will be set",
-    method: { id: "gmail.users.settings.forwardingAddresses.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/forwardingAddresses", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.forwardingAddresses.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/forwardingAddresses", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[7] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -415,7 +430,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_forwarding_addresses_delete",
     cud: "delete",
     description: "Deletes the specified forwarding address and revokes any verification that may have been required. For more information, see [Manage email forwarding](https://d",
-    method: { id: "gmail.users.settings.forwardingAddresses.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","forwardingEmail"] },
+    method: { id: "gmail.users.settings.forwardingAddresses.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","forwardingEmail"], scopes: S_gmail_v1[7] },
     params: [{"field":"forwardingEmail","api":"forwardingEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -429,7 +444,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_forwarding_addresses_get",
     cud: "read",
     description: "Gets the specified forwarding address. For more information, see [Manage email forwarding](https://developers.google.com/workspace/gmail/api/guides/forwarding_s",
-    method: { id: "gmail.users.settings.forwardingAddresses.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","forwardingEmail"] },
+    method: { id: "gmail.users.settings.forwardingAddresses.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","forwardingEmail"], scopes: S_gmail_v1[8] },
     params: [{"field":"forwardingEmail","api":"forwardingEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -443,7 +458,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_forwarding_addresses_list",
     cud: "read",
     description: "Lists the forwarding addresses for the specified account. For more information, see [Manage email forwarding](https://developers.google.com/workspace/gmail/api/",
-    method: { id: "gmail.users.settings.forwardingAddresses.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/forwardingAddresses", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.forwardingAddresses.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/forwardingAddresses", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[8] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -456,7 +471,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_get_auto_forwarding",
     cud: "read",
     description: "Gets the auto-forwarding setting for the specified account. For more information, see [Manage email forwarding](https://developers.google.com/workspace/gmail/ap",
-    method: { id: "gmail.users.settings.getAutoForwarding", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/autoForwarding", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.getAutoForwarding", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/autoForwarding", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[8] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -469,7 +484,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_get_imap",
     cud: "read",
     description: "Gets IMAP settings. For more information, see [Configure POP and IMAP settings with the Gmail API](https://developers.google.com/workspace/gmail/api/guides/pop_",
-    method: { id: "gmail.users.settings.getImap", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/imap", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.getImap", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/imap", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[8] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -482,7 +497,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_get_language",
     cud: "read",
     description: "Gets language settings. For more information, see [Manage language settings](https://developers.google.com/workspace/gmail/api/guides/language-settings).",
-    method: { id: "gmail.users.settings.getLanguage", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/language", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.getLanguage", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/language", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[8] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -495,7 +510,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_get_pop",
     cud: "read",
     description: "Gets POP settings. For more information, see [Configure POP and IMAP settings with the Gmail API](https://developers.google.com/workspace/gmail/api/guides/pop_i",
-    method: { id: "gmail.users.settings.getPop", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/pop", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.getPop", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/pop", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[8] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -508,7 +523,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_create",
     cud: "create",
     description: "Creates a custom \"from\" send-as alias. If an SMTP MSA is specified, Gmail will attempt to connect to the SMTP service to validate the configuration before creat",
-    method: { id: "gmail.users.settings.sendAs.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/sendAs", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.sendAs.create", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/sendAs", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[7] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -522,7 +537,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_delete",
     cud: "delete",
     description: "Deletes the specified send-as alias. Revokes any verification that may have been required for using it. For more information, see [Manage aliases and signatures",
-    method: { id: "gmail.users.settings.sendAs.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"] },
+    method: { id: "gmail.users.settings.sendAs.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"], scopes: S_gmail_v1[7] },
     params: [{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -536,7 +551,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_get",
     cud: "read",
     description: "Gets the specified send-as alias. Fails with an HTTP 404 error if the specified address is not a member of the collection. For more information, see [Manage ali",
-    method: { id: "gmail.users.settings.sendAs.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"] },
+    method: { id: "gmail.users.settings.sendAs.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"], scopes: S_gmail_v1[8] },
     params: [{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -550,7 +565,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_list",
     cud: "read",
     description: "Lists the send-as aliases for the specified account. The result includes the primary send-as address associated with the account as well as any custom \"from\" al",
-    method: { id: "gmail.users.settings.sendAs.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/sendAs", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.sendAs.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/sendAs", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[8] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -563,7 +578,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_patch",
     cud: "update",
     description: "Patch the specified send-as alias. For more information, see [Manage aliases and signatures with the Gmail API](https://developers.google.com/workspace/gmail/ap",
-    method: { id: "gmail.users.settings.sendAs.patch", httpMethod: "PATCH", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"] },
+    method: { id: "gmail.users.settings.sendAs.patch", httpMethod: "PATCH", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"], scopes: S_gmail_v1[5] },
     params: [{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -578,7 +593,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_smime_info_delete",
     cud: "delete",
     description: "Deletes the specified S/MIME config for the specified send-as alias. For more information, see [Manage S/MIME certificates with the Gmail API](https://developer",
-    method: { id: "gmail.users.settings.sendAs.smimeInfo.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail","id"] },
+    method: { id: "gmail.users.settings.sendAs.smimeInfo.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail","id"], scopes: S_gmail_v1[5] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -593,7 +608,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_smime_info_get",
     cud: "read",
     description: "Gets the specified S/MIME config for the specified send-as alias. For more information, see [Manage S/MIME certificates with the Gmail API](https://developers.g",
-    method: { id: "gmail.users.settings.sendAs.smimeInfo.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail","id"] },
+    method: { id: "gmail.users.settings.sendAs.smimeInfo.get", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail","id"], scopes: S_gmail_v1[6] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -608,7 +623,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_smime_info_insert",
     cud: "create",
     description: "Insert (upload) the given S/MIME config for the specified send-as alias. Note that `pkcs12` format is required for the key. For more information, see [Manage S/",
-    method: { id: "gmail.users.settings.sendAs.smimeInfo.insert", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"] },
+    method: { id: "gmail.users.settings.sendAs.smimeInfo.insert", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"], scopes: S_gmail_v1[5] },
     params: [{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -623,7 +638,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_smime_info_list",
     cud: "read",
     description: "Lists S/MIME configs for the specified send-as alias. For more information, see [Manage S/MIME certificates with the Gmail API](https://developers.google.com/wo",
-    method: { id: "gmail.users.settings.sendAs.smimeInfo.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"] },
+    method: { id: "gmail.users.settings.sendAs.smimeInfo.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"], scopes: S_gmail_v1[6] },
     params: [{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -637,7 +652,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_smime_info_set_default",
     cud: "update",
     description: "Sets the default S/MIME config for the specified send-as alias. For more information, see [Manage S/MIME certificates with the Gmail API](https://developers.goo",
-    method: { id: "gmail.users.settings.sendAs.smimeInfo.setDefault", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}/setDefault", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail","id"] },
+    method: { id: "gmail.users.settings.sendAs.smimeInfo.setDefault", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}/setDefault", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail","id"], scopes: S_gmail_v1[5] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -652,7 +667,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_update",
     cud: "update",
     description: "Updates a send-as alias. If a signature is provided, Gmail will sanitize the HTML before saving it with the alias. For more information, see [Manage aliases and",
-    method: { id: "gmail.users.settings.sendAs.update", httpMethod: "PUT", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"] },
+    method: { id: "gmail.users.settings.sendAs.update", httpMethod: "PUT", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"], scopes: S_gmail_v1[5] },
     params: [{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -667,7 +682,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_send_as_verify",
     cud: "create",
     description: "Sends a verification email to the specified send-as alias address. The verification status must be `pending`. For more information, see [Manage aliases and sign",
-    method: { id: "gmail.users.settings.sendAs.verify", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/verify", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"] },
+    method: { id: "gmail.users.settings.sendAs.verify", httpMethod: "POST", path: "gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/verify", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","sendAsEmail"], scopes: S_gmail_v1[7] },
     params: [{"field":"sendAsEmail","api":"sendAsEmail","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -681,7 +696,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_update_auto_forwarding",
     cud: "update",
     description: "Updates the auto-forwarding setting for the specified account. A verified forwarding address must be specified when auto-forwarding is enabled. For more informa",
-    method: { id: "gmail.users.settings.updateAutoForwarding", httpMethod: "PUT", path: "gmail/v1/users/{userId}/settings/autoForwarding", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.updateAutoForwarding", httpMethod: "PUT", path: "gmail/v1/users/{userId}/settings/autoForwarding", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[7] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -695,7 +710,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_update_imap",
     cud: "update",
     description: "Updates IMAP settings. For more information, see [Configure POP and IMAP settings with the Gmail API](https://developers.google.com/workspace/gmail/api/guides/p",
-    method: { id: "gmail.users.settings.updateImap", httpMethod: "PUT", path: "gmail/v1/users/{userId}/settings/imap", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.updateImap", httpMethod: "PUT", path: "gmail/v1/users/{userId}/settings/imap", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[9] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -709,7 +724,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_update_language",
     cud: "update",
     description: "Updates language settings. For more information, see [Manage language settings](https://developers.google.com/workspace/gmail/api/guides/language-settings). If",
-    method: { id: "gmail.users.settings.updateLanguage", httpMethod: "PUT", path: "gmail/v1/users/{userId}/settings/language", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.updateLanguage", httpMethod: "PUT", path: "gmail/v1/users/{userId}/settings/language", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[9] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -723,7 +738,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_settings_update_pop",
     cud: "update",
     description: "Updates POP settings. For more information, see [Configure POP and IMAP settings with the Gmail API](https://developers.google.com/workspace/gmail/api/guides/po",
-    method: { id: "gmail.users.settings.updatePop", httpMethod: "PUT", path: "gmail/v1/users/{userId}/settings/pop", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.settings.updatePop", httpMethod: "PUT", path: "gmail/v1/users/{userId}/settings/pop", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[9] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -737,7 +752,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_stop",
     cud: "create",
     description: "Turn off push notification delivery for the given user mailbox. For more information, see [Configure push notifications in Gmail API](https://developers.google.",
-    method: { id: "gmail.users.stop", httpMethod: "POST", path: "gmail/v1/users/{userId}/stop", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.stop", httpMethod: "POST", path: "gmail/v1/users/{userId}/stop", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[10] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -750,7 +765,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_threads_delete",
     cud: "delete",
     description: "Immediately and permanently deletes the specified thread. Any messages that belong to the thread are also deleted. This operation cannot be undone. Prefer `thre",
-    method: { id: "gmail.users.threads.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/threads/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.threads.delete", httpMethod: "DELETE", path: "gmail/v1/users/{userId}/threads/{id}", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[11] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -764,7 +779,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_threads_list",
     cud: "read",
     description: "Lists the threads in the user's mailbox. For more information, see [Manage threads](https://developers.google.com/workspace/gmail/api/guides/threads).",
-    method: { id: "gmail.users.threads.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/threads", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.threads.list", httpMethod: "GET", path: "gmail/v1/users/{userId}/threads", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[10] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"includeSpamTrash","api":"includeSpamTrash","location":"query"},{"field":"labelIds","api":"labelIds","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"q","api":"q","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -782,7 +797,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_threads_modify",
     cud: "update",
     description: "Modifies the labels applied to the thread. This applies to all messages in the thread. For more information, see [Manage threads](https://developers.google.com/",
-    method: { id: "gmail.users.threads.modify", httpMethod: "POST", path: "gmail/v1/users/{userId}/threads/{id}/modify", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.threads.modify", httpMethod: "POST", path: "gmail/v1/users/{userId}/threads/{id}/modify", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[4] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -797,7 +812,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_threads_trash",
     cud: "delete",
     description: "Moves the specified thread to the trash. Any messages that belong to the thread are also moved to the trash. For more information, see [Manage threads](https://",
-    method: { id: "gmail.users.threads.trash", httpMethod: "POST", path: "gmail/v1/users/{userId}/threads/{id}/trash", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.threads.trash", httpMethod: "POST", path: "gmail/v1/users/{userId}/threads/{id}/trash", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[4] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -811,7 +826,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_threads_untrash",
     cud: "update",
     description: "Removes the specified thread from the trash. Any messages that belong to the thread are also removed from the trash. For more information, see [Manage threads](",
-    method: { id: "gmail.users.threads.untrash", httpMethod: "POST", path: "gmail/v1/users/{userId}/threads/{id}/untrash", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"] },
+    method: { id: "gmail.users.threads.untrash", httpMethod: "POST", path: "gmail/v1/users/{userId}/threads/{id}/untrash", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId","id"], scopes: S_gmail_v1[4] },
     params: [{"field":"id","api":"id","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -825,7 +840,7 @@ export function registerGmailGeneratedTools(registry: ToolRegistry): void {
     name: "gmail_users_watch",
     cud: "create",
     description: "Set up or update a push notification watch on the given user mailbox. For more information, see [Configure push notifications in Gmail API](https://developers.g",
-    method: { id: "gmail.users.watch", httpMethod: "POST", path: "gmail/v1/users/{userId}/watch", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"] },
+    method: { id: "gmail.users.watch", httpMethod: "POST", path: "gmail/v1/users/{userId}/watch", baseUrl: "https://gmail.googleapis.com/", requiredParams: ["userId"], scopes: S_gmail_v1[10] },
     params: [{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/groupsmigration.ts
+++ b/src/tools/generated/groupsmigration.ts
@@ -4,11 +4,15 @@ import type { ToolRegistry } from '../../registry.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerGroupsmigrationGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_groupsmigration_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/apps.groups.migration"],
+  ];
   registerGeneratedTool(registry, {
     name: "groupsmigration_archive_insert",
     cud: "create",
     description: "Inserts a new mail into the archive of the Google group.",
-    method: { id: "groupsmigration.archive.insert", httpMethod: "POST", path: "groups/v1/groups/{groupId}/archive", baseUrl: "https://groupsmigration.googleapis.com/", requiredParams: ["groupId"] },
+    method: { id: "groupsmigration.archive.insert", httpMethod: "POST", path: "groups/v1/groups/{groupId}/archive", baseUrl: "https://groupsmigration.googleapis.com/", requiredParams: ["groupId"], scopes: S_groupsmigration_v1[0] },
     params: [{"field":"groupId","api":"groupId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/groupssettings.ts
+++ b/src/tools/generated/groupssettings.ts
@@ -5,11 +5,15 @@ import { coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerGroupssettingsGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_groupssettings_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/apps.groups.settings"],
+  ];
   registerGeneratedTool(registry, {
     name: "groupssettings_groups_get",
     cud: "read",
     description: "Gets one resource by id.",
-    method: { id: "groupsSettings.groups.get", httpMethod: "GET", path: "{groupUniqueId}", baseUrl: "https://www.googleapis.com/groups/v1/groups/", requiredParams: ["groupUniqueId"] },
+    method: { id: "groupsSettings.groups.get", httpMethod: "GET", path: "{groupUniqueId}", baseUrl: "https://www.googleapis.com/groups/v1/groups/", requiredParams: ["groupUniqueId"], scopes: S_groupssettings_v1[0] },
     params: [{"field":"groupUniqueId","api":"groupUniqueId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -22,7 +26,7 @@ export function registerGroupssettingsGeneratedTools(registry: ToolRegistry): vo
     name: "groupssettings_groups_patch",
     cud: "update",
     description: "Updates an existing resource. This method supports patch semantics.",
-    method: { id: "groupsSettings.groups.patch", httpMethod: "PATCH", path: "{groupUniqueId}", baseUrl: "https://www.googleapis.com/groups/v1/groups/", requiredParams: ["groupUniqueId"] },
+    method: { id: "groupsSettings.groups.patch", httpMethod: "PATCH", path: "{groupUniqueId}", baseUrl: "https://www.googleapis.com/groups/v1/groups/", requiredParams: ["groupUniqueId"], scopes: S_groupssettings_v1[0] },
     params: [{"field":"groupUniqueId","api":"groupUniqueId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -36,7 +40,7 @@ export function registerGroupssettingsGeneratedTools(registry: ToolRegistry): vo
     name: "groupssettings_groups_update",
     cud: "update",
     description: "Updates an existing resource.",
-    method: { id: "groupsSettings.groups.update", httpMethod: "PUT", path: "{groupUniqueId}", baseUrl: "https://www.googleapis.com/groups/v1/groups/", requiredParams: ["groupUniqueId"] },
+    method: { id: "groupsSettings.groups.update", httpMethod: "PUT", path: "{groupUniqueId}", baseUrl: "https://www.googleapis.com/groups/v1/groups/", requiredParams: ["groupUniqueId"], scopes: S_groupssettings_v1[0] },
     params: [{"field":"groupUniqueId","api":"groupUniqueId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/keep.ts
+++ b/src/tools/generated/keep.ts
@@ -5,11 +5,16 @@ import { coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerKeepGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_keep_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/keep","https://www.googleapis.com/auth/keep.readonly"],
+    ["https://www.googleapis.com/auth/keep"],
+  ];
   registerGeneratedTool(registry, {
     name: "keep_media_download",
     cud: "read",
     description: "Gets an attachment. To download attachment media via REST requires the alt=media query parameter. Returns a 400 bad request error if attachment media is not ava",
-    method: { id: "keep.media.download", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://keep.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "keep.media.download", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://keep.googleapis.com/", requiredParams: ["name"], scopes: S_keep_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"mimeType","api":"mimeType","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -23,7 +28,7 @@ export function registerKeepGeneratedTools(registry: ToolRegistry): void {
     name: "keep_notes_create",
     cud: "create",
     description: "Creates a new note.",
-    method: { id: "keep.notes.create", httpMethod: "POST", path: "v1/notes", baseUrl: "https://keep.googleapis.com/", requiredParams: [] },
+    method: { id: "keep.notes.create", httpMethod: "POST", path: "v1/notes", baseUrl: "https://keep.googleapis.com/", requiredParams: [], scopes: S_keep_v1[1] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -36,7 +41,7 @@ export function registerKeepGeneratedTools(registry: ToolRegistry): void {
     name: "keep_notes_delete",
     cud: "delete",
     description: "Deletes a note. Caller must have the `OWNER` role on the note to delete. Deleting a note removes the resource immediately and cannot be undone. Any collaborator",
-    method: { id: "keep.notes.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://keep.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "keep.notes.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://keep.googleapis.com/", requiredParams: ["name"], scopes: S_keep_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -49,7 +54,7 @@ export function registerKeepGeneratedTools(registry: ToolRegistry): void {
     name: "keep_notes_get",
     cud: "read",
     description: "Gets a note.",
-    method: { id: "keep.notes.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://keep.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "keep.notes.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://keep.googleapis.com/", requiredParams: ["name"], scopes: S_keep_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -62,7 +67,7 @@ export function registerKeepGeneratedTools(registry: ToolRegistry): void {
     name: "keep_notes_list",
     cud: "read",
     description: "Lists notes. Every list call returns a page of results with `page_size` as the upper bound of returned items. A `page_size` of zero allows the server to choose",
-    method: { id: "keep.notes.list", httpMethod: "GET", path: "v1/notes", baseUrl: "https://keep.googleapis.com/", requiredParams: [] },
+    method: { id: "keep.notes.list", httpMethod: "GET", path: "v1/notes", baseUrl: "https://keep.googleapis.com/", requiredParams: [], scopes: S_keep_v1[0] },
     params: [{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -77,7 +82,7 @@ export function registerKeepGeneratedTools(registry: ToolRegistry): void {
     name: "keep_notes_permissions_batch_create",
     cud: "create",
     description: "Creates one or more permissions on the note. Only permissions with the `WRITER` role may be created. If adding any permission fails, then the entire request fai",
-    method: { id: "keep.notes.permissions.batchCreate", httpMethod: "POST", path: "v1/{+parent}/permissions:batchCreate", baseUrl: "https://keep.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "keep.notes.permissions.batchCreate", httpMethod: "POST", path: "v1/{+parent}/permissions:batchCreate", baseUrl: "https://keep.googleapis.com/", requiredParams: ["parent"], scopes: S_keep_v1[1] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -91,7 +96,7 @@ export function registerKeepGeneratedTools(registry: ToolRegistry): void {
     name: "keep_notes_permissions_batch_delete",
     cud: "delete",
     description: "Deletes one or more permissions on the note. The specified entities will immediately lose access. A permission with the `OWNER` role can't be removed. If removi",
-    method: { id: "keep.notes.permissions.batchDelete", httpMethod: "POST", path: "v1/{+parent}/permissions:batchDelete", baseUrl: "https://keep.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "keep.notes.permissions.batchDelete", httpMethod: "POST", path: "v1/{+parent}/permissions:batchDelete", baseUrl: "https://keep.googleapis.com/", requiredParams: ["parent"], scopes: S_keep_v1[1] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/licensing.ts
+++ b/src/tools/generated/licensing.ts
@@ -5,11 +5,15 @@ import { coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_licensing_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/apps.licensing"],
+  ];
   registerGeneratedTool(registry, {
     name: "licensing_license_assignments_delete",
     cud: "delete",
     description: "Revoke a license.",
-    method: { id: "licensing.licenseAssignments.delete", httpMethod: "DELETE", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"] },
+    method: { id: "licensing.licenseAssignments.delete", httpMethod: "DELETE", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"], scopes: S_licensing_v1[0] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"skuId","api":"skuId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -24,7 +28,7 @@ export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
     name: "licensing_license_assignments_get",
     cud: "read",
     description: "Get a specific user's license by product SKU.",
-    method: { id: "licensing.licenseAssignments.get", httpMethod: "GET", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"] },
+    method: { id: "licensing.licenseAssignments.get", httpMethod: "GET", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"], scopes: S_licensing_v1[0] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"skuId","api":"skuId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -39,7 +43,7 @@ export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
     name: "licensing_license_assignments_insert",
     cud: "create",
     description: "Assign a license.",
-    method: { id: "licensing.licenseAssignments.insert", httpMethod: "POST", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId"] },
+    method: { id: "licensing.licenseAssignments.insert", httpMethod: "POST", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId"], scopes: S_licensing_v1[0] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"skuId","api":"skuId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -54,7 +58,7 @@ export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
     name: "licensing_license_assignments_list_for_product",
     cud: "read",
     description: "List all users assigned licenses for a specific product SKU.",
-    method: { id: "licensing.licenseAssignments.listForProduct", httpMethod: "GET", path: "apps/licensing/v1/product/{productId}/users", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","customerId"] },
+    method: { id: "licensing.licenseAssignments.listForProduct", httpMethod: "GET", path: "apps/licensing/v1/product/{productId}/users", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","customerId"], scopes: S_licensing_v1[0] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"customerId","api":"customerId","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -70,7 +74,7 @@ export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
     name: "licensing_license_assignments_list_for_product_and_sku",
     cud: "read",
     description: "List all users assigned licenses for a specific product SKU.",
-    method: { id: "licensing.licenseAssignments.listForProductAndSku", httpMethod: "GET", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/users", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","customerId"] },
+    method: { id: "licensing.licenseAssignments.listForProductAndSku", httpMethod: "GET", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/users", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","customerId"], scopes: S_licensing_v1[0] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"skuId","api":"skuId","location":"path"},{"field":"customerId","api":"customerId","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -87,7 +91,7 @@ export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
     name: "licensing_license_assignments_patch",
     cud: "update",
     description: "Reassign a user's product SKU with a different SKU in the same product. This method supports patch semantics.",
-    method: { id: "licensing.licenseAssignments.patch", httpMethod: "PATCH", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"] },
+    method: { id: "licensing.licenseAssignments.patch", httpMethod: "PATCH", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"], scopes: S_licensing_v1[0] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"skuId","api":"skuId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -103,7 +107,7 @@ export function registerLicensingGeneratedTools(registry: ToolRegistry): void {
     name: "licensing_license_assignments_update",
     cud: "update",
     description: "Reassign a user's product SKU with a different SKU in the same product.",
-    method: { id: "licensing.licenseAssignments.update", httpMethod: "PUT", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"] },
+    method: { id: "licensing.licenseAssignments.update", httpMethod: "PUT", path: "apps/licensing/v1/product/{productId}/sku/{skuId}/user/{userId}", baseUrl: "https://licensing.googleapis.com/", requiredParams: ["productId","skuId","userId"], scopes: S_licensing_v1[0] },
     params: [{"field":"productId","api":"productId","location":"path"},{"field":"skuId","api":"skuId","location":"path"},{"field":"userId","api":"userId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/meet.ts
+++ b/src/tools/generated/meet.ts
@@ -5,11 +5,18 @@ import { coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerMeetGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_meet_v2: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/meetings.space.created","https://www.googleapis.com/auth/meetings.space.readonly"],
+    ["https://www.googleapis.com/auth/meetings.space.created"],
+    ["https://www.googleapis.com/auth/meetings.space.created","https://www.googleapis.com/auth/meetings.space.readonly","https://www.googleapis.com/auth/meetings.space.settings"],
+    ["https://www.googleapis.com/auth/meetings.space.created","https://www.googleapis.com/auth/meetings.space.settings"],
+  ];
   registerGeneratedTool(registry, {
     name: "meet_conference_records_participants_get",
     cud: "read",
     description: "Gets a participant by participant ID.",
-    method: { id: "meet.conferenceRecords.participants.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "meet.conferenceRecords.participants.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"], scopes: S_meet_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -22,7 +29,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_conference_records_participants_list",
     cud: "read",
     description: "Lists the participants in a conference record. By default, ordered by join time and in descending order. This API supports `fields` as standard parameters like",
-    method: { id: "meet.conferenceRecords.participants.list", httpMethod: "GET", path: "v2/{+parent}/participants", baseUrl: "https://meet.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "meet.conferenceRecords.participants.list", httpMethod: "GET", path: "v2/{+parent}/participants", baseUrl: "https://meet.googleapis.com/", requiredParams: ["parent"], scopes: S_meet_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -38,7 +45,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_conference_records_participants_participant_sessions_get",
     cud: "read",
     description: "Gets a participant session by participant session ID.",
-    method: { id: "meet.conferenceRecords.participants.participantSessions.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "meet.conferenceRecords.participants.participantSessions.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"], scopes: S_meet_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -51,7 +58,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_conference_records_participants_participant_sessions_list",
     cud: "read",
     description: "Lists the participant sessions of a participant in a conference record. By default, ordered by join time and in descending order. This API supports `fields` as",
-    method: { id: "meet.conferenceRecords.participants.participantSessions.list", httpMethod: "GET", path: "v2/{+parent}/participantSessions", baseUrl: "https://meet.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "meet.conferenceRecords.participants.participantSessions.list", httpMethod: "GET", path: "v2/{+parent}/participantSessions", baseUrl: "https://meet.googleapis.com/", requiredParams: ["parent"], scopes: S_meet_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -67,7 +74,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_conference_records_recordings_get",
     cud: "read",
     description: "Gets a recording by recording ID.",
-    method: { id: "meet.conferenceRecords.recordings.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "meet.conferenceRecords.recordings.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"], scopes: S_meet_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -80,7 +87,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_conference_records_smart_notes_get",
     cud: "read",
     description: "Gets smart notes by smart note ID.",
-    method: { id: "meet.conferenceRecords.smartNotes.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "meet.conferenceRecords.smartNotes.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"], scopes: S_meet_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -93,7 +100,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_conference_records_smart_notes_list",
     cud: "read",
     description: "Lists the set of smart notes from the conference record. By default, ordered by start time and in ascending order.",
-    method: { id: "meet.conferenceRecords.smartNotes.list", httpMethod: "GET", path: "v2/{+parent}/smartNotes", baseUrl: "https://meet.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "meet.conferenceRecords.smartNotes.list", httpMethod: "GET", path: "v2/{+parent}/smartNotes", baseUrl: "https://meet.googleapis.com/", requiredParams: ["parent"], scopes: S_meet_v2[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -108,7 +115,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_conference_records_transcripts_entries_get",
     cud: "read",
     description: "Gets a `TranscriptEntry` resource by entry ID. Note: The transcript entries returned by the Google Meet API might not match the transcription found in the Googl",
-    method: { id: "meet.conferenceRecords.transcripts.entries.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "meet.conferenceRecords.transcripts.entries.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"], scopes: S_meet_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -121,7 +128,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_conference_records_transcripts_get",
     cud: "read",
     description: "Gets a transcript by transcript ID.",
-    method: { id: "meet.conferenceRecords.transcripts.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "meet.conferenceRecords.transcripts.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"], scopes: S_meet_v2[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -134,7 +141,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_spaces_create",
     cud: "create",
     description: "Creates a space.",
-    method: { id: "meet.spaces.create", httpMethod: "POST", path: "v2/spaces", baseUrl: "https://meet.googleapis.com/", requiredParams: [] },
+    method: { id: "meet.spaces.create", httpMethod: "POST", path: "v2/spaces", baseUrl: "https://meet.googleapis.com/", requiredParams: [], scopes: S_meet_v2[1] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -147,7 +154,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_spaces_end_active_conference",
     cud: "create",
     description: "Ends an active conference (if there's one). For an example, see [End active conference](https://developers.google.com/workspace/meet/api/guides/meeting-spaces#e",
-    method: { id: "meet.spaces.endActiveConference", httpMethod: "POST", path: "v2/{+name}:endActiveConference", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "meet.spaces.endActiveConference", httpMethod: "POST", path: "v2/{+name}:endActiveConference", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"], scopes: S_meet_v2[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -161,7 +168,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_spaces_get",
     cud: "read",
     description: "Gets details about a meeting space. For an example, see [Get a meeting space](https://developers.google.com/workspace/meet/api/guides/meeting-spaces#get-meeting",
-    method: { id: "meet.spaces.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "meet.spaces.get", httpMethod: "GET", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"], scopes: S_meet_v2[2] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -174,7 +181,7 @@ export function registerMeetGeneratedTools(registry: ToolRegistry): void {
     name: "meet_spaces_patch",
     cud: "update",
     description: "Updates details about a meeting space. For an example, see [Update a meeting space](https://developers.google.com/workspace/meet/api/guides/meeting-spaces#updat",
-    method: { id: "meet.spaces.patch", httpMethod: "PATCH", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "meet.spaces.patch", httpMethod: "PATCH", path: "v2/{+name}", baseUrl: "https://meet.googleapis.com/", requiredParams: ["name"], scopes: S_meet_v2[3] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/postmaster.ts
+++ b/src/tools/generated/postmaster.ts
@@ -4,11 +4,15 @@ import type { ToolRegistry } from '../../registry.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerPostmasterGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_gmailpostmastertools_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/postmaster.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "postmaster_domains_get",
     cud: "read",
     description: "Gets a specific domain registered by the client. Returns NOT_FOUND if the domain does not exist.",
-    method: { id: "gmailpostmastertools.domains.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://gmailpostmastertools.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "gmailpostmastertools.domains.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://gmailpostmastertools.googleapis.com/", requiredParams: ["name"], scopes: S_gmailpostmastertools_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -21,7 +25,7 @@ export function registerPostmasterGeneratedTools(registry: ToolRegistry): void {
     name: "postmaster_domains_list",
     cud: "read",
     description: "Lists the domains that have been registered by the client. The order of domains in the response is unspecified and non-deterministic. Newly created domains will",
-    method: { id: "gmailpostmastertools.domains.list", httpMethod: "GET", path: "v1/domains", baseUrl: "https://gmailpostmastertools.googleapis.com/", requiredParams: [] },
+    method: { id: "gmailpostmastertools.domains.list", httpMethod: "GET", path: "v1/domains", baseUrl: "https://gmailpostmastertools.googleapis.com/", requiredParams: [], scopes: S_gmailpostmastertools_v1[0] },
     params: [{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -35,7 +39,7 @@ export function registerPostmasterGeneratedTools(registry: ToolRegistry): void {
     name: "postmaster_domains_traffic_stats_get",
     cud: "read",
     description: "Get traffic statistics for a domain on a specific date. Returns PERMISSION_DENIED if user does not have permission to access TrafficStats for the domain.",
-    method: { id: "gmailpostmastertools.domains.trafficStats.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://gmailpostmastertools.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "gmailpostmastertools.domains.trafficStats.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://gmailpostmastertools.googleapis.com/", requiredParams: ["name"], scopes: S_gmailpostmastertools_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -48,7 +52,7 @@ export function registerPostmasterGeneratedTools(registry: ToolRegistry): void {
     name: "postmaster_domains_traffic_stats_list",
     cud: "read",
     description: "List traffic statistics for all available days. Returns PERMISSION_DENIED if user does not have permission to access TrafficStats for the domain.",
-    method: { id: "gmailpostmastertools.domains.trafficStats.list", httpMethod: "GET", path: "v1/{+parent}/trafficStats", baseUrl: "https://gmailpostmastertools.googleapis.com/", requiredParams: ["parent"] },
+    method: { id: "gmailpostmastertools.domains.trafficStats.list", httpMethod: "GET", path: "v1/{+parent}/trafficStats", baseUrl: "https://gmailpostmastertools.googleapis.com/", requiredParams: ["parent"], scopes: S_gmailpostmastertools_v1[0] },
     params: [{"field":"parent","api":"parent","location":"path"},{"field":"endDate.day","api":"endDate.day","location":"query"},{"field":"endDate.month","api":"endDate.month","location":"query"},{"field":"endDate.year","api":"endDate.year","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"startDate.day","api":"startDate.day","location":"query"},{"field":"startDate.month","api":"startDate.month","location":"query"},{"field":"startDate.year","api":"startDate.year","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/reseller.ts
+++ b/src/tools/generated/reseller.ts
@@ -5,11 +5,16 @@ import { coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerResellerGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_reseller_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/apps.order","https://www.googleapis.com/auth/apps.order.readonly"],
+    ["https://www.googleapis.com/auth/apps.order"],
+  ];
   registerGeneratedTool(registry, {
     name: "reseller_customers_get",
     cud: "read",
     description: "Gets a customer account. Use this operation to see a customer account already in your reseller management, or to see the minimal account information for an exis",
-    method: { id: "reseller.customers.get", httpMethod: "GET", path: "apps/reseller/v1/customers/{customerId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "reseller.customers.get", httpMethod: "GET", path: "apps/reseller/v1/customers/{customerId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId"], scopes: S_reseller_v1[0] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -22,7 +27,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_customers_insert",
     cud: "create",
     description: "Orders a new customer's account. Before ordering a new customer account, establish whether the customer account already exists using the [`customers.get`](https",
-    method: { id: "reseller.customers.insert", httpMethod: "POST", path: "apps/reseller/v1/customers", baseUrl: "https://reseller.googleapis.com/", requiredParams: [] },
+    method: { id: "reseller.customers.insert", httpMethod: "POST", path: "apps/reseller/v1/customers", baseUrl: "https://reseller.googleapis.com/", requiredParams: [], scopes: S_reseller_v1[1] },
     params: [{"field":"customerAuthToken","api":"customerAuthToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -36,7 +41,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_customers_patch",
     cud: "update",
     description: "Updates a customer account's settings. This method supports patch semantics. You cannot update `customerType` via the Reseller API, but a `\"team\"` customer can",
-    method: { id: "reseller.customers.patch", httpMethod: "PATCH", path: "apps/reseller/v1/customers/{customerId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "reseller.customers.patch", httpMethod: "PATCH", path: "apps/reseller/v1/customers/{customerId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId"], scopes: S_reseller_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -50,7 +55,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_customers_update",
     cud: "update",
     description: "Updates a customer account's settings. You cannot update `customerType` via the Reseller API, but a `\"team\"` customer can verify their domain and become `custom",
-    method: { id: "reseller.customers.update", httpMethod: "PUT", path: "apps/reseller/v1/customers/{customerId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "reseller.customers.update", httpMethod: "PUT", path: "apps/reseller/v1/customers/{customerId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId"], scopes: S_reseller_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -64,7 +69,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_resellernotify_getwatchdetails",
     cud: "read",
     description: "Returns all the details of the watch corresponding to the reseller.",
-    method: { id: "reseller.resellernotify.getwatchdetails", httpMethod: "GET", path: "apps/reseller/v1/resellernotify/getwatchdetails", baseUrl: "https://reseller.googleapis.com/", requiredParams: [] },
+    method: { id: "reseller.resellernotify.getwatchdetails", httpMethod: "GET", path: "apps/reseller/v1/resellernotify/getwatchdetails", baseUrl: "https://reseller.googleapis.com/", requiredParams: [], scopes: S_reseller_v1[0] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -76,7 +81,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_resellernotify_register",
     cud: "create",
     description: "Registers a Reseller for receiving notifications.",
-    method: { id: "reseller.resellernotify.register", httpMethod: "POST", path: "apps/reseller/v1/resellernotify/register", baseUrl: "https://reseller.googleapis.com/", requiredParams: [] },
+    method: { id: "reseller.resellernotify.register", httpMethod: "POST", path: "apps/reseller/v1/resellernotify/register", baseUrl: "https://reseller.googleapis.com/", requiredParams: [], scopes: S_reseller_v1[1] },
     params: [{"field":"serviceAccountEmailAddress","api":"serviceAccountEmailAddress","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -89,7 +94,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_resellernotify_unregister",
     cud: "create",
     description: "Unregisters a Reseller for receiving notifications.",
-    method: { id: "reseller.resellernotify.unregister", httpMethod: "POST", path: "apps/reseller/v1/resellernotify/unregister", baseUrl: "https://reseller.googleapis.com/", requiredParams: [] },
+    method: { id: "reseller.resellernotify.unregister", httpMethod: "POST", path: "apps/reseller/v1/resellernotify/unregister", baseUrl: "https://reseller.googleapis.com/", requiredParams: [], scopes: S_reseller_v1[1] },
     params: [{"field":"serviceAccountEmailAddress","api":"serviceAccountEmailAddress","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -102,7 +107,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_activate",
     cud: "create",
     description: "Activates a subscription previously suspended by the reseller. If you did not suspend the customer subscription and it is suspended for any other reason, such a",
-    method: { id: "reseller.subscriptions.activate", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/activate", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
+    method: { id: "reseller.subscriptions.activate", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/activate", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"], scopes: S_reseller_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -116,7 +121,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_change_plan",
     cud: "create",
     description: "Updates a subscription plan. Use this method to update a plan for a 30-day trial or a flexible plan subscription to an annual commitment plan with monthly or ye",
-    method: { id: "reseller.subscriptions.changePlan", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/changePlan", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
+    method: { id: "reseller.subscriptions.changePlan", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/changePlan", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"], scopes: S_reseller_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -131,7 +136,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_change_renewal_settings",
     cud: "create",
     description: "Updates a user license's renewal settings. This is applicable for accounts with annual commitment plans only. For more information, see the description in [mana",
-    method: { id: "reseller.subscriptions.changeRenewalSettings", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/changeRenewalSettings", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
+    method: { id: "reseller.subscriptions.changeRenewalSettings", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/changeRenewalSettings", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"], scopes: S_reseller_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -146,7 +151,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_change_seats",
     cud: "create",
     description: "Updates a subscription's user license settings. For more information about updating an annual commitment plan or a flexible plan subscription’s licenses, see [M",
-    method: { id: "reseller.subscriptions.changeSeats", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/changeSeats", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
+    method: { id: "reseller.subscriptions.changeSeats", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/changeSeats", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"], scopes: S_reseller_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -161,7 +166,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_delete",
     cud: "delete",
     description: "Cancels, suspends, or transfers a subscription to direct.",
-    method: { id: "reseller.subscriptions.delete", httpMethod: "DELETE", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId","deletionType"] },
+    method: { id: "reseller.subscriptions.delete", httpMethod: "DELETE", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId","deletionType"], scopes: S_reseller_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"deletionType","api":"deletionType","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -176,7 +181,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_get",
     cud: "read",
     description: "Gets a specific subscription. The `subscriptionId` can be found using the [Retrieve all reseller subscriptions](https://developers.google.com/workspace/admin/re",
-    method: { id: "reseller.subscriptions.get", httpMethod: "GET", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
+    method: { id: "reseller.subscriptions.get", httpMethod: "GET", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"], scopes: S_reseller_v1[0] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -190,7 +195,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_insert",
     cud: "create",
     description: "Creates or transfer a subscription. Create a subscription for a customer's account that you ordered using the [Order a new customer account](https://developers.",
-    method: { id: "reseller.subscriptions.insert", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId"] },
+    method: { id: "reseller.subscriptions.insert", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId"], scopes: S_reseller_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"action","api":"action","location":"query"},{"field":"customerAuthToken","api":"customerAuthToken","location":"query"},{"field":"sourceSkuId","api":"sourceSkuId","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -207,7 +212,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_list",
     cud: "read",
     description: "Lists of subscriptions managed by the reseller. The list can be all subscriptions, all of a customer's subscriptions, or all of a customer's transferable subscr",
-    method: { id: "reseller.subscriptions.list", httpMethod: "GET", path: "apps/reseller/v1/subscriptions", baseUrl: "https://reseller.googleapis.com/", requiredParams: [] },
+    method: { id: "reseller.subscriptions.list", httpMethod: "GET", path: "apps/reseller/v1/subscriptions", baseUrl: "https://reseller.googleapis.com/", requiredParams: [], scopes: S_reseller_v1[0] },
     params: [{"field":"customerAuthToken","api":"customerAuthToken","location":"query"},{"field":"customerId","api":"customerId","location":"query"},{"field":"customerNamePrefix","api":"customerNamePrefix","location":"query"},{"field":"maxResults","api":"maxResults","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -224,7 +229,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_start_paid_service",
     cud: "create",
     description: "Immediately move a 30-day free trial subscription to a paid service subscription. This method is only applicable if a payment plan has already been set up for t",
-    method: { id: "reseller.subscriptions.startPaidService", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/startPaidService", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
+    method: { id: "reseller.subscriptions.startPaidService", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/startPaidService", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"], scopes: S_reseller_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -238,7 +243,7 @@ export function registerResellerGeneratedTools(registry: ToolRegistry): void {
     name: "reseller_subscriptions_suspend",
     cud: "create",
     description: "Suspends an active subscription. You can use this method to suspend a paid subscription that is currently in the `ACTIVE` state. * For `FLEXIBLE` subscriptions,",
-    method: { id: "reseller.subscriptions.suspend", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/suspend", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"] },
+    method: { id: "reseller.subscriptions.suspend", httpMethod: "POST", path: "apps/reseller/v1/customers/{customerId}/subscriptions/{subscriptionId}/suspend", baseUrl: "https://reseller.googleapis.com/", requiredParams: ["customerId","subscriptionId"], scopes: S_reseller_v1[1] },
     params: [{"field":"customerId","api":"customerId","location":"path"},{"field":"subscriptionId","api":"subscriptionId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/script.ts
+++ b/src/tools/generated/script.ts
@@ -5,11 +5,21 @@ import { coerceArray, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerScriptGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_script_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/script.processes"],
+    ["https://www.googleapis.com/auth/script.projects"],
+    ["https://www.googleapis.com/auth/script.deployments"],
+    ["https://www.googleapis.com/auth/script.deployments","https://www.googleapis.com/auth/script.deployments.readonly"],
+    ["https://www.googleapis.com/auth/script.projects","https://www.googleapis.com/auth/script.projects.readonly"],
+    ["https://www.googleapis.com/auth/script.metrics"],
+    ["https://mail.google.com/","https://www.google.com/calendar/feeds","https://www.google.com/m8/feeds","https://www.googleapis.com/auth/admin.directory.group","https://www.googleapis.com/auth/admin.directory.user","https://www.googleapis.com/auth/documents","https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/forms","https://www.googleapis.com/auth/forms.currentonly","https://www.googleapis.com/auth/groups","https://www.googleapis.com/auth/spreadsheets","https://www.googleapis.com/auth/userinfo.email"],
+  ];
   registerGeneratedTool(registry, {
     name: "script_processes_list",
     cud: "read",
     description: "List information about processes made by or on behalf of a user, such as process type and current status.",
-    method: { id: "script.processes.list", httpMethod: "GET", path: "v1/processes", baseUrl: "https://script.googleapis.com/", requiredParams: [] },
+    method: { id: "script.processes.list", httpMethod: "GET", path: "v1/processes", baseUrl: "https://script.googleapis.com/", requiredParams: [], scopes: S_script_v1[0] },
     params: [{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"userProcessFilter.deploymentId","api":"userProcessFilter.deploymentId","location":"query"},{"field":"userProcessFilter.endTime","api":"userProcessFilter.endTime","location":"query"},{"field":"userProcessFilter.functionName","api":"userProcessFilter.functionName","location":"query"},{"field":"userProcessFilter.projectName","api":"userProcessFilter.projectName","location":"query"},{"field":"userProcessFilter.scriptId","api":"userProcessFilter.scriptId","location":"query"},{"field":"userProcessFilter.startTime","api":"userProcessFilter.startTime","location":"query"},{"field":"userProcessFilter.statuses","api":"userProcessFilter.statuses","location":"query"},{"field":"userProcessFilter.types","api":"userProcessFilter.types","location":"query"},{"field":"userProcessFilter.userAccessLevels","api":"userProcessFilter.userAccessLevels","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -32,7 +42,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_processes_list_script_processes",
     cud: "read",
     description: "List information about a script's executed processes, such as process type and current status.",
-    method: { id: "script.processes.listScriptProcesses", httpMethod: "GET", path: "v1/processes:listScriptProcesses", baseUrl: "https://script.googleapis.com/", requiredParams: [] },
+    method: { id: "script.processes.listScriptProcesses", httpMethod: "GET", path: "v1/processes:listScriptProcesses", baseUrl: "https://script.googleapis.com/", requiredParams: [], scopes: S_script_v1[0] },
     params: [{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"scriptId","api":"scriptId","location":"query"},{"field":"scriptProcessFilter.deploymentId","api":"scriptProcessFilter.deploymentId","location":"query"},{"field":"scriptProcessFilter.endTime","api":"scriptProcessFilter.endTime","location":"query"},{"field":"scriptProcessFilter.functionName","api":"scriptProcessFilter.functionName","location":"query"},{"field":"scriptProcessFilter.startTime","api":"scriptProcessFilter.startTime","location":"query"},{"field":"scriptProcessFilter.statuses","api":"scriptProcessFilter.statuses","location":"query"},{"field":"scriptProcessFilter.types","api":"scriptProcessFilter.types","location":"query"},{"field":"scriptProcessFilter.userAccessLevels","api":"scriptProcessFilter.userAccessLevels","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -54,7 +64,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_create",
     cud: "create",
     description: "Creates a new, empty script project with no script files and a base manifest file.",
-    method: { id: "script.projects.create", httpMethod: "POST", path: "v1/projects", baseUrl: "https://script.googleapis.com/", requiredParams: [] },
+    method: { id: "script.projects.create", httpMethod: "POST", path: "v1/projects", baseUrl: "https://script.googleapis.com/", requiredParams: [], scopes: S_script_v1[1] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -67,7 +77,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_deployments_create",
     cud: "create",
     description: "Creates a deployment of an Apps Script project.",
-    method: { id: "script.projects.deployments.create", httpMethod: "POST", path: "v1/projects/{scriptId}/deployments", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"] },
+    method: { id: "script.projects.deployments.create", httpMethod: "POST", path: "v1/projects/{scriptId}/deployments", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"], scopes: S_script_v1[2] },
     params: [{"field":"scriptId","api":"scriptId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -81,7 +91,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_deployments_delete",
     cud: "delete",
     description: "Deletes a deployment of an Apps Script project.",
-    method: { id: "script.projects.deployments.delete", httpMethod: "DELETE", path: "v1/projects/{scriptId}/deployments/{deploymentId}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId","deploymentId"] },
+    method: { id: "script.projects.deployments.delete", httpMethod: "DELETE", path: "v1/projects/{scriptId}/deployments/{deploymentId}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId","deploymentId"], scopes: S_script_v1[2] },
     params: [{"field":"deploymentId","api":"deploymentId","location":"path"},{"field":"scriptId","api":"scriptId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -95,7 +105,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_deployments_get",
     cud: "read",
     description: "Gets a deployment of an Apps Script project.",
-    method: { id: "script.projects.deployments.get", httpMethod: "GET", path: "v1/projects/{scriptId}/deployments/{deploymentId}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId","deploymentId"] },
+    method: { id: "script.projects.deployments.get", httpMethod: "GET", path: "v1/projects/{scriptId}/deployments/{deploymentId}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId","deploymentId"], scopes: S_script_v1[3] },
     params: [{"field":"deploymentId","api":"deploymentId","location":"path"},{"field":"scriptId","api":"scriptId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -109,7 +119,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_deployments_list",
     cud: "read",
     description: "Lists the deployments of an Apps Script project.",
-    method: { id: "script.projects.deployments.list", httpMethod: "GET", path: "v1/projects/{scriptId}/deployments", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"] },
+    method: { id: "script.projects.deployments.list", httpMethod: "GET", path: "v1/projects/{scriptId}/deployments", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"], scopes: S_script_v1[3] },
     params: [{"field":"scriptId","api":"scriptId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -124,7 +134,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_deployments_update",
     cud: "update",
     description: "Updates a deployment of an Apps Script project.",
-    method: { id: "script.projects.deployments.update", httpMethod: "PUT", path: "v1/projects/{scriptId}/deployments/{deploymentId}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId","deploymentId"] },
+    method: { id: "script.projects.deployments.update", httpMethod: "PUT", path: "v1/projects/{scriptId}/deployments/{deploymentId}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId","deploymentId"], scopes: S_script_v1[2] },
     params: [{"field":"deploymentId","api":"deploymentId","location":"path"},{"field":"scriptId","api":"scriptId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -139,7 +149,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_get",
     cud: "read",
     description: "Gets a script project's metadata.",
-    method: { id: "script.projects.get", httpMethod: "GET", path: "v1/projects/{scriptId}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"] },
+    method: { id: "script.projects.get", httpMethod: "GET", path: "v1/projects/{scriptId}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"], scopes: S_script_v1[4] },
     params: [{"field":"scriptId","api":"scriptId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -152,7 +162,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_get_content",
     cud: "read",
     description: "Gets the content of the script project, including the code source and metadata for each script file.",
-    method: { id: "script.projects.getContent", httpMethod: "GET", path: "v1/projects/{scriptId}/content", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"] },
+    method: { id: "script.projects.getContent", httpMethod: "GET", path: "v1/projects/{scriptId}/content", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"], scopes: S_script_v1[4] },
     params: [{"field":"scriptId","api":"scriptId","location":"path"},{"field":"versionNumber","api":"versionNumber","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -166,7 +176,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_get_metrics",
     cud: "read",
     description: "Get metrics data for scripts, such as number of executions and active users.",
-    method: { id: "script.projects.getMetrics", httpMethod: "GET", path: "v1/projects/{scriptId}/metrics", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"] },
+    method: { id: "script.projects.getMetrics", httpMethod: "GET", path: "v1/projects/{scriptId}/metrics", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"], scopes: S_script_v1[5] },
     params: [{"field":"scriptId","api":"scriptId","location":"path"},{"field":"metricsFilter.deploymentId","api":"metricsFilter.deploymentId","location":"query"},{"field":"metricsGranularity","api":"metricsGranularity","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -181,7 +191,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_update_content",
     cud: "update",
     description: "Updates the content of the specified script project. This content is stored as the HEAD version, and is used when the script is executed as a trigger, in the sc",
-    method: { id: "script.projects.updateContent", httpMethod: "PUT", path: "v1/projects/{scriptId}/content", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"] },
+    method: { id: "script.projects.updateContent", httpMethod: "PUT", path: "v1/projects/{scriptId}/content", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"], scopes: S_script_v1[1] },
     params: [{"field":"scriptId","api":"scriptId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -195,7 +205,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_versions_create",
     cud: "create",
     description: "Creates a new immutable version using the current code, with a unique version number.",
-    method: { id: "script.projects.versions.create", httpMethod: "POST", path: "v1/projects/{scriptId}/versions", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"] },
+    method: { id: "script.projects.versions.create", httpMethod: "POST", path: "v1/projects/{scriptId}/versions", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"], scopes: S_script_v1[1] },
     params: [{"field":"scriptId","api":"scriptId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -209,7 +219,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_versions_get",
     cud: "read",
     description: "Gets a version of a script project.",
-    method: { id: "script.projects.versions.get", httpMethod: "GET", path: "v1/projects/{scriptId}/versions/{versionNumber}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId","versionNumber"] },
+    method: { id: "script.projects.versions.get", httpMethod: "GET", path: "v1/projects/{scriptId}/versions/{versionNumber}", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId","versionNumber"], scopes: S_script_v1[4] },
     params: [{"field":"scriptId","api":"scriptId","location":"path"},{"field":"versionNumber","api":"versionNumber","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -223,7 +233,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_projects_versions_list",
     cud: "read",
     description: "List the versions of a script project.",
-    method: { id: "script.projects.versions.list", httpMethod: "GET", path: "v1/projects/{scriptId}/versions", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"] },
+    method: { id: "script.projects.versions.list", httpMethod: "GET", path: "v1/projects/{scriptId}/versions", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"], scopes: S_script_v1[4] },
     params: [{"field":"scriptId","api":"scriptId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -238,7 +248,7 @@ export function registerScriptGeneratedTools(registry: ToolRegistry): void {
     name: "script_scripts_run",
     cud: "create",
     description: "POST script.scripts.run",
-    method: { id: "script.scripts.run", httpMethod: "POST", path: "v1/scripts/{scriptId}:run", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"] },
+    method: { id: "script.scripts.run", httpMethod: "POST", path: "v1/scripts/{scriptId}:run", baseUrl: "https://script.googleapis.com/", requiredParams: ["scriptId"], scopes: S_script_v1[6] },
     params: [{"field":"scriptId","api":"scriptId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/sheets.ts
+++ b/src/tools/generated/sheets.ts
@@ -5,11 +5,15 @@ import { coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerSheetsGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_sheets_v4: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/spreadsheets"],
+  ];
   registerGeneratedTool(registry, {
     name: "sheets_spreadsheets_developer_metadata_get",
     cud: "read",
     description: "Returns the developer metadata with the specified ID. The caller must specify the spreadsheet ID and the developer metadata's unique metadataId. For more inform",
-    method: { id: "sheets.spreadsheets.developerMetadata.get", httpMethod: "GET", path: "v4/spreadsheets/{spreadsheetId}/developerMetadata/{metadataId}", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId","metadataId"] },
+    method: { id: "sheets.spreadsheets.developerMetadata.get", httpMethod: "GET", path: "v4/spreadsheets/{spreadsheetId}/developerMetadata/{metadataId}", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId","metadataId"], scopes: S_sheets_v4[0] },
     params: [{"field":"metadataId","api":"metadataId","location":"path"},{"field":"spreadsheetId","api":"spreadsheetId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -23,7 +27,7 @@ export function registerSheetsGeneratedTools(registry: ToolRegistry): void {
     name: "sheets_spreadsheets_developer_metadata_search",
     cud: "read",
     description: "Returns all developer metadata matching the specified DataFilter. For more information, see [Read, write, and search metadata](https://developers.google.com/wor",
-    method: { id: "sheets.spreadsheets.developerMetadata.search", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}/developerMetadata:search", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId"] },
+    method: { id: "sheets.spreadsheets.developerMetadata.search", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}/developerMetadata:search", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId"], scopes: S_sheets_v4[0] },
     params: [{"field":"spreadsheetId","api":"spreadsheetId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -37,7 +41,7 @@ export function registerSheetsGeneratedTools(registry: ToolRegistry): void {
     name: "sheets_spreadsheets_get_by_data_filter",
     cud: "read",
     description: "Returns the spreadsheet at the given ID. The caller must specify the spreadsheet ID. For more information, see [Read, write, and search metadata](https://develo",
-    method: { id: "sheets.spreadsheets.getByDataFilter", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}:getByDataFilter", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId"] },
+    method: { id: "sheets.spreadsheets.getByDataFilter", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}:getByDataFilter", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId"], scopes: S_sheets_v4[0] },
     params: [{"field":"spreadsheetId","api":"spreadsheetId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -51,7 +55,7 @@ export function registerSheetsGeneratedTools(registry: ToolRegistry): void {
     name: "sheets_spreadsheets_sheets_copy_to",
     cud: "create",
     description: "Copies a single sheet from a spreadsheet to another spreadsheet. Returns the properties of the newly created sheet.",
-    method: { id: "sheets.spreadsheets.sheets.copyTo", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId","sheetId"] },
+    method: { id: "sheets.spreadsheets.sheets.copyTo", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}/sheets/{sheetId}:copyTo", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId","sheetId"], scopes: S_sheets_v4[0] },
     params: [{"field":"sheetId","api":"sheetId","location":"path"},{"field":"spreadsheetId","api":"spreadsheetId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -66,7 +70,7 @@ export function registerSheetsGeneratedTools(registry: ToolRegistry): void {
     name: "sheets_spreadsheets_values_batch_clear_by_data_filter",
     cud: "delete",
     description: "Clears one or more ranges of values from a spreadsheet. For more information, see [Read, write, and search metadata](https://developers.google.com/workspace/she",
-    method: { id: "sheets.spreadsheets.values.batchClearByDataFilter", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}/values:batchClearByDataFilter", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId"] },
+    method: { id: "sheets.spreadsheets.values.batchClearByDataFilter", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}/values:batchClearByDataFilter", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId"], scopes: S_sheets_v4[0] },
     params: [{"field":"spreadsheetId","api":"spreadsheetId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -80,7 +84,7 @@ export function registerSheetsGeneratedTools(registry: ToolRegistry): void {
     name: "sheets_spreadsheets_values_batch_get_by_data_filter",
     cud: "read",
     description: "Returns one or more ranges of values that match the specified data filters. For more information, see [Read, write, and search metadata](https://developers.goog",
-    method: { id: "sheets.spreadsheets.values.batchGetByDataFilter", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}/values:batchGetByDataFilter", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId"] },
+    method: { id: "sheets.spreadsheets.values.batchGetByDataFilter", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}/values:batchGetByDataFilter", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId"], scopes: S_sheets_v4[0] },
     params: [{"field":"spreadsheetId","api":"spreadsheetId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -94,7 +98,7 @@ export function registerSheetsGeneratedTools(registry: ToolRegistry): void {
     name: "sheets_spreadsheets_values_batch_update_by_data_filter",
     cud: "create",
     description: "Sets values in one or more ranges of a spreadsheet. For more information, see [Read, write, and search metadata](https://developers.google.com/workspace/sheets/",
-    method: { id: "sheets.spreadsheets.values.batchUpdateByDataFilter", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}/values:batchUpdateByDataFilter", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId"] },
+    method: { id: "sheets.spreadsheets.values.batchUpdateByDataFilter", httpMethod: "POST", path: "v4/spreadsheets/{spreadsheetId}/values:batchUpdateByDataFilter", baseUrl: "https://sheets.googleapis.com/", requiredParams: ["spreadsheetId"], scopes: S_sheets_v4[0] },
     params: [{"field":"spreadsheetId","api":"spreadsheetId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/tasks.ts
+++ b/src/tools/generated/tasks.ts
@@ -5,11 +5,15 @@ import { coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerTasksGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_tasks_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/tasks"],
+  ];
   registerGeneratedTool(registry, {
     name: "tasks_tasklists_update",
     cud: "update",
     description: "Updates the authenticated user's specified task list.",
-    method: { id: "tasks.tasklists.update", httpMethod: "PUT", path: "tasks/v1/users/@me/lists/{tasklist}", baseUrl: "https://tasks.googleapis.com/", requiredParams: ["tasklist"] },
+    method: { id: "tasks.tasklists.update", httpMethod: "PUT", path: "tasks/v1/users/@me/lists/{tasklist}", baseUrl: "https://tasks.googleapis.com/", requiredParams: ["tasklist"], scopes: S_tasks_v1[0] },
     params: [{"field":"tasklist","api":"tasklist","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -23,7 +27,7 @@ export function registerTasksGeneratedTools(registry: ToolRegistry): void {
     name: "tasks_tasks_update",
     cud: "update",
     description: "Updates the specified task.",
-    method: { id: "tasks.tasks.update", httpMethod: "PUT", path: "tasks/v1/lists/{tasklist}/tasks/{task}", baseUrl: "https://tasks.googleapis.com/", requiredParams: ["tasklist","task"] },
+    method: { id: "tasks.tasks.update", httpMethod: "PUT", path: "tasks/v1/lists/{tasklist}/tasks/{task}", baseUrl: "https://tasks.googleapis.com/", requiredParams: ["tasklist","task"], scopes: S_tasks_v1[0] },
     params: [{"field":"task","api":"task","location":"path"},{"field":"tasklist","api":"tasklist","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/src/tools/generated/vault.ts
+++ b/src/tools/generated/vault.ts
@@ -5,11 +5,16 @@ import { coerceBoolean, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerVaultGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_vault_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/ediscovery"],
+    ["https://www.googleapis.com/auth/ediscovery","https://www.googleapis.com/auth/ediscovery.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "vault_matters_add_permissions",
     cud: "create",
     description: "Adds an account as a matter collaborator.",
-    method: { id: "vault.matters.addPermissions", httpMethod: "POST", path: "v1/matters/{matterId}:addPermissions", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.addPermissions", httpMethod: "POST", path: "v1/matters/{matterId}:addPermissions", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -23,7 +28,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_close",
     cud: "create",
     description: "Closes the specified matter. Returns the matter with updated state.",
-    method: { id: "vault.matters.close", httpMethod: "POST", path: "v1/matters/{matterId}:close", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.close", httpMethod: "POST", path: "v1/matters/{matterId}:close", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -37,7 +42,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_count",
     cud: "read",
     description: "Counts the accounts processed by the specified query.",
-    method: { id: "vault.matters.count", httpMethod: "POST", path: "v1/matters/{matterId}:count", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.count", httpMethod: "POST", path: "v1/matters/{matterId}:count", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -51,7 +56,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_create",
     cud: "create",
     description: "Creates a matter with the given name and description. The initial state is open, and the owner is the method caller. Returns the created matter with default vie",
-    method: { id: "vault.matters.create", httpMethod: "POST", path: "v1/matters", baseUrl: "https://vault.googleapis.com/", requiredParams: [] },
+    method: { id: "vault.matters.create", httpMethod: "POST", path: "v1/matters", baseUrl: "https://vault.googleapis.com/", requiredParams: [], scopes: S_vault_v1[0] },
     params: [{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -64,7 +69,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_delete",
     cud: "delete",
     description: "Deletes the specified matter. Returns the matter with updated state.",
-    method: { id: "vault.matters.delete", httpMethod: "DELETE", path: "v1/matters/{matterId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.delete", httpMethod: "DELETE", path: "v1/matters/{matterId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -77,7 +82,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_exports_create",
     cud: "create",
     description: "Creates an export.",
-    method: { id: "vault.matters.exports.create", httpMethod: "POST", path: "v1/matters/{matterId}/exports", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.exports.create", httpMethod: "POST", path: "v1/matters/{matterId}/exports", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -91,7 +96,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_exports_delete",
     cud: "delete",
     description: "Deletes an export.",
-    method: { id: "vault.matters.exports.delete", httpMethod: "DELETE", path: "v1/matters/{matterId}/exports/{exportId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","exportId"] },
+    method: { id: "vault.matters.exports.delete", httpMethod: "DELETE", path: "v1/matters/{matterId}/exports/{exportId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","exportId"], scopes: S_vault_v1[0] },
     params: [{"field":"exportId","api":"exportId","location":"path"},{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -105,7 +110,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_exports_get",
     cud: "read",
     description: "Gets an export.",
-    method: { id: "vault.matters.exports.get", httpMethod: "GET", path: "v1/matters/{matterId}/exports/{exportId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","exportId"] },
+    method: { id: "vault.matters.exports.get", httpMethod: "GET", path: "v1/matters/{matterId}/exports/{exportId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","exportId"], scopes: S_vault_v1[1] },
     params: [{"field":"exportId","api":"exportId","location":"path"},{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -119,7 +124,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_exports_list",
     cud: "read",
     description: "Lists details about the exports in the specified matter.",
-    method: { id: "vault.matters.exports.list", httpMethod: "GET", path: "v1/matters/{matterId}/exports", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.exports.list", httpMethod: "GET", path: "v1/matters/{matterId}/exports", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[1] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -134,7 +139,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_get",
     cud: "read",
     description: "Gets the specified matter.",
-    method: { id: "vault.matters.get", httpMethod: "GET", path: "v1/matters/{matterId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.get", httpMethod: "GET", path: "v1/matters/{matterId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[1] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"view","api":"view","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -148,7 +153,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_holds_accounts_create",
     cud: "create",
     description: "Adds an account to a hold. Accounts can be added only to a hold that does not have an organizational unit set. If you try to add an account to an organizational",
-    method: { id: "vault.matters.holds.accounts.create", httpMethod: "POST", path: "v1/matters/{matterId}/holds/{holdId}/accounts", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"] },
+    method: { id: "vault.matters.holds.accounts.create", httpMethod: "POST", path: "v1/matters/{matterId}/holds/{holdId}/accounts", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"], scopes: S_vault_v1[0] },
     params: [{"field":"holdId","api":"holdId","location":"path"},{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -163,7 +168,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_holds_accounts_delete",
     cud: "delete",
     description: "Removes an account from a hold.",
-    method: { id: "vault.matters.holds.accounts.delete", httpMethod: "DELETE", path: "v1/matters/{matterId}/holds/{holdId}/accounts/{accountId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId","accountId"] },
+    method: { id: "vault.matters.holds.accounts.delete", httpMethod: "DELETE", path: "v1/matters/{matterId}/holds/{holdId}/accounts/{accountId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId","accountId"], scopes: S_vault_v1[0] },
     params: [{"field":"accountId","api":"accountId","location":"path"},{"field":"holdId","api":"holdId","location":"path"},{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -178,7 +183,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_holds_accounts_list",
     cud: "read",
     description: "Lists the accounts covered by a hold. This can list only individually-specified accounts covered by the hold. If the hold covers an organizational unit, use the",
-    method: { id: "vault.matters.holds.accounts.list", httpMethod: "GET", path: "v1/matters/{matterId}/holds/{holdId}/accounts", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"] },
+    method: { id: "vault.matters.holds.accounts.list", httpMethod: "GET", path: "v1/matters/{matterId}/holds/{holdId}/accounts", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"], scopes: S_vault_v1[1] },
     params: [{"field":"holdId","api":"holdId","location":"path"},{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -192,7 +197,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_holds_add_held_accounts",
     cud: "create",
     description: "Adds accounts to a hold. Returns a list of accounts that have been successfully added. Accounts can be added only to an existing account-based hold.",
-    method: { id: "vault.matters.holds.addHeldAccounts", httpMethod: "POST", path: "v1/matters/{matterId}/holds/{holdId}:addHeldAccounts", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"] },
+    method: { id: "vault.matters.holds.addHeldAccounts", httpMethod: "POST", path: "v1/matters/{matterId}/holds/{holdId}:addHeldAccounts", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"], scopes: S_vault_v1[0] },
     params: [{"field":"holdId","api":"holdId","location":"path"},{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -207,7 +212,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_holds_create",
     cud: "create",
     description: "Creates a hold in the specified matter.",
-    method: { id: "vault.matters.holds.create", httpMethod: "POST", path: "v1/matters/{matterId}/holds", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.holds.create", httpMethod: "POST", path: "v1/matters/{matterId}/holds", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -221,7 +226,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_holds_delete",
     cud: "delete",
     description: "Removes the specified hold and releases the accounts or organizational unit covered by the hold. If the data is not preserved by another hold or retention rule,",
-    method: { id: "vault.matters.holds.delete", httpMethod: "DELETE", path: "v1/matters/{matterId}/holds/{holdId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"] },
+    method: { id: "vault.matters.holds.delete", httpMethod: "DELETE", path: "v1/matters/{matterId}/holds/{holdId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"], scopes: S_vault_v1[0] },
     params: [{"field":"holdId","api":"holdId","location":"path"},{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -235,7 +240,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_holds_get",
     cud: "read",
     description: "Gets the specified hold.",
-    method: { id: "vault.matters.holds.get", httpMethod: "GET", path: "v1/matters/{matterId}/holds/{holdId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"] },
+    method: { id: "vault.matters.holds.get", httpMethod: "GET", path: "v1/matters/{matterId}/holds/{holdId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"], scopes: S_vault_v1[1] },
     params: [{"field":"holdId","api":"holdId","location":"path"},{"field":"matterId","api":"matterId","location":"path"},{"field":"view","api":"view","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -250,7 +255,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_holds_list",
     cud: "read",
     description: "Lists the holds in a matter.",
-    method: { id: "vault.matters.holds.list", httpMethod: "GET", path: "v1/matters/{matterId}/holds", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.holds.list", httpMethod: "GET", path: "v1/matters/{matterId}/holds", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[1] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"view","api":"view","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -266,7 +271,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_holds_remove_held_accounts",
     cud: "delete",
     description: "Removes the specified accounts from a hold. Returns a list of statuses in the same order as the request.",
-    method: { id: "vault.matters.holds.removeHeldAccounts", httpMethod: "POST", path: "v1/matters/{matterId}/holds/{holdId}:removeHeldAccounts", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"] },
+    method: { id: "vault.matters.holds.removeHeldAccounts", httpMethod: "POST", path: "v1/matters/{matterId}/holds/{holdId}:removeHeldAccounts", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"], scopes: S_vault_v1[0] },
     params: [{"field":"holdId","api":"holdId","location":"path"},{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -281,7 +286,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_holds_update",
     cud: "update",
     description: "Updates the scope (organizational unit or accounts) and query parameters of a hold. You cannot add accounts to a hold that covers an organizational unit, nor ca",
-    method: { id: "vault.matters.holds.update", httpMethod: "PUT", path: "v1/matters/{matterId}/holds/{holdId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"] },
+    method: { id: "vault.matters.holds.update", httpMethod: "PUT", path: "v1/matters/{matterId}/holds/{holdId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","holdId"], scopes: S_vault_v1[0] },
     params: [{"field":"holdId","api":"holdId","location":"path"},{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -296,7 +301,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_list",
     cud: "read",
     description: "Lists matters the requestor has access to.",
-    method: { id: "vault.matters.list", httpMethod: "GET", path: "v1/matters", baseUrl: "https://vault.googleapis.com/", requiredParams: [] },
+    method: { id: "vault.matters.list", httpMethod: "GET", path: "v1/matters", baseUrl: "https://vault.googleapis.com/", requiredParams: [], scopes: S_vault_v1[1] },
     params: [{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"state","api":"state","location":"query"},{"field":"view","api":"view","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -312,7 +317,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_remove_permissions",
     cud: "delete",
     description: "Removes an account as a matter collaborator.",
-    method: { id: "vault.matters.removePermissions", httpMethod: "POST", path: "v1/matters/{matterId}:removePermissions", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.removePermissions", httpMethod: "POST", path: "v1/matters/{matterId}:removePermissions", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -326,7 +331,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_reopen",
     cud: "create",
     description: "Reopens the specified matter. Returns the matter with updated state.",
-    method: { id: "vault.matters.reopen", httpMethod: "POST", path: "v1/matters/{matterId}:reopen", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.reopen", httpMethod: "POST", path: "v1/matters/{matterId}:reopen", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -340,7 +345,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_saved_queries_create",
     cud: "create",
     description: "Creates a saved query.",
-    method: { id: "vault.matters.savedQueries.create", httpMethod: "POST", path: "v1/matters/{matterId}/savedQueries", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.savedQueries.create", httpMethod: "POST", path: "v1/matters/{matterId}/savedQueries", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -354,7 +359,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_saved_queries_delete",
     cud: "delete",
     description: "Deletes the specified saved query.",
-    method: { id: "vault.matters.savedQueries.delete", httpMethod: "DELETE", path: "v1/matters/{matterId}/savedQueries/{savedQueryId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","savedQueryId"] },
+    method: { id: "vault.matters.savedQueries.delete", httpMethod: "DELETE", path: "v1/matters/{matterId}/savedQueries/{savedQueryId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","savedQueryId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"savedQueryId","api":"savedQueryId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -368,7 +373,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_saved_queries_get",
     cud: "read",
     description: "Retrieves the specified saved query.",
-    method: { id: "vault.matters.savedQueries.get", httpMethod: "GET", path: "v1/matters/{matterId}/savedQueries/{savedQueryId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","savedQueryId"] },
+    method: { id: "vault.matters.savedQueries.get", httpMethod: "GET", path: "v1/matters/{matterId}/savedQueries/{savedQueryId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId","savedQueryId"], scopes: S_vault_v1[1] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"savedQueryId","api":"savedQueryId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -382,7 +387,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_saved_queries_list",
     cud: "read",
     description: "Lists the saved queries in a matter.",
-    method: { id: "vault.matters.savedQueries.list", httpMethod: "GET", path: "v1/matters/{matterId}/savedQueries", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.savedQueries.list", httpMethod: "GET", path: "v1/matters/{matterId}/savedQueries", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[1] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -397,7 +402,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_undelete",
     cud: "update",
     description: "Undeletes the specified matter. Returns the matter with updated state.",
-    method: { id: "vault.matters.undelete", httpMethod: "POST", path: "v1/matters/{matterId}:undelete", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.undelete", httpMethod: "POST", path: "v1/matters/{matterId}:undelete", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -411,7 +416,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_matters_update",
     cud: "update",
     description: "Updates the specified matter. This updates only the name and description of the matter, identified by matter ID. Changes to any other fields are ignored. Return",
-    method: { id: "vault.matters.update", httpMethod: "PUT", path: "v1/matters/{matterId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"] },
+    method: { id: "vault.matters.update", httpMethod: "PUT", path: "v1/matters/{matterId}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["matterId"], scopes: S_vault_v1[0] },
     params: [{"field":"matterId","api":"matterId","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -425,7 +430,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_operations_cancel",
     cud: "create",
     description: "Starts asynchronous cancellation on a long-running operation. The server makes a best effort to cancel the operation, but success is not guaranteed. If the serv",
-    method: { id: "vault.operations.cancel", httpMethod: "POST", path: "v1/{+name}:cancel", baseUrl: "https://vault.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "vault.operations.cancel", httpMethod: "POST", path: "v1/{+name}:cancel", baseUrl: "https://vault.googleapis.com/", requiredParams: ["name"], scopes: S_vault_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -439,7 +444,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_operations_delete",
     cud: "delete",
     description: "Deletes a long-running operation. This method indicates that the client is no longer interested in the operation result. It does not cancel the operation. If th",
-    method: { id: "vault.operations.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "vault.operations.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["name"], scopes: S_vault_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -452,7 +457,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_operations_get",
     cud: "read",
     description: "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.",
-    method: { id: "vault.operations.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "vault.operations.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["name"], scopes: S_vault_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -465,7 +470,7 @@ export function registerVaultGeneratedTools(registry: ToolRegistry): void {
     name: "vault_operations_list",
     cud: "read",
     description: "Lists operations that match the specified filter in the request. If the server doesn't support this method, it returns `UNIMPLEMENTED`.",
-    method: { id: "vault.operations.list", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "vault.operations.list", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://vault.googleapis.com/", requiredParams: ["name"], scopes: S_vault_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"returnPartialSuccess","api":"returnPartialSuccess","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {

--- a/src/tools/generated/workspaceevents.ts
+++ b/src/tools/generated/workspaceevents.ts
@@ -5,6 +5,11 @@ import { coerceBoolean, coerceJson } from '../_coerce.js';
 import { accountField, registerGeneratedTool } from './_shared.js';
 
 export function registerWorkspaceeventsGeneratedTools(registry: ToolRegistry): void {
+  // Interned method scope sets (shared across tools; see scope-observability).
+  const S_workspaceevents_v1: readonly (readonly string[])[] = [
+    ["https://www.googleapis.com/auth/chat.bot","https://www.googleapis.com/auth/chat.memberships","https://www.googleapis.com/auth/chat.memberships.readonly","https://www.googleapis.com/auth/chat.messages","https://www.googleapis.com/auth/chat.messages.reactions","https://www.googleapis.com/auth/chat.messages.reactions.readonly","https://www.googleapis.com/auth/chat.messages.readonly","https://www.googleapis.com/auth/chat.spaces","https://www.googleapis.com/auth/chat.spaces.readonly","https://www.googleapis.com/auth/chat.users.availability","https://www.googleapis.com/auth/chat.users.availability.readonly","https://www.googleapis.com/auth/chat.users.readstate","https://www.googleapis.com/auth/chat.users.readstate.readonly","https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.metadata","https://www.googleapis.com/auth/drive.metadata.readonly","https://www.googleapis.com/auth/drive.readonly","https://www.googleapis.com/auth/meetings.space.created","https://www.googleapis.com/auth/meetings.space.readonly"],
+    ["https://www.googleapis.com/auth/chat.app.all.memberships.readonly","https://www.googleapis.com/auth/chat.app.all.messages.readonly","https://www.googleapis.com/auth/chat.app.all.spaces.readonly","https://www.googleapis.com/auth/chat.app.all.users.readstate.readonly","https://www.googleapis.com/auth/chat.app.memberships","https://www.googleapis.com/auth/chat.app.memberships.readonly","https://www.googleapis.com/auth/chat.app.messages.readonly","https://www.googleapis.com/auth/chat.app.spaces","https://www.googleapis.com/auth/chat.app.spaces.readonly","https://www.googleapis.com/auth/chat.memberships","https://www.googleapis.com/auth/chat.memberships.readonly","https://www.googleapis.com/auth/chat.messages","https://www.googleapis.com/auth/chat.messages.reactions","https://www.googleapis.com/auth/chat.messages.reactions.readonly","https://www.googleapis.com/auth/chat.messages.readonly","https://www.googleapis.com/auth/chat.spaces","https://www.googleapis.com/auth/chat.spaces.readonly","https://www.googleapis.com/auth/chat.users.availability","https://www.googleapis.com/auth/chat.users.availability.readonly","https://www.googleapis.com/auth/chat.users.readstate","https://www.googleapis.com/auth/chat.users.readstate.readonly","https://www.googleapis.com/auth/drive","https://www.googleapis.com/auth/drive.file","https://www.googleapis.com/auth/drive.metadata","https://www.googleapis.com/auth/drive.metadata.readonly","https://www.googleapis.com/auth/drive.readonly","https://www.googleapis.com/auth/meetings.space.created","https://www.googleapis.com/auth/meetings.space.readonly"],
+  ];
   registerGeneratedTool(registry, {
     name: "workspaceevents_message_stream",
     cud: "create",
@@ -22,7 +27,7 @@ export function registerWorkspaceeventsGeneratedTools(registry: ToolRegistry): v
     name: "workspaceevents_operations_get",
     cud: "read",
     description: "Gets the latest state of a long-running operation. Clients can use this method to poll the operation result at intervals as recommended by the API service.",
-    method: { id: "workspaceevents.operations.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "workspaceevents.operations.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: ["name"], scopes: S_workspaceevents_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -35,7 +40,7 @@ export function registerWorkspaceeventsGeneratedTools(registry: ToolRegistry): v
     name: "workspaceevents_subscriptions_create",
     cud: "create",
     description: "Creates a Google Workspace subscription. To learn how to use this method, see [Create a Google Workspace subscription](https://developers.google.com/workspace/e",
-    method: { id: "workspaceevents.subscriptions.create", httpMethod: "POST", path: "v1/subscriptions", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: [] },
+    method: { id: "workspaceevents.subscriptions.create", httpMethod: "POST", path: "v1/subscriptions", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: [], scopes: S_workspaceevents_v1[1] },
     params: [{"field":"validateOnly","api":"validateOnly","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -49,7 +54,7 @@ export function registerWorkspaceeventsGeneratedTools(registry: ToolRegistry): v
     name: "workspaceevents_subscriptions_delete",
     cud: "delete",
     description: "Deletes a Google Workspace subscription. To learn how to use this method, see [Delete a Google Workspace subscription](https://developers.google.com/workspace/e",
-    method: { id: "workspaceevents.subscriptions.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "workspaceevents.subscriptions.delete", httpMethod: "DELETE", path: "v1/{+name}", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: ["name"], scopes: S_workspaceevents_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"allowMissing","api":"allowMissing","location":"query"},{"field":"etag","api":"etag","location":"query"},{"field":"validateOnly","api":"validateOnly","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -65,7 +70,7 @@ export function registerWorkspaceeventsGeneratedTools(registry: ToolRegistry): v
     name: "workspaceevents_subscriptions_get",
     cud: "read",
     description: "Gets details about a Google Workspace subscription. To learn how to use this method, see [Get details about a Google Workspace subscription](https://developers.",
-    method: { id: "workspaceevents.subscriptions.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "workspaceevents.subscriptions.get", httpMethod: "GET", path: "v1/{+name}", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: ["name"], scopes: S_workspaceevents_v1[0] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -78,7 +83,7 @@ export function registerWorkspaceeventsGeneratedTools(registry: ToolRegistry): v
     name: "workspaceevents_subscriptions_list",
     cud: "read",
     description: "Lists Google Workspace subscriptions. To learn how to use this method, see [List Google Workspace subscriptions](https://developers.google.com/workspace/events/",
-    method: { id: "workspaceevents.subscriptions.list", httpMethod: "GET", path: "v1/subscriptions", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: [] },
+    method: { id: "workspaceevents.subscriptions.list", httpMethod: "GET", path: "v1/subscriptions", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: [], scopes: S_workspaceevents_v1[0] },
     params: [{"field":"filter","api":"filter","location":"query"},{"field":"pageSize","api":"pageSize","location":"query"},{"field":"pageToken","api":"pageToken","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: false,
     shape: {
@@ -93,7 +98,7 @@ export function registerWorkspaceeventsGeneratedTools(registry: ToolRegistry): v
     name: "workspaceevents_subscriptions_patch",
     cud: "update",
     description: "Updates or renews a Google Workspace subscription. To learn how to use this method, see [Update or renew a Google Workspace subscription](https://developers.goo",
-    method: { id: "workspaceevents.subscriptions.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "workspaceevents.subscriptions.patch", httpMethod: "PATCH", path: "v1/{+name}", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: ["name"], scopes: S_workspaceevents_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"updateMask","api":"updateMask","location":"query"},{"field":"validateOnly","api":"validateOnly","location":"query"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {
@@ -109,7 +114,7 @@ export function registerWorkspaceeventsGeneratedTools(registry: ToolRegistry): v
     name: "workspaceevents_subscriptions_reactivate",
     cud: "create",
     description: "Reactivates a suspended Google Workspace subscription. This method resets your subscription's `State` field to `ACTIVE`. Before you use this method, you must fi",
-    method: { id: "workspaceevents.subscriptions.reactivate", httpMethod: "POST", path: "v1/{+name}:reactivate", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: ["name"] },
+    method: { id: "workspaceevents.subscriptions.reactivate", httpMethod: "POST", path: "v1/{+name}:reactivate", baseUrl: "https://workspaceevents.googleapis.com/", requiredParams: ["name"], scopes: S_workspaceevents_v1[1] },
     params: [{"field":"name","api":"name","location":"path"},{"field":"fields","api":"fields","location":"query"}],
     hasBody: true,
     shape: {

--- a/tests/accounts-tool.test.ts
+++ b/tests/accounts-tool.test.ts
@@ -21,7 +21,12 @@ describe('deriveAccountHealth', () => {
     const h = deriveAccountHealth(ALIAS, deps({ hasToken: () => false }));
     expect(h.token.status).toBe('missing');
     expect(h.token.hint).toContain('auth --account test');
-    expect(h.scopes).toEqual({ configured: CONFIGURED.length, granted: 0, missing: CONFIGURED });
+    expect(h.scopes).toMatchObject({ configured: CONFIGURED.length, granted: 0 });
+    // B3 extension: missing kept for v5 consumers, now sorted; three-state
+    // breakdown present.
+    expect(h.scopes.missing).toEqual([...CONFIGURED].sort());
+    expect(h.scopes.requestable).toEqual([...CONFIGURED].sort());
+    expect(h.scopes.callable).toEqual([]);
     expect(h.email).toBe('test@example.com');
   });
 
@@ -58,7 +63,7 @@ describe('deriveAccountHealth', () => {
     expect(h.token.status).toBe('ok');
     expect(h.token.expiryDate).toBe(new Date(NOW + 60_000).toISOString());
     expect(h.scopes.granted).toBe(2);
-    expect(h.scopes.missing).toEqual(CONFIGURED.slice(2));
+    expect(h.scopes.missing).toEqual([...CONFIGURED.slice(2)].sort());
   });
 
   it('reports expired_refreshable when expired but a refresh token exists', () => {

--- a/tests/scope-observability.test.ts
+++ b/tests/scope-observability.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyScope,
+  classifyMethodScopes,
+  scopeHint,
+  scopeHintForMethod,
+  buildScopesReport,
+} from '../src/scope-observability.js';
+import { ADMIN_SCOPES, BUNDLE_CATALOG } from '../src/scope-catalog.js';
+import { deriveAccountHealth } from '../src/tools/accounts-tool.js';
+
+const FORMS_BODY = 'https://www.googleapis.com/auth/forms.body';
+const GMAIL_MODIFY = 'https://www.googleapis.com/auth/gmail.modify';
+
+describe('classifyScope (three-state)', () => {
+  const granted = new Set([GMAIL_MODIFY]);
+  const profile = new Set([GMAIL_MODIFY, FORMS_BODY]);
+
+  it('granted -> callable', () => {
+    expect(classifyScope(GMAIL_MODIFY, granted, profile).state).toBe('callable');
+  });
+
+  it('in profile, not granted -> requestable_not_granted', () => {
+    expect(classifyScope(FORMS_BODY, granted, profile).state).toBe('requestable_not_granted');
+  });
+
+  it('in catalog, not in profile -> not_requestable{add_bundle} naming the narrowest bundle', () => {
+    const c = classifyScope('https://www.googleapis.com/auth/presentations', granted, profile);
+    expect(c).toMatchObject({ state: 'not_requestable', reason: 'add_bundle', bundle: 'slides' });
+  });
+
+  it('unknown scope -> not_requestable{unknown_scope}', () => {
+    const c = classifyScope('https://www.googleapis.com/auth/made-up', granted, profile);
+    expect(c).toMatchObject({ state: 'not_requestable', reason: 'unknown_scope' });
+  });
+});
+
+describe('classifyMethodScopes (Discovery scopes are ANY-OF alternatives)', () => {
+  const CHAT_MESSAGES = 'https://www.googleapis.com/auth/chat.messages';
+  const CHAT_BOT = 'https://www.googleapis.com/auth/chat.bot';
+
+  it('any single granted alternative makes the method callable', () => {
+    const c = classifyMethodScopes([CHAT_BOT, GMAIL_MODIFY], new Set([GMAIL_MODIFY]), new Set());
+    expect(c?.state).toBe('callable');
+    expect(c?.scope).toBe(GMAIL_MODIFY);
+  });
+
+  it('FLAGSHIP: an unknown alternative (chat.bot) never masks a requestable one', () => {
+    // Bundle in profile, unchecked at consent: the standard add-then-re-auth flow.
+    const c = classifyMethodScopes([CHAT_BOT, CHAT_MESSAGES], new Set(), new Set([CHAT_MESSAGES]));
+    expect(c?.state).toBe('requestable_not_granted');
+    expect(c?.scope).toBe(CHAT_MESSAGES);
+  });
+
+  it('hint and classification always refer to the SAME scope', () => {
+    const BASIC = 'https://www.googleapis.com/auth/gmail.settings.basic';
+    const SHARING = 'https://www.googleapis.com/auth/gmail.settings.sharing';
+    // basic in profile (unchecked), sharing not in profile: best = requestable basic.
+    const c = classifyMethodScopes([BASIC, SHARING], new Set(), new Set([BASIC]));
+    expect(c?.scope).toBe(BASIC);
+    expect(c?.state).toBe('requestable_not_granted');
+  });
+});
+
+describe('remediation hints (gh-CLI style, honest retriable)', () => {
+  it('requestable: re-auth same account, retriable', () => {
+    const h = scopeHint(FORMS_BODY, { state: 'requestable_not_granted' }, 'work');
+    expect(h.hint).toContain('auth --account work');
+    expect(h.retriable).toBe(true);
+  });
+
+  it('add_bundle: names the bundle and config.json, not retriable', () => {
+    const h = scopeHint(FORMS_BODY, { state: 'not_requestable', reason: 'add_bundle', bundle: 'forms' }, 'work');
+    expect(h.hint).toContain('"forms"');
+    expect(h.hint).toContain('config.json');
+    expect(h.retriable).toBe(false);
+  });
+
+  it('unknown: says stop retrying', () => {
+    const h = scopeHint('https://x/y', { state: 'not_requestable', reason: 'unknown_scope' }, 'work');
+    expect(h.hint).toContain('Do not retry');
+    expect(h.retriable).toBe(false);
+  });
+});
+
+describe('scopeHintForMethod (runtime 403 enrichment)', () => {
+  const deps = {
+    readTokenFn: () => ({ scope: GMAIL_MODIFY, refresh_token: 'r' }),
+    profileFn: () => [GMAIL_MODIFY, FORMS_BODY, ...ADMIN_SCOPES],
+  };
+
+  it('state-2 scope produces a re-auth hint', () => {
+    const h = scopeHintForMethod([FORMS_BODY], 'work', deps);
+    expect(h?.retriable).toBe(true);
+    expect(h?.hint).toContain('auth --account work');
+  });
+
+  it('admin scope IN profile but 403ing -> hedged re-auth hint (never a fabricated dead end)', () => {
+    const h = scopeHintForMethod([ADMIN_SCOPES[0]], 'maybe-workspace', deps);
+    expect(h?.retriable).toBe(true);
+    expect(h?.hint).toContain('auth --account maybe-workspace');
+    expect(h?.hint).toContain('Workspace alias');
+  });
+
+  it('base scope excluded by includesBase:false -> includesBase remediation, never "add base bundle"', () => {
+    const h = scopeHintForMethod([GMAIL_MODIFY], 'minimal', {
+      readTokenFn: () => ({ scope: '', refresh_token: 'r' }),
+      profileFn: () => [],
+    });
+    expect(h?.hint).toContain('includesBase');
+    expect(h?.hint).not.toContain('"base" bundle');
+    expect(h?.retriable).toBe(false);
+  });
+
+  it('null when the token is unreadable (falls back to the generic hint)', () => {
+    expect(
+      scopeHintForMethod([FORMS_BODY], 'work', { ...deps, readTokenFn: () => { throw new Error('decrypt'); } }),
+    ).toBeNull();
+  });
+});
+
+describe('buildScopesReport / account_list block', () => {
+  it('classifies the compact profile∪granted universe with v5-compatible missing', () => {
+    const granted = new Set([GMAIL_MODIFY]);
+    const profile = new Set([GMAIL_MODIFY, FORMS_BODY]);
+    const r = buildScopesReport(granted, profile);
+    expect(r.callable).toEqual([GMAIL_MODIFY]);
+    expect(r.requestable).toEqual([FORMS_BODY]);
+    expect(r.missing).toEqual([FORMS_BODY]);
+    expect(r.notRequestable.addBundle).toEqual([]);
+  });
+
+  it('registered tool scopes outside the profile classify as add_bundle with the bundle name', () => {
+    const r = buildScopesReport(new Set(), new Set([GMAIL_MODIFY]), BUNDLE_CATALOG.slides.scopes);
+    expect(r.notRequestable.addBundle).toEqual([
+      { scope: 'https://www.googleapis.com/auth/presentations', bundle: 'slides' },
+    ]);
+  });
+
+  it('deriveAccountHealth emits the extended block', () => {
+    const health = deriveAccountHealth('test', {
+      hasToken: () => true,
+      readToken: () => ({ scope: GMAIL_MODIFY, refresh_token: 'r', expiry_date: Date.now() + 60000 }),
+      fileExists: () => false,
+      now: Date.now,
+    });
+    expect(health.scopes.callable).toContain(GMAIL_MODIFY);
+    expect(Array.isArray(health.scopes.requestable)).toBe(true);
+    expect(health.scopes.notRequestable).toBeDefined();
+  });
+});


### PR DESCRIPTION
B3 per the §9.3 landing order — the #114 model, closing the loop on the issue's roadmap-input status.

- `src/scope-observability.ts`: three-state classifier (callable / requestable_not_granted / not_requestable{add_bundle|account_type|unknown_scope}), worst-of per-tool classification, narrowest-bundle reverse index, gh-CLI-style remediation templates with honest `retriable`
- Generated tools: required scopes **baked + interned** at gen time (per-doc frozen tables, shared arrays, deterministic ordering) — zero-I/O classification; escape hatch uses the runtime Discovery scopes it already holds; ONE enrichment point in `executeApiMethod`'s 403 path covers both surfaces
- `account_list` scopes block gains the three-state breakdown (compact profile∪granted universe; `missing` kept for v5 consumers, now sorted); the registered-tool universe is doctor's tool-grained view (B9)
- `account_type` refinement: an admin scope that IS in the profile but 403s means Workspace-only for this alias — the hint says use another alias instead of looping re-auth
- Deferred, recorded in the runbook: the proactive prefer-curated coverage hint needs `CURATED_METHOD_IDS` to become an id→tool map (B10/Rz2)

## Verification
- 436/436 tests (18 new: classifier states, worst-of, hint templates, runtime enrichment incl. the account_type dead-end and decrypt-fallback, report block, extended deriveAccountHealth)
- **Live end-to-end**: a real Google 403 on `gmail.users.settings.updateVacation` for `personal` (no `gmail_settings`) returned `insufficient_scope` with the add_bundle remediation naming the bundle and `retriable: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)