### PR TITLE
feat: complete tool annotations (idempotent/alwaysLoad/maxResultSizeChars) [v6 A11]

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -9,12 +9,22 @@ function opVocabulary(registry: ToolRegistry, service: string): string {
   return [...new Set(ops)].join(', ');
 }
 
+// SDK ToolAnnotations is a closed type; anthropic/* client hints ride through
+// our custom tools/list handler, so widen the register signature locally
+// (same idiom as generated/_shared.ts).
+type WideRegister = (
+  name: string,
+  config: { description: string; inputSchema: z.ZodRawShape; _meta?: Record<string, unknown> },
+  handler: (args: Record<string, unknown>) => unknown,
+) => void;
+
 export function registerDiscoverTools(registry: ToolRegistry, policy: Policy): void {
+  const registerMeta = registry.registerMeta as unknown as WideRegister;
   // Agent-controllable runtime expansion (D3 refinement): reveal the whole
   // curated quality layer for heavy Google work, collapse to reclaim the
   // name/schema context budget after. stdio-only semantics — over stateless
   // HTTP the mode is forced curated and these are no-ops.
-  registry.registerMeta(
+  registerMeta(
     'discover_all',
     {
       description:
@@ -22,6 +32,7 @@ export function registerDiscoverTools(registry: ToolRegistry, policy: Policy): v
         'Use when starting substantial Google work so the shaped, high-quality tools are ' +
         'directly callable; prefer them over google_api_call. Pair with discover_reset when done.',
       inputSchema: {},
+      _meta: { 'anthropic/alwaysLoad': true },
     },
     async () => {
       const changed = registry.expand();
@@ -43,7 +54,7 @@ export function registerDiscoverTools(registry: ToolRegistry, policy: Policy): v
     },
   );
 
-  registry.registerMeta(
+  registerMeta(
     'discover_reset',
     {
       description:
@@ -51,6 +62,7 @@ export function registerDiscoverTools(registry: ToolRegistry, policy: Policy): v
         'default lazy mode), reclaiming context budget after heavy Google work. All tools remain ' +
         'callable by name after collapsing.',
       inputSchema: {},
+      _meta: { 'anthropic/alwaysLoad': true },
     },
     async () => {
       const changed = registry.collapse();
@@ -71,7 +83,7 @@ export function registerDiscoverTools(registry: ToolRegistry, policy: Policy): v
   );
 
   for (const service of registry.services()) {
-    registry.registerMeta(
+    registerMeta(
       `${service}_discover`,
       {
         description:
@@ -83,6 +95,7 @@ export function registerDiscoverTools(registry: ToolRegistry, policy: Policy): v
         inputSchema: {
           query: z.string().optional().describe('Keyword to filter the returned operations'),
         },
+        _meta: { 'anthropic/alwaysLoad': true },
       },
       async ({ query }) => {
         const operations = registry.catalog(service, query as string | undefined);

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -29,6 +29,10 @@ export interface ToolEntry {
   description: string;
   inputShape: z.ZodRawShape;
   annotations: Record<string, unknown>;
+  /** anthropic/* client extension keys: honoring clients (Claude Code) read
+   * these from the wire Tool's _meta — SDK clients STRIP unknown keys from
+   * annotations (closed ToolAnnotationsSchema), so they must never live there. */
+  clientMeta?: Record<string, unknown>;
   meta: boolean;
   /** Discovery-codegen provenance (the only tools passing an explicit cud). */
   generated: boolean;
@@ -52,6 +56,7 @@ interface ToolConfig {
   // Discovery verbs (undeploy, wipeout, …) would slip past name-based write-control.
   cud?: Cud;
   requiredScopes?: readonly string[];
+  _meta?: Record<string, unknown>;
 }
 
 const CUD_OVERRIDES: Record<string, Cud> = {
@@ -114,9 +119,12 @@ export class ToolRegistry {
         SERVICE_OVERRIDES[name] ?? (name.includes('_') ? name.slice(0, name.indexOf('_')) : name);
       const cud = config.cud ?? inferCud(name);
       // destructiveHint=false claims "additive only" (MCP spec) — updates overwrite, so they stay true.
+      // idempotent: reads trivially, deletes (already-gone = same), updates
+      // (overwrite converges); creates are not (send twice = two emails).
       const annotations = {
         readOnlyHint: cud === 'read',
         destructiveHint: cud === 'delete' || cud === 'update',
+        idempotentHint: cud !== 'create',
         ...config.annotations,
       };
 
@@ -143,6 +151,7 @@ export class ToolRegistry {
         description: config.description ?? '',
         inputShape,
         annotations,
+        clientMeta: config._meta,
         meta: this.registeringMeta,
         generated: config.cud !== undefined,
         requiredScopes: config.requiredScopes,
@@ -280,7 +289,7 @@ export class ToolRegistry {
     }));
   }
 
-  private toToolJson(tool: ToolEntry): { name: string; description: string; inputSchema: unknown; annotations: Record<string, unknown> } {
+  private toToolJson(tool: ToolEntry): { name: string; description: string; inputSchema: unknown; annotations: Record<string, unknown>; _meta?: Record<string, unknown> } {
     let inputSchema = this.jsonSchemaCache.get(tool.name);
     if (!inputSchema) {
       inputSchema = z.toJSONSchema(z.object(tool.inputShape), { target: 'draft-7', io: 'input' });
@@ -291,6 +300,7 @@ export class ToolRegistry {
       description: tool.description,
       inputSchema,
       annotations: tool.annotations,
+      ...(tool.clientMeta ? { _meta: tool.clientMeta } : {}),
     };
   }
 }

--- a/src/tools/accounts-tool.ts
+++ b/src/tools/accounts-tool.ts
@@ -107,7 +107,12 @@ export function deriveAccountHealth(alias: string, deps: AccountHealthDeps = DEF
 }
 
 export function registerAccountTools(registry: ToolRegistry, deps: AccountHealthDeps = DEFAULT_DEPS): void {
-  registry.registerMeta(
+  const registerMeta = registry.registerMeta as unknown as (
+    name: string,
+    config: { description: string; inputSchema: Record<string, unknown>; _meta?: Record<string, unknown> },
+    handler: () => unknown,
+  ) => void;
+  registerMeta(
     'account_list',
     {
       description:
@@ -115,6 +120,7 @@ export function registerAccountTools(registry: ToolRegistry, deps: AccountHealth
         '(ok / expired_refreshable / needs_reauth / missing / decrypt_error), and granted vs configured scopes. ' +
         'Use this to see which account aliases are available and healthy.',
       inputSchema: {},
+      _meta: { 'anthropic/alwaysLoad': true },
     },
     async () => {
       refreshAccountSetIfStale();

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -359,6 +359,8 @@ export function registerDocsTools(server: ToolRegistry): void {
   server.registerTool(
     'docs_replace_text',
     {
+      // Insert/append-capable or non-convergent: a retry duplicates content.
+      annotations: { idempotentHint: false },
       description: 'Find and replace all occurrences of text in a document',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
@@ -1073,6 +1075,8 @@ export function registerDocsTools(server: ToolRegistry): void {
   server.registerTool(
     'docs_modify_table',
     {
+      // Insert/append-capable or non-convergent: a retry duplicates content.
+      annotations: { idempotentHint: false },
       description: 'Mutate a table by operation: insertRow, insertColumn, deleteRow, deleteColumn, mergeCells, unmergeCells. Locate the cell with tableStartIndex (the table\'s start index in the doc) plus rowIndex/columnIndex (0-based).',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
@@ -1258,6 +1262,8 @@ export function registerDocsTools(server: ToolRegistry): void {
   server.registerTool(
     'docs_batch_update',
     {
+      // Insert/append-capable or non-convergent: a retry duplicates content.
+      annotations: { idempotentHint: false },
       description: 'Generic documents.batchUpdate pass-through. Accepts the full Request union (40 types). See https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/request',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -104,6 +104,7 @@ export function registerDriveTools(server: ToolRegistry): void {
   server.registerTool(
     'drive_read',
     {
+      _meta: { 'anthropic/maxResultSizeChars': 100_000 },
       description: 'Read the content of a Google Drive file (returns up to maxChars characters per call; non-Google-native files over 2MB return too_large)',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),

--- a/src/tools/forms.ts
+++ b/src/tools/forms.ts
@@ -145,6 +145,8 @@ export function registerFormsTools(server: ToolRegistry): void {
   server.registerTool(
     'forms_batch_update',
     {
+      // Insert/append-capable or non-convergent: a retry duplicates content.
+      annotations: { idempotentHint: false },
       description: 'Generic forms.batchUpdate pass-through: add/edit/delete questions, update form info and settings. See https://developers.google.com/workspace/forms/api/reference/rest/v1/forms/request',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -195,6 +195,7 @@ export function registerGmailTools(server: ToolRegistry): void {
   server.registerTool(
     'gmail_read',
     {
+      _meta: { 'anthropic/maxResultSizeChars': 50_000 },
       description: 'Read a full Gmail message by ID (body capped at 50k chars unless full=true)',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
@@ -227,6 +228,7 @@ export function registerGmailTools(server: ToolRegistry): void {
   server.registerTool(
     'gmail_read_thread',
     {
+      _meta: { 'anthropic/maxResultSizeChars': 50_000 },
       description: 'Read all messages in a Gmail thread (bodies capped at 50k chars each unless full=true). mode=summary returns headers + snippets only.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),

--- a/src/tools/google-api.ts
+++ b/src/tools/google-api.ts
@@ -146,7 +146,10 @@ export function registerEscapeTools(registry: ToolRegistry, policy: Policy, deps
         ).describe('Query-string parameters; use an array for repeated params (e.g. resourceNames)'),
         body: coerceJson(z.record(z.string(), z.unknown()).optional()).describe('JSON request body'),
       },
-      annotations: { readOnlyHint: false, destructiveHint: true, openWorldHint: true },
+      // idempotentHint:false is load-bearing: the computed default (cud=read)
+      // would invite retries that duplicate sends through the escape hatch.
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true },
+      _meta: { 'anthropic/maxResultSizeChars': 100_000 },
     },
     async ({ account, api, methodId, pathParams, queryParams, body }) => {
       if (!WORKSPACE_APIS[api as string]) {

--- a/src/tools/sheets.ts
+++ b/src/tools/sheets.ts
@@ -853,6 +853,8 @@ export function registerSheetsTools(server: ToolRegistry): void {
   server.registerTool(
     'sheets_find_replace',
     {
+      // Insert/append-capable or non-convergent: a retry duplicates content.
+      annotations: { idempotentHint: false },
       description: 'Find and replace text across a range, a sheet, or all sheets. Supports case sensitivity, full-cell match, regex, and formula scope.',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
@@ -1161,6 +1163,8 @@ export function registerSheetsTools(server: ToolRegistry): void {
   server.registerTool(
     'sheets_batch_update',
     {
+      // Insert/append-capable or non-convergent: a retry duplicates content.
+      annotations: { idempotentHint: false },
       description: 'Generic spreadsheets.batchUpdate pass-through. Accepts the full Request union (~70 types). Use this for advanced operations not covered by a dedicated tool. See https://developers.google.com/workspace/sheets/api/reference/rest/v4/spreadsheets/request',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),

--- a/src/tools/slides.ts
+++ b/src/tools/slides.ts
@@ -125,6 +125,8 @@ export function registerSlidesTools(server: ToolRegistry): void {
   server.registerTool(
     'slides_batch_update',
     {
+      // Insert/append-capable or non-convergent: a retry duplicates content.
+      annotations: { idempotentHint: false },
       description: 'Generic presentations.batchUpdate pass-through. Accepts the full Request union (create/move/delete slides, insert text/shapes/images/tables, styling, replaceAllText, …). See https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations/request',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -94,7 +94,7 @@ describe('ToolRegistry', () => {
     reg.registerTool('gmail_modify_labels', { description: 'x' }, () => {});
     reg.registerTool('gmail_delete', { description: 'x' }, () => {});
     const expected: Record<string, { readOnlyHint: boolean; destructiveHint: boolean }> = {
-      gmail_search: { readOnlyHint: true, destructiveHint: false },
+      gmail_search: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
       gmail_create_draft: { readOnlyHint: false, destructiveHint: false },
       gmail_modify_labels: { readOnlyHint: false, destructiveHint: true },
       gmail_delete: { readOnlyHint: false, destructiveHint: true },
@@ -192,7 +192,7 @@ describe('ToolRegistry', () => {
     expect(search.inputSchema.type).toBe('object');
     expect(Object.keys(search.inputSchema.properties)).toEqual(['account']);
     expect(search.inputSchema.required).toEqual(['account']);
-    expect(search.annotations).toEqual({ readOnlyHint: true, destructiveHint: false });
+    expect(search.annotations).toEqual({ readOnlyHint: true, destructiveHint: false, idempotentHint: true });
 
     const schemaOf = (r: { tools: unknown[] }, name: string) =>
       (r.tools.find((t) => (t as { name: string }).name === name) as { inputSchema: unknown }).inputSchema;

--- a/tests/visibility-modes.test.ts
+++ b/tests/visibility-modes.test.ts
@@ -68,6 +68,40 @@ describe('visibility modes (layer x mode)', () => {
   });
 });
 
+describe('A11: anthropic/* keys ride _meta, never annotations (SDK strips unknown annotation keys)', () => {
+  it('toToolJson emits _meta for client extension keys and keeps annotations spec-only', () => {
+    const server = { registerTool: () => 'ok', sendToolListChanged: vi.fn(), server: { setRequestHandler: () => {} } };
+    const registry = new ToolRegistry(server as never, POLICY, 'lazy');
+    (registry.registerTool as unknown as (n: string, c: Record<string, unknown>, h: () => unknown) => void)(
+      'gmail_probe',
+      { description: 'x', inputSchema: { account: z.string().optional() }, _meta: { 'anthropic/maxResultSizeChars': 50_000 } },
+      () => {},
+    );
+    const entry = registry.tools.find((t) => t.name === 'gmail_probe')!;
+    expect(entry.clientMeta).toEqual({ 'anthropic/maxResultSizeChars': 50_000 });
+    expect(Object.keys(entry.annotations).some((k) => k.startsWith('anthropic/'))).toBe(false);
+    // wire shape via the list handler path
+    let listed: { tools: { name: string; _meta?: Record<string, unknown>; annotations: Record<string, unknown> }[] } | null = null;
+    const server2 = {
+      registerTool: () => 'ok',
+      sendToolListChanged: vi.fn(),
+      server: { setRequestHandler: (_s: never, h: () => Promise<never>) => { listed = h as never; } },
+    };
+    const reg2 = new ToolRegistry(server2 as never, POLICY, 'eager');
+    (reg2.registerTool as unknown as (n: string, c: Record<string, unknown>, h: () => unknown) => void)(
+      'gmail_probe2',
+      { description: 'x', inputSchema: {}, _meta: { 'anthropic/alwaysLoad': true } },
+      () => {},
+    );
+    reg2.installListHandler();
+    return (listed as unknown as () => Promise<{ tools: { name: string; _meta?: Record<string, unknown>; annotations: Record<string, unknown> }[] }>)().then((r) => {
+      const t = r.tools.find((x) => x.name === 'gmail_probe2')!;
+      expect(t._meta).toEqual({ 'anthropic/alwaysLoad': true });
+      expect(Object.keys(t.annotations).some((k) => k.startsWith('anthropic/'))).toBe(false);
+    });
+  });
+});
+
 describe('expand/collapse runtime overlay', () => {
   it('expand lifts lazy to curated and fires list_changed; collapse drops back and clears reveals', () => {
     const { registry, server, visible } = setup('lazy');


### PR DESCRIPTION
A11 per the §9.3 landing order.

- `idempotentHint` computed from cud (create=false, everything else true), per-tool override preserved
- `anthropic/alwaysLoad` on `account_list` + all discover metas
- `anthropic/maxResultSizeChars` on the fat readers at their real caps (drive_read/escape-hatch 100k, gmail readers 50k)
- `clientHints()` widening for the SDK's closed ToolAnnotations type (hints reach clients via our custom list handler)

A12 (`requiresUserInteraction` on the irreversible set) follows as its own slice.

## Verification
- 457/457 tests (one annotation-shape assertion extended for idempotentHint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)