### PR TITLE
chore: genericize gmail label example (drop internal project names)

### DIFF
--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -719,7 +719,7 @@ export function registerGmailTools(server: ToolRegistry): void {
       description: 'Create a new custom Gmail label',
       inputSchema: {
         account: accountEnum.describe('Google account alias'),
-        name: z.string().describe('Label name, e.g. "Ideacrafters/ComptaLegal"'),
+        name: z.string().describe('Label name, e.g. "Work/Projects" (nested labels use "/")'),
         messageListVisibility: z.enum(['show', 'hide']).optional()
           .describe('Whether messages with this label show in message list (default: show)'),
         labelListVisibility: z.enum(['labelShow', 'labelShowIfUnread', 'labelHide']).optional()


### PR DESCRIPTION
The `gmail_create_label` description shipped a real internal example (`"Ideacrafters/ComptaLegal"`). Replaced with a neutral `"Work/Projects"` that still demonstrates the nested-label `/` convention. Docs-only string in a tool description; no behavior change.

Found during a PII sweep of the public repo. (Same string is on `main` from v5; this fixes it going forward on the v6 line.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)