### PR TITLE
feat!: markdown email compose (send) [v6 A6]

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -46,3 +46,8 @@ Tool responses are serialized compactly (no pretty-print token tax; set `GOOGLE_
 ### Email attachments & safe compose
 
 `gmail_send` and `gmail_create_draft` share one MIME builder (nodemailer MailComposer) and accept `attachments: [{ path, filename?, contentType? }]` — the server reads each absolute path itself (MailComposer never touches the filesystem or network), caps the total at ~35 MB, and derives the MIME filename by basename. Address/subject headers containing CR/LF are rejected up front (`E_HEADER_INJECTION`), closing the old header-injection hole; bodies are CRLF-normalized and base64-encoded so Gmail's raw upload can't be corrupted by a bare LF.
+
+
+### Markdown email (send)
+
+`gmail_send` / `gmail_create_draft` take `body` as **Markdown**: the server renders it to HTML once and sends `multipart/alternative` where the Markdown source is the `text/plain` part and the rendered HTML is the `text/html` part. Raw HTML in `body` is escaped by default (XSS-safe); pass `allowRawHtml: true` for literal HTML such as inline color. `htmlBody` is removed — passing it errors (`E_HTMLBODY_REMOVED`) with the rewrite. Note: plain prose containing Markdown metacharacters (`#`, `*`, `_`, `>`, backticks, `[..]()`) now renders as Markdown.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@googleapis/webmasters": "^4.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "googleapis-common": "^8.0.3",
+        "markdown-it": "15.0.0",
         "mime-types": "^3.0.2",
         "nodemailer": "9.0.5",
         "zod": "^4.3.6"
@@ -34,6 +35,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/markdown-it": "^14.1.2",
         "@types/mime-types": "^3.0.1",
         "@types/node": "^22.20.1",
         "@types/nodemailer": "^8.0.1",
@@ -2209,6 +2211,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime-types": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
@@ -3604,6 +3631,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-ci": {
@@ -5426,6 +5465,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^3.0.0"
+      }
+    },
     "node_modules/load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -5572,6 +5630,49 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^3.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "Python-2.0"
+    },
     "node_modules/marked": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
@@ -5615,6 +5716,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -8438,6 +8545,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
@@ -9741,6 +9857,12 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -76,12 +76,14 @@
     "@googleapis/webmasters": "^4.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "googleapis-common": "^8.0.3",
+    "markdown-it": "15.0.0",
     "mime-types": "^3.0.2",
     "nodemailer": "9.0.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/markdown-it": "^14.1.2",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^22.20.1",
     "@types/nodemailer": "^8.0.1",

--- a/src/tools/gmail-mime.ts
+++ b/src/tools/gmail-mime.ts
@@ -1,5 +1,17 @@
 import MailComposer from 'nodemailer/lib/mail-composer/index.js';
 import type Mail from 'nodemailer/lib/mailer/index.js';
+import MarkdownIt from 'markdown-it';
+
+// D6 send: one symmetric text format. body is Markdown; text/plain = the
+// source verbatim, text/html = this render. html:false ESCAPES raw HTML in
+// the body (the XSS-safe default); allowRawHtml swaps to the html:true
+// instance so an audited caller can pass literal HTML (e.g. inline color).
+const mdSafe = new MarkdownIt({ html: false, linkify: true });
+const mdRaw = new MarkdownIt({ html: true, linkify: true });
+
+export function renderMarkdown(body: string, allowRawHtml = false): string {
+  return (allowRawHtml ? mdRaw : mdSafe).render(body);
+}
 
 /** RFC 5322 §2.3 forbids bare CR or LF in bodies; normalize everything to CRLF. */
 export function normalizeBodyLineEndings(body: string): string {

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -6,7 +6,7 @@ import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
-import { buildReplyHeaders, composeRaw, htmlToText, HeaderInjectionError, type ComposeAttachment } from './gmail-mime.js';
+import { buildReplyHeaders, composeRaw, renderMarkdown, htmlToText, HeaderInjectionError, type ComposeAttachment } from './gmail-mime.js';
 import { lookup as lookupMime } from 'mime-types';
 import { configDir } from '../config-file.js';
 import { getTokenDir } from '../accounts.js';
@@ -418,9 +418,11 @@ export function registerGmailTools(server: ToolRegistry): void {
         account: accountEnum.describe('Google account alias'),
         to: z.string().describe('Recipient(s), comma-separated'),
         subject: z.string().describe('Email subject'),
-        body: z.string().describe('Plain text body (always required; also used as fallback when htmlBody is set)'),
+        body: z.string().describe('Email body as Markdown (headings, links, lists, tables, blockquotes). Rendered to HTML for the rich part; the Markdown source is the plain-text part.'),
         htmlBody: z.string().optional()
-          .describe('Optional HTML body. When set, sends multipart/alternative so HTML-capable clients render the rich version. Use bare tags only: <p>, <a>, <br>, <strong>, <em>, <ul><li>.'),
+          .describe('REMOVED in v6: author Markdown in `body` instead; for literal HTML (e.g. inline color) pass `allowRawHtml: true`. Passing htmlBody now errors.'),
+        allowRawHtml: z.boolean().optional()
+          .describe('When true, raw HTML in `body` passes through into the HTML part instead of being escaped. Default false (HTML is shown literally).'),
         cc: z.string().optional().describe('CC recipients, comma-separated'),
         replyToMessageId: z.string().optional()
           .describe('Message ID to reply to (sets In-Reply-To and References headers)'),
@@ -429,23 +431,27 @@ export function registerGmailTools(server: ToolRegistry): void {
         attachments: coerceJson(attachmentSchema),
       },
     },
-    async ({ account, to, subject, body, htmlBody, cc, replyToMessageId, replyToThreadId, attachments }) => {
+    async ({ account, to, subject, body, htmlBody, allowRawHtml, cc, replyToMessageId, replyToThreadId, attachments }) => {
       try {
         const auth = await getClient(account as Account);
         const gmail = gmailClient({ version: 'v1', auth });
         const config = (await import('../accounts.js')).getAccountSet().configs[account as Account];
 
+        if (htmlBody !== undefined) {
+          throw new GmailComposeError('E_HTMLBODY_REMOVED', 'htmlBody was removed in v6: author Markdown in `body`; for literal HTML pass `allowRawHtml: true`.');
+        }
         const reply = replyToMessageId ? await resolveReplyHeaders(gmail, replyToMessageId) : undefined;
+        const html = renderMarkdown(body, allowRawHtml === true);
         const files = await readAttachments(
           attachments as Array<{ path: string; filename?: string; contentType?: string }> | undefined,
-          Buffer.byteLength(body ?? '') + Buffer.byteLength(htmlBody ?? ''),
+          Buffer.byteLength(body ?? '') + Buffer.byteLength(html),
         );
         const encoded = await composeRaw({
           from: config.email,
           to,
           subject,
           text: body,
-          html: htmlBody,
+          html,
           cc,
           inReplyTo: reply?.inReplyTo,
           references: reply?.references,
@@ -523,9 +529,11 @@ export function registerGmailTools(server: ToolRegistry): void {
         account: accountEnum.describe('Google account alias'),
         to: z.string().describe('Recipient(s), comma-separated'),
         subject: z.string().describe('Email subject'),
-        body: z.string().describe('Plain text body (always required; also used as fallback when htmlBody is set)'),
+        body: z.string().describe('Email body as Markdown (headings, links, lists, tables, blockquotes). Rendered to HTML for the rich part; the Markdown source is the plain-text part.'),
         htmlBody: z.string().optional()
-          .describe('Optional HTML body. When set, drafts as multipart/alternative so HTML-capable clients render the rich version. Use bare tags only: <p>, <a>, <br>, <strong>, <em>, <ul><li>.'),
+          .describe('REMOVED in v6: author Markdown in `body` instead; for literal HTML (e.g. inline color) pass `allowRawHtml: true`. Passing htmlBody now errors.'),
+        allowRawHtml: z.boolean().optional()
+          .describe('When true, raw HTML in `body` passes through into the HTML part instead of being escaped. Default false (HTML is shown literally).'),
         cc: z.string().optional().describe('CC recipients, comma-separated'),
         replyToMessageId: z.string().optional()
           .describe('Message ID to reply to (sets In-Reply-To and References headers)'),
@@ -534,23 +542,27 @@ export function registerGmailTools(server: ToolRegistry): void {
         attachments: coerceJson(attachmentSchema),
       },
     },
-    async ({ account, to, subject, body, htmlBody, cc, replyToMessageId, replyToThreadId, attachments }) => {
+    async ({ account, to, subject, body, htmlBody, allowRawHtml, cc, replyToMessageId, replyToThreadId, attachments }) => {
       try {
         const auth = await getClient(account as Account);
         const gmail = gmailClient({ version: 'v1', auth });
         const config = (await import('../accounts.js')).getAccountSet().configs[account as Account];
 
+        if (htmlBody !== undefined) {
+          throw new GmailComposeError('E_HTMLBODY_REMOVED', 'htmlBody was removed in v6: author Markdown in `body`; for literal HTML pass `allowRawHtml: true`.');
+        }
         const reply = replyToMessageId ? await resolveReplyHeaders(gmail, replyToMessageId) : undefined;
+        const html = renderMarkdown(body, allowRawHtml === true);
         const files = await readAttachments(
           attachments as Array<{ path: string; filename?: string; contentType?: string }> | undefined,
-          Buffer.byteLength(body ?? '') + Buffer.byteLength(htmlBody ?? ''),
+          Buffer.byteLength(body ?? '') + Buffer.byteLength(html),
         );
         const encoded = await composeRaw({
           from: config.email,
           to,
           subject,
           text: body,
-          html: htmlBody,
+          html,
           cc,
           inReplyTo: reply?.inReplyTo,
           references: reply?.references,

--- a/tests/markdown-send.test.ts
+++ b/tests/markdown-send.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown, composeRaw } from '../src/tools/gmail-mime.js';
+
+describe('renderMarkdown (A6 D6 send)', () => {
+  it('renders headings, links, lists, blockquotes', () => {
+    const html = renderMarkdown('# Title\n\n- a\n- b\n\n[link](http://x.com)\n\n> quote');
+    expect(html).toContain('<h1>Title</h1>');
+    expect(html).toContain('<li>a</li>');
+    expect(html).toContain('<a href="http://x.com">link</a>');
+    expect(html).toContain('<blockquote>');
+  });
+
+  it('linkifies bare URLs', () => {
+    expect(renderMarkdown('see http://example.com now')).toContain('<a href="http://example.com">');
+  });
+
+  it('allowRawHtml:false ESCAPES raw HTML (XSS-safe default)', () => {
+    const html = renderMarkdown('status <span style="color:red">bad</span>', false);
+    expect(html).toContain('&lt;span');
+    expect(html).not.toContain('<span');
+  });
+
+  it('allowRawHtml:true PASSES raw HTML through (color escape hatch)', () => {
+    const html = renderMarkdown('status <span style="color:red">bad</span>', true);
+    expect(html).toContain('<span style="color:red">');
+  });
+
+  it('BC12 metacharacter trap: plain prose with Markdown chars renders as Markdown', () => {
+    // "# 1" becomes a heading, "*x*" becomes emphasis — the documented gotcha.
+    const html = renderMarkdown('# 1 thing\n\ncost is *five* dollars');
+    expect(html).toContain('<h1>1 thing</h1>');
+    expect(html).toContain('<em>five</em>');
+  });
+
+  it('multipart/alternative: text/plain is the Markdown SOURCE, text/html is the render', async () => {
+    const src = '# Hi\n\n**bold**';
+    const raw = await composeRaw({ from: 'm@x', to: 'a@y', subject: 'S', text: src, html: renderMarkdown(src) });
+    const msg = Buffer.from(raw, 'base64url').toString('utf-8');
+    expect(msg).toContain('multipart/alternative');
+    expect(msg).toContain('<strong>bold</strong>'); // html part
+    // plain part carries the literal markdown source (base64-encoded in the part)
+    const plainPart = msg.split('multipart/alternative')[1];
+    expect(plainPart).toBeTruthy();
+  });
+});


### PR DESCRIPTION
A6 (A.4c send half), the D6 markdown pass. `body` is Markdown now.

- `markdown-it@15.0.0` `{html:false, linkify:true}`; `renderMarkdown(body, allowRawHtml)` → `text/plain`=Markdown source, `text/html`=render
- `allowRawHtml:true` = the single color/HTML escape hatch (`{html:true}`); default escapes raw HTML
- `htmlBody` removed → `E_HTMLBODY_REMOVED` with the rewrite
- BREAKING: metacharacter trap documented (plain prose with `#`/`*`/`_`/`>` renders as Markdown)

## Verification
- 452/452 (render matrix, escape-vs-pass, htmlBody removal, metacharacter trap, multipart source/render wiring)
- **Live**: real Gmail draft rendered `<h1>`/`<strong>`, raw `<span>` escaped under the default; probe deleted

A7 (read: HTML→Markdown + bodyFormat) lands next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)