### PR TITLE
feat(gmail): Markdown email read (A7/D6) — HTML→Markdown + bodyFormat

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -51,3 +51,14 @@ Tool responses are serialized compactly (no pretty-print token tax; set `GOOGLE_
 ### Markdown email (send)
 
 `gmail_send` / `gmail_create_draft` take `body` as **Markdown**: the server renders it to HTML once and sends `multipart/alternative` where the Markdown source is the `text/plain` part and the rendered HTML is the `text/html` part. Raw HTML in `body` is escaped by default (XSS-safe); pass `allowRawHtml: true` for literal HTML such as inline color. `htmlBody` is removed — passing it errors (`E_HTMLBODY_REMOVED`) with the rewrite. Note: plain prose containing Markdown metacharacters (`#`, `*`, `_`, `>`, backticks, `[..]()`) now renders as Markdown.
+
+
+### Markdown email (read)
+
+`gmail_read` / `gmail_read_thread` return a `bodyFormat` discriminator on every message so the model knows how to read `body`:
+
+- `plain` — a `text/plain` part existed (or the message had no body). `body` is that part verbatim, byte-identical to v5. Plain parts always win over an HTML alternative.
+- `markdown` — the message was **HTML-only**; the server converts it to Markdown (headings, links, lists, GFM tables/strikethrough) so structure survives instead of collapsing to a flat text dump. The 50k body cap applies to the converted Markdown, not the source HTML.
+- `html` — you passed `rawHtml: true` and the message was HTML-only; `body` is the unconverted source HTML.
+
+Script/style/head content is dropped during conversion (never leaked into `body`); if conversion fails the server falls back to plain-text extraction and reports `bodyFormat: 'plain'`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "markdown-it": "15.0.0",
         "mime-types": "^3.0.2",
         "nodemailer": "9.0.5",
+        "turndown": "7.2.4",
+        "turndown-plugin-gfm": "1.0.2",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -39,6 +41,7 @@
         "@types/mime-types": "^3.0.1",
         "@types/node": "^22.20.1",
         "@types/nodemailer": "^8.0.1",
+        "@types/turndown": "^5.0.6",
         "eslint": "^10.2.1",
         "semantic-release": "^25.0.3",
         "tsx": "^4.23.1",
@@ -1031,6 +1034,12 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.30.0",
@@ -2267,6 +2276,13 @@
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/turndown": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/turndown/-/turndown-5.0.6.tgz",
+      "integrity": "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9761,6 +9777,25 @@
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
+    },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "markdown-it": "15.0.0",
     "mime-types": "^3.0.2",
     "nodemailer": "9.0.5",
+    "turndown": "7.2.4",
+    "turndown-plugin-gfm": "1.0.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -87,6 +89,7 @@
     "@types/mime-types": "^3.0.1",
     "@types/node": "^22.20.1",
     "@types/nodemailer": "^8.0.1",
+    "@types/turndown": "^5.0.6",
     "eslint": "^10.2.1",
     "semantic-release": "^25.0.3",
     "tsx": "^4.23.1",

--- a/src/tools/gmail-mime.ts
+++ b/src/tools/gmail-mime.ts
@@ -1,6 +1,10 @@
 import MailComposer from 'nodemailer/lib/mail-composer/index.js';
 import type Mail from 'nodemailer/lib/mailer/index.js';
 import MarkdownIt from 'markdown-it';
+import TurndownService from 'turndown';
+// @ts-expect-error turndown-plugin-gfm ships no type declarations
+import { gfm } from 'turndown-plugin-gfm';
+import type { Plugin } from 'turndown';
 
 // D6 send: one symmetric text format. body is Markdown; text/plain = the
 // source verbatim, text/html = this render. html:false ESCAPES raw HTML in
@@ -99,6 +103,24 @@ export function htmlToText(html: string): string {
     .replace(/[ \t]*\n[ \t]*/g, '\n')
     .replace(/\n{3,}/g, '\n\n')
     .trim();
+}
+
+// D6 read: HTML-only bodies convert to Markdown so the model reads structure
+// (headings, links, lists, GFM tables), not a flat text dump. turndown's
+// bundled @mixmark-io/domino fork does NOT execute scripts; remove() drops
+// script/style/head entirely (turndown otherwise leaks their text content).
+const turndownService = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced', bulletListMarker: '-' });
+turndownService.use(gfm as Plugin);
+turndownService.remove(['script', 'style', 'head']);
+
+/** Convert HTML to Markdown; on any turndown failure fall back to the
+ * plain-text extractor (caller then reports bodyFormat 'plain', not 'markdown'). */
+export function htmlToMarkdown(html: string): { text: string; ok: boolean } {
+  try {
+    return { text: turndownService.turndown(html), ok: true };
+  } catch {
+    return { text: htmlToText(html), ok: false };
+  }
 }
 
 /** In-Reply-To/References need the parent's real RFC 5322 Message-ID header, not the Gmail API id;

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -6,7 +6,7 @@ import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
-import { buildReplyHeaders, composeRaw, renderMarkdown, htmlToText, HeaderInjectionError, type ComposeAttachment } from './gmail-mime.js';
+import { buildReplyHeaders, composeRaw, renderMarkdown, htmlToMarkdown, HeaderInjectionError, type ComposeAttachment } from './gmail-mime.js';
 import { lookup as lookupMime } from 'mime-types';
 import { configDir } from '../config-file.js';
 import { getTokenDir } from '../accounts.js';
@@ -42,18 +42,22 @@ function collectTextParts(part: any, plain: string[], html: string[], topLevel =
 function decodeBody(
   payload: any,
   rawHtml = false,
-): { body: string; bodyOrigin?: 'text/plain' | 'text/html' } {
+): { body: string; bodyFormat: 'plain' | 'markdown' | 'html' } {
   const plain: string[] = [];
   const html: string[] = [];
   collectTextParts(payload, plain, html, true);
   // Concatenating every plain leaf keeps forwarded/mixed messages whole;
   // any plain content beats HTML because alternatives duplicate the same body.
-  if (plain.length > 0) return { body: plain.join('\n\n'), bodyOrigin: 'text/plain' };
+  // A plain leaf is returned verbatim (byte-identical to v5).
+  if (plain.length > 0) return { body: plain.join('\n\n'), bodyFormat: 'plain' };
   if (html.length > 0) {
     const joined = html.join('\n\n');
-    return { body: rawHtml ? joined : htmlToText(joined), bodyOrigin: 'text/html' };
+    if (rawHtml) return { body: joined, bodyFormat: 'html' };
+    // HTML-only -> Markdown (D6). turndown failure degrades to plain text.
+    const { text, ok } = htmlToMarkdown(joined);
+    return { body: text, bodyFormat: ok ? 'markdown' : 'plain' };
   }
-  return { body: '' };
+  return { body: '', bodyFormat: 'plain' };
 }
 
 function getAttachments(payload: any): GmailAttachment[] {
@@ -233,7 +237,7 @@ export function parseMessage(
   opts?: { rawHtml?: boolean },
 ): GmailMessageFull {
   const headers = msg.payload?.headers ?? [];
-  const { body, bodyOrigin } = decodeBody(msg.payload, opts?.rawHtml === true);
+  const { body, bodyFormat } = decodeBody(msg.payload, opts?.rawHtml === true);
   const capped = bodyCap !== undefined && body.length > bodyCap;
   const messageIdHeader = getHeader(headers, 'Message-ID');
   const inReplyTo = getHeader(headers, 'In-Reply-To');
@@ -247,7 +251,7 @@ export function parseMessage(
     cc: getHeader(headers, 'Cc'),
     date: getHeader(headers, 'Date'),
     body: capped ? sliceClean(body, bodyCap) : body,
-    ...(bodyOrigin ? { bodyOrigin } : {}),
+    bodyFormat,
     ...(capped ? { bodyTruncated: true, bodyTotalChars: body.length } : {}),
     ...(messageIdHeader ? { messageIdHeader } : {}),
     ...(inReplyTo ? { inReplyTo } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface GmailMessageFull {
   cc: string;
   date: string;
   body: string;
-  bodyOrigin?: 'text/plain' | 'text/html';
+  bodyFormat: 'plain' | 'markdown' | 'html';
   bodyTruncated?: boolean;
   bodyTotalChars?: number;
   messageIdHeader?: string;

--- a/tests/gmail-read.test.ts
+++ b/tests/gmail-read.test.ts
@@ -30,7 +30,7 @@ describe('parseMessage body selection', () => {
     };
     const out = parseMessage(msg(payload));
     expect(out.body).toBe('plain version');
-    expect(out.bodyOrigin).toBe('text/plain');
+    expect(out.bodyFormat).toBe('plain');
   });
 
   it('prefers text/plain in a classic multipart/alternative', () => {
@@ -43,7 +43,7 @@ describe('parseMessage body selection', () => {
     };
     const out = parseMessage(msg(payload));
     expect(out.body).toBe('plain');
-    expect(out.bodyOrigin).toBe('text/plain');
+    expect(out.bodyFormat).toBe('plain');
   });
 
   it('concatenates sequential text/plain parts of the same container', () => {
@@ -56,13 +56,13 @@ describe('parseMessage body selection', () => {
     };
     const out = parseMessage(msg(payload));
     expect(out.body).toBe('intro\n\nforwarded body');
-    expect(out.bodyOrigin).toBe('text/plain');
+    expect(out.bodyFormat).toBe('plain');
   });
 
-  it('converts an HTML-only message to plain text', () => {
+  it('converts an HTML-only message to Markdown (D6)', () => {
     const out = parseMessage(msg(textPart('text/html', '<p>Hello <strong>world</strong></p>')));
-    expect(out.body).toBe('Hello world');
-    expect(out.bodyOrigin).toBe('text/html');
+    expect(out.body).toBe('Hello **world**');
+    expect(out.bodyFormat).toBe('markdown');
   });
 
   it('concatenates multiple HTML parts before converting', () => {
@@ -75,13 +75,13 @@ describe('parseMessage body selection', () => {
     };
     const out = parseMessage(msg(payload));
     expect(out.body).toBe('one\n\ntwo');
-    expect(out.bodyOrigin).toBe('text/html');
+    expect(out.bodyFormat).toBe('markdown');
   });
 
   it('returns the raw HTML body when rawHtml is set', () => {
     const out = parseMessage(msg(textPart('text/html', '<p>Hi</p>')), undefined, { rawHtml: true });
     expect(out.body).toBe('<p>Hi</p>');
-    expect(out.bodyOrigin).toBe('text/html');
+    expect(out.bodyFormat).toBe('html');
   });
 
   it('still prefers text/plain when rawHtml is set', () => {
@@ -94,10 +94,10 @@ describe('parseMessage body selection', () => {
     };
     const out = parseMessage(msg(payload), undefined, { rawHtml: true });
     expect(out.body).toBe('plain');
-    expect(out.bodyOrigin).toBe('text/plain');
+    expect(out.bodyFormat).toBe('plain');
   });
 
-  it('applies the body cap to the converted text, not the raw HTML', () => {
+  it('applies the body cap to the converted Markdown, not the raw HTML', () => {
     const html = `<p>${'a'.repeat(40)}</p>`.repeat(3);
     const converted = [`${'a'.repeat(40)}`, `${'a'.repeat(40)}`, `${'a'.repeat(40)}`].join('\n\n');
     expect(html.length).toBeGreaterThan(130);
@@ -112,10 +112,10 @@ describe('parseMessage body selection', () => {
     expect(capped.bodyTotalChars).toBe(converted.length);
   });
 
-  it('omits bodyOrigin when the message has no body', () => {
+  it("reports bodyFormat 'plain' for a message with no body (total discriminator)", () => {
     const out = parseMessage(msg({ mimeType: 'multipart/mixed', parts: [] }));
     expect(out.body).toBe('');
-    expect(out.bodyOrigin).toBeUndefined();
+    expect(out.bodyFormat).toBe('plain');
   });
 });
 

--- a/tests/markdown-read.test.ts
+++ b/tests/markdown-read.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { htmlToMarkdown } from '../src/tools/gmail-mime.js';
+
+// D6 read: the HTML->Markdown converter behind gmail read's `markdown`
+// bodyFormat. The parseMessage-level discriminator matrix (plain/markdown/html)
+// lives in gmail-read.test.ts; this suite pins the converter's own contract.
+describe('htmlToMarkdown (A7 D6 read)', () => {
+  it('converts headings, links, and lists to Markdown', () => {
+    const { text, ok } = htmlToMarkdown(
+      '<h1>Title</h1><p>see <a href="http://x.com">link</a></p><ul><li>a</li></ul>',
+    );
+    expect(ok).toBe(true);
+    expect(text).toContain('# Title');
+    expect(text).toContain('[link](http://x.com)');
+    expect(text).toContain('-   a');
+  });
+
+  it('emits GFM tables via the plugin', () => {
+    const { text, ok } = htmlToMarkdown(
+      '<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>',
+    );
+    expect(ok).toBe(true);
+    expect(text).toContain('| A | B |');
+    expect(text).toContain('| --- | --- |');
+    expect(text).toContain('| 1 | 2 |');
+  });
+
+  it('strips script/style/head content (never leaks JS/CSS into the body)', () => {
+    const { text } = htmlToMarkdown(
+      '<head><title>t</title></head><p>hi</p><script>evil()</script><style>x{color:red}</style>',
+    );
+    expect(text).toContain('hi');
+    expect(text).not.toContain('evil()');
+    expect(text).not.toContain('color:red');
+  });
+
+  it('preserves GFM strikethrough from the plugin', () => {
+    const { text } = htmlToMarkdown('<p><del>gone</del></p>');
+    expect(text).toContain('~gone~');
+  });
+});


### PR DESCRIPTION
## A7 / D6 — email read side

Completes the D6 Markdown email pair (send landed in #153). `gmail_read` / `gmail_read_thread` now return a **`bodyFormat`** discriminator on every message so the model knows how to read `body`:

- **`plain`** — a `text/plain` part existed (or no body). `body` is that part verbatim, byte-identical to v5. Plain always beats an HTML alternative.
- **`markdown`** — the message was **HTML-only**; converted via turndown + GFM (headings, links, lists, tables, strikethrough). The 50k cap applies to the converted Markdown, not the source HTML.
- **`html`** — `rawHtml: true` on an HTML-only message; `body` is the unconverted source HTML.

Safety: `script` / `style` / `head` content is dropped during conversion (never leaks into `body`); turndown failure degrades to plain-text extraction and reports `bodyFormat: 'plain'`.

### Contract change
`bodyOrigin?: 'text/plain'|'text/html'` → **`bodyFormat: 'plain'|'markdown'|'html'`** (now a total, always-present discriminator, including empty-body → `'plain'`).

### Tests
- `tests/markdown-read.test.ts` — htmlToMarkdown unit suite (headings/links/lists, GFM table, GFM strikethrough, script/style/head strip).
- `tests/gmail-read.test.ts` — updated to the new `bodyFormat` contract + Markdown outputs; full discriminator matrix (plain wins / html-only → markdown / rawHtml → html / empty → plain).
- 456 tests green; typecheck + lint + build clean.

### Live smoke
Ran the built `parseMessage` on a real HTML-only GitHub release notification: produced clean Markdown (H1/links/list, `&middot;`/`&mdash;` decoded), the embedded `<script type="application/ld+json">` block fully stripped, and `rawHtml:true` → `bodyFormat 'html'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)