### PR TITLE
feat(gmail): gmail_read_batch (A9/A.4d)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -40,6 +40,7 @@ Tool responses are serialized compactly (no pretty-print token tax; set `GOOGLE_
 
 - `drive_read` returns up to `maxChars` characters (default 100k) with `truncated`/`totalChars`/`offset` for paging — this also bounds Google Doc exports, which can reach 10MB. (Non-Google-native files over 2MB are still rejected with `too_large`, not paged.)
 - `gmail_read` / `gmail_read_thread` cap each message body at 50k chars (`bodyTruncated` + `bodyTotalChars` flags); pass `full: true` for the whole body.
+- `gmail_read_batch` reads up to 100 message ids in one call (collapsing the search→read triage loop): one ordered entry per id (`{ id, ...message }` or `{ id, error }`) plus a trailing `{ counts: { ok, failed }, truncated? }` summary. A single failed id does not fail the batch (auth/scope failures do); per-message bodies are capped at 50k (unless `full: true`) and the aggregate output is bounded so a large batch never blows the context window.
 - `calendar_list_events` / `calendar_list_instances` trim descriptions to ~300 chars and drop empty/audit fields in list view; `calendar_get_event` always returns the full event.
 
 

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -5,7 +5,7 @@ import { gmail as gmailClient } from '@googleapis/gmail';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
-import { handleGoogleApiError } from './_errors.js';
+import { handleGoogleApiError, mapGoogleError } from './_errors.js';
 import { buildReplyHeaders, composeRaw, renderMarkdown, htmlToMarkdown, HeaderInjectionError, type ComposeAttachment } from './gmail-mime.js';
 import addressparser from 'nodemailer/lib/addressparser/index.js';
 import { lookup as lookupMime } from 'mime-types';
@@ -213,6 +213,11 @@ export async function resolveReply(
 }
 
 const BODY_CAP_CHARS = 50_000;
+// gmail_read_batch aggregate ceiling: a batch of up to 100 messages must never
+// blow the context window, so the summed serialized output is bounded here
+// (matches the tool's anthropic/maxResultSizeChars hint). Per-message bodies are
+// still individually capped at BODY_CAP_CHARS first.
+const BATCH_MAX_RESULT_CHARS = 100_000;
 // Gmail's messages.send raw/JSON path rejects messages near ~25 MB (the wire
 // message is base64-encoded, ~+33% over the raw bytes), so cap the ESTIMATED
 // ENCODED total there rather than the spec's nominal 35 MB raw (spike/live
@@ -371,6 +376,102 @@ export function parseMessage(
   };
 }
 
+/**
+ * A9 gmail_read_batch core: fetch N ids with bounded parallelism, parse each,
+ * and bound the aggregate output. Order is preserved by input index. A per-id
+ * failure becomes a `{ id, error }` entry; an account-wide auth/scope failure
+ * is rethrown so the caller maps it to a whole-call isError. Returns the
+ * ordered per-id entries followed by a trailing counts summary.
+ */
+export async function readBatch(
+  gmail: any,
+  account: Account,
+  ids: string[],
+  full: boolean,
+  rawHtml: boolean,
+): Promise<any[]> {
+  if (ids.length === 0) {
+    throw new GmailComposeError('validation_error', '`ids` must be a non-empty array of 1..100 message IDs.');
+  }
+  if (ids.length > 100) {
+    throw new GmailComposeError('validation_error', `\`ids\` accepts at most 100 message IDs per call (got ${ids.length}).`);
+  }
+
+  const cap = full ? undefined : BODY_CAP_CHARS;
+  const CHUNK_SIZE = 10;
+  const entries: any[] = new Array(ids.length);
+  let ok = 0;
+  let failed = 0;
+
+  for (let i = 0; i < ids.length; i += CHUNK_SIZE) {
+    const slice = ids.slice(i, i + CHUNK_SIZE);
+    const settled = await Promise.all(slice.map(async (id, j) => {
+      try {
+        const res = await gmail.users.messages.get({ userId: 'me', id, format: 'full' });
+        return { idx: i + j, id, ok: true as const, data: res.data };
+      } catch (err: any) {
+        return { idx: i + j, id, ok: false as const, err };
+      }
+    }));
+    for (const s of settled) {
+      if (s.ok) {
+        entries[s.idx] = parseMessage(s.data, cap, { rawHtml });
+        ok++;
+      } else {
+        const env = mapGoogleError(s.err, account);
+        // Auth/scope problems are account-wide, not id-specific: fail the whole
+        // batch rather than emit N identical per-item errors.
+        if (env.error === 'auth_required' || env.error === 'insufficient_scope' || env.error === 'invalid_scope') {
+          throw s.err;
+        }
+        const { account: _dropped, ...itemError } = env;
+        entries[s.idx] = { id: s.id, error: itemError };
+        failed++;
+      }
+    }
+  }
+
+  // Aggregate guard: walk in order, accumulating serialized size. Once the
+  // running total would exceed the maxResultSizeChars budget, cap this and every
+  // later success body so a big batch never blows the context window.
+  let running = 0;
+  let truncatedAny = false;
+  let exhausted = false;
+  for (const e of entries) {
+    if (!e || e.error) {
+      running += JSON.stringify(e ?? {}).length;
+      continue;
+    }
+    const body: string = e.body ?? '';
+    if (exhausted) {
+      if (body.length > 0) {
+        if (!e.bodyTruncated) e.bodyTotalChars = body.length;
+        e.body = '';
+        e.bodyTruncated = true;
+        truncatedAny = true;
+      }
+      running += JSON.stringify(e).length;
+      continue;
+    }
+    const serialized = JSON.stringify(e).length;
+    if (running + serialized > BATCH_MAX_RESULT_CHARS) {
+      const envelope = serialized - body.length; // non-body overhead of this entry
+      const remaining = Math.max(0, BATCH_MAX_RESULT_CHARS - running - envelope);
+      if (!e.bodyTruncated) e.bodyTotalChars = body.length;
+      e.body = sliceClean(body, Math.min(body.length, remaining));
+      e.bodyTruncated = true;
+      truncatedAny = true;
+      exhausted = true;
+      running += JSON.stringify(e).length;
+    } else {
+      running += serialized;
+    }
+  }
+
+  const summary = { counts: { ok, failed }, ...(truncatedAny ? { truncated: true } : {}) };
+  return [...entries, summary];
+}
+
 export function registerGmailTools(server: ToolRegistry): void {
   server.registerTool(
     'gmail_search',
@@ -516,6 +617,34 @@ export function registerGmailTools(server: ToolRegistry): void {
         const messages = (res.data.messages ?? []).map((m) => parseMessage(m, full ? undefined : BODY_CAP_CHARS, { rawHtml }));
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(messages, null, 2) }],
+        };
+      } catch (error: any) {
+        const mapped = composeErrorResult(error, account as Account);
+        return mapped ?? handleGmailError(error, account as Account);
+      }
+    },
+  );
+  server.registerTool(
+    'gmail_read_batch',
+    {
+      _meta: { 'anthropic/maxResultSizeChars': BATCH_MAX_RESULT_CHARS },
+      annotations: { readOnlyHint: true, openWorldHint: true },
+      description: 'Read many Gmail messages by ID in one call, collapsing the search→read triage loop. Bodies are capped at 50k chars each (unless full=true) and the aggregate output is bounded. Returns one ordered entry per id plus a trailing counts summary; a single failed id does NOT fail the batch.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        ids: coerceArray(z.string()).describe('Gmail message IDs to read (1..100). Comma-separated string or JSON array.'),
+        full: coerceBoolean.optional().describe('Return entire bodies without the per-message 50k character cap'),
+        rawHtml: coerceBoolean.optional()
+          .describe('Return HTML bodies unconverted instead of the plain-text rendering (HTML-only messages)'),
+      },
+    },
+    async ({ account, ids, full, rawHtml }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const gmail = gmailClient({ version: 'v1', auth });
+        const result = await readBatch(gmail, account as Account, (ids as string[]) ?? [], full === true, rawHtml === true);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
         };
       } catch (error: any) {
         const mapped = composeErrorResult(error, account as Account);

--- a/tests/read-batch.test.ts
+++ b/tests/read-batch.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { readBatch } from '../src/tools/gmail.js';
+
+const b64 = (s: string) => Buffer.from(s, 'utf-8').toString('base64url');
+
+// A plain-text message payload parseMessage understands.
+function plainMsg(id: string, subject: string, body: string) {
+  return {
+    id,
+    threadId: `t-${id}`,
+    payload: {
+      headers: [{ name: 'Subject', value: subject }, { name: 'From', value: `${id}@x.com` }],
+      mimeType: 'text/plain',
+      body: { data: b64(body) },
+    },
+  };
+}
+
+const httpError = (code: number) => Object.assign(new Error(`HTTP ${code}`), { code });
+
+// Fake Gmail: messages.get resolves/rejects per an id→behavior map.
+function fakeGmail(byId: Record<string, { data?: any; throw?: any }>) {
+  return {
+    users: {
+      messages: {
+        get: async ({ id }: { id: string }) => {
+          const b = byId[id];
+          if (!b) throw httpError(404);
+          if (b.throw) throw b.throw;
+          return { data: b.data };
+        },
+      },
+    },
+  };
+}
+
+describe('readBatch (A9 gmail_read_batch core)', () => {
+  it('reads N ids in order, appends a counts summary', async () => {
+    const g = fakeGmail({
+      a: { data: plainMsg('a', 'SA', 'body a') },
+      b: { data: plainMsg('b', 'SB', 'body b') },
+      c: { data: plainMsg('c', 'SC', 'body c') },
+    });
+    const out = await readBatch(g, 'acct', ['a', 'b', 'c'], false, false);
+    expect(out).toHaveLength(4); // 3 messages + summary
+    expect(out.slice(0, 3).map((e) => e.id)).toEqual(['a', 'b', 'c']);
+    expect(out[0].subject).toBe('SA');
+    expect(out[0].body).toBe('body a');
+    expect(out[3]).toEqual({ counts: { ok: 3, failed: 0 } });
+  });
+
+  it('caps each body at 50k (per-message BODY_CAP_CHARS)', async () => {
+    const big = 'a'.repeat(60_000);
+    const g = fakeGmail({ x: { data: plainMsg('x', 'S', big) } });
+    const out = await readBatch(g, 'acct', ['x'], false, false);
+    expect(out[0].body.length).toBeLessThanOrEqual(50_000);
+    expect(out[0].bodyTruncated).toBe(true);
+    expect(out[0].bodyTotalChars).toBe(60_000);
+  });
+
+  it('full=true removes the per-message cap', async () => {
+    const big = 'a'.repeat(60_000);
+    const g = fakeGmail({ x: { data: plainMsg('x', 'S', big) } });
+    const out = await readBatch(g, 'acct', ['x'], true, false);
+    expect(out[0].body.length).toBe(60_000);
+    expect(out[0].bodyTruncated).toBeUndefined();
+  });
+
+  it('a single failed id becomes a per-item error; the batch still succeeds', async () => {
+    const g = fakeGmail({
+      ok1: { data: plainMsg('ok1', 'S1', 'one') },
+      bad: { throw: httpError(404) },
+      ok2: { data: plainMsg('ok2', 'S2', 'two') },
+    });
+    const out = await readBatch(g, 'acct', ['ok1', 'bad', 'ok2'], false, false);
+    expect(out[0].subject).toBe('S1');
+    expect(out[1]).toMatchObject({ id: 'bad', error: { error: 'not_found', retriable: false } });
+    expect(out[1].error).not.toHaveProperty('account'); // account stripped from per-item envelope
+    expect(out[2].subject).toBe('S2');
+    expect(out[3]).toEqual({ counts: { ok: 2, failed: 1 } });
+  });
+
+  it('marks 429 per-item as retriable, batch stays ok', async () => {
+    const g = fakeGmail({
+      a: { data: plainMsg('a', 'S', 'x') },
+      b: { throw: httpError(429) },
+    });
+    const out = await readBatch(g, 'acct', ['a', 'b'], false, false);
+    expect(out[1].error).toMatchObject({ error: 'rate_limited', retriable: true });
+    expect(out[2]).toEqual({ counts: { ok: 1, failed: 1 } });
+  });
+
+  it('aggregate guard caps later bodies and flags truncated in the summary', async () => {
+    const body = 'a'.repeat(45_000); // each < 50k per-message cap; 3 sum > 100k aggregate
+    const g = fakeGmail({
+      a: { data: plainMsg('a', 'S', body) },
+      b: { data: plainMsg('b', 'S', body) },
+      c: { data: plainMsg('c', 'S', body) },
+    });
+    const out = await readBatch(g, 'acct', ['a', 'b', 'c'], false, false);
+    expect(out[0].bodyTruncated).toBeUndefined(); // first fits
+    const summary = out[3];
+    expect(summary.truncated).toBe(true);
+    // the last entry is capped by the aggregate budget
+    expect(out[2].bodyTruncated).toBe(true);
+    const totalChars = out.slice(0, 3).reduce((n, e) => n + (e.body?.length ?? 0), 0);
+    expect(totalChars).toBeLessThanOrEqual(100_000);
+  });
+
+  it('account-wide auth failure rejects the whole call (not per-item)', async () => {
+    const g = fakeGmail({ x: { throw: httpError(401) } });
+    await expect(readBatch(g, 'acct', ['x'], false, false)).rejects.toBeTruthy();
+  });
+
+  it('empty ids is a validation error', async () => {
+    const g = fakeGmail({});
+    await expect(readBatch(g, 'acct', [], false, false)).rejects.toMatchObject({ slug: 'validation_error' });
+  });
+
+  it('>100 ids is a validation error', async () => {
+    const g = fakeGmail({});
+    const many = Array.from({ length: 101 }, (_, i) => `id${i}`);
+    await expect(readBatch(g, 'acct', many, false, false)).rejects.toMatchObject({ slug: 'validation_error' });
+  });
+});


### PR DESCRIPTION
## A9 / A.4d — `gmail_read_batch`

Second A.4d convenience. New **read-only** tool that reads up to **100 message ids in one call**, collapsing the `gmail_search` → N × `gmail_read` triage loop.

### Shape
Ordered array, one entry per input id, plus a trailing summary:
- `{ id, ...message }` — id read OK (reuses `parseMessage`, so `bodyFormat` and all read semantics carry over).
- `{ id, error: { error, message, retriable, ... } }` — that id failed; standard taxonomy envelope **minus** `account`.
- trailing `{ counts: { ok, failed }, truncated? }`.

### Semantics
- **Partial failure is not batch failure:** a single 404/429 id becomes a per-item entry (`isError` absent); 429s are marked `retriable:true` so the agent can re-issue just the failed ids. **Account-wide** auth/scope failures (401 / `insufficient_scope` / `invalid_scope`) fail the whole call.
- **Bounded parallelism** (`CHUNK_SIZE=10`), input order preserved by index.
- **Two-level size control:** each body keeps the 50k `BODY_CAP_CHARS` (unless `full:true`); an **aggregate guard** bounds the summed serialized output at `BATCH_MAX_RESULT_CHARS` (100k) — once exceeded, later bodies are capped (`bodyTruncated:true`) and the summary carries `truncated:true`, so a big batch never blows the context window.
- Annotations: `readOnlyHint:true`, `openWorldHint:true`, `anthropic/maxResultSizeChars`. `cud=read` (verified via `inferCud`) — ungated by write-control.

### Tests / verification
- `tests/read-batch.test.ts` — 9 tests: order + summary, per-message 50k cap, `full` uncaps, per-item 404 error (account stripped) with batch still ok, 429 retriable, aggregate cap + `truncated`, account-wide auth rethrow, empty / >100 `ids` validation.
- 472 tests green; typecheck + lint + build clean.
- Note: `readBatch`'s fetch+parse path is identical to `gmail_read` (already live-verified on real Gmail data in A7); the batch orchestration on top is what the unit tests exercise. A bare-node live smoke against real auth was skipped — the token/scope env differs from the live MCP wrapper and reproducing it is out of scope for this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)