### PR TITLE
feat(contacts): contacts_resolve — name → canonical email (A10/A.4d)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -75,3 +75,8 @@ Set `replyToMessageId` on `gmail_send` / `gmail_create_draft` and the server der
 - `In-Reply-To` / `References` threading headers as before.
 
 Any value you pass explicitly wins over the derived one (`to`, `cc`, `subject` are now optional when `replyToMessageId` is set). If the source can't be fetched: with a caller `to`, the send proceeds with threading degraded to the message id; without a `to`, the call fails `not_found` rather than sending to nobody. A failed send-as lookup degrades the own-address set to your primary and never blocks the send.
+
+
+### Contact resolver
+
+`contacts_resolve` turns a free-text name into **one canonical email**, so an agent stops hand-expanding transliterations (`Rym OR Rim OR Reem`) into `contacts_search` OR-queries. It searches saved contacts (and, by default, auto-saved "other contacts" you've emailed) and applies a deterministic tie-break: exact name (accent-folded) over prefix, saved over other-contact, primary/`work` email over the rest, fuller record over bare. It returns one confident `{ resolved: { name, email, resourceName, source } }`, an explicit `{ ambiguous: true, candidates: [...] }` when a real tie survives, or `{ resolved: null }` for no match (never an error). A missing "other contacts" scope degrades to saved contacts only.

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -64,6 +64,8 @@ interface ToolConfig {
 const CUD_OVERRIDES: Record<string, Cud> = {
   drive_untrash: 'update',
   drive_transfer: 'create',
+  // read-only resolver; the name's "resolve" verb would otherwise infer update.
+  contacts_resolve: 'read',
 };
 
 const SERVICE_OVERRIDES: Record<string, string> = {

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -4,6 +4,7 @@ import { people as peopleClient } from '@googleapis/people';
 import { ACCOUNTS } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
+import { coerceBoolean } from './_coerce.js';
 import { handleGoogleApiError } from './_errors.js';
 
 const accountEnum = z.enum(ACCOUNTS).optional();
@@ -35,6 +36,111 @@ function formatContact(person: any) {
     })),
     photo: person.photos?.[0]?.url ?? '',
   };
+}
+
+// --- A10 contacts_resolve: name -> one canonical email ---------------------
+
+export interface ResolveCandidate {
+  resourceName: string;
+  displayName: string;
+  source: 'contacts' | 'otherContacts';
+  emails: { value: string; type?: string; primary?: boolean }[];
+  hasOrg: boolean;
+}
+
+/** Accent-fold + lowercase for name comparison ("Rym" == "Rÿm"). */
+const foldName = (s: string): string =>
+  s.normalize('NFD').replace(/\p{Diacritic}/gu, '').toLowerCase().trim();
+
+/** Canonical-address preference within one contact: explicit primary, then
+ * People type order work > home > other. */
+function emailRank(e: { type?: string; primary?: boolean }): number {
+  if (e.primary) return 3;
+  const t = (e.type ?? '').toLowerCase();
+  if (t === 'work') return 2;
+  if (t === 'home') return 1;
+  return 0;
+}
+
+function pickEmail(c: ResolveCandidate): { value: string; type?: string; primary?: boolean } {
+  return [...c.emails].sort((a, b) => emailRank(b) - emailRank(a))[0];
+}
+
+/** Deterministic rank tuple; higher wins, compared lexicographically so the
+ * first discriminating rule decides (A10 tie-break table). */
+function scoreTuple(c: ResolveCandidate, foldedQuery: string): number[] {
+  const exact = foldName(c.displayName) === foldedQuery ? 1 : 0;   // 1. exact over prefix
+  const saved = c.source === 'contacts' ? 1 : 0;                    // 2. saved over other-contact
+  const bestEmail = c.emails.length ? Math.max(...c.emails.map(emailRank)) : 0; // 3. canonical address
+  const complete = c.hasOrg ? 1 : 0;                               // 4. fuller record
+  return [exact, saved, bestEmail, complete];
+}
+
+function cmpTuple(a: number[], b: number[]): number {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return b[i] - a[i];
+  }
+  return 0;
+}
+
+const projectCandidate = (c: ResolveCandidate) => ({
+  name: c.displayName,
+  email: pickEmail(c).value,
+  resourceName: c.resourceName,
+  source: c.source,
+});
+
+/** Rank candidates and return one confident match, an explicit ambiguous list,
+ * or null. Candidates without any email are dropped first. Pure (no I/O) so the
+ * tie-break is unit-testable. */
+export function resolveContacts(candidates: ResolveCandidate[], name: string, maxCandidates: number) {
+  const withEmail = candidates.filter((c) => c.emails.some((e) => e.value));
+  if (withEmail.length === 0) return { query: name, resolved: null };
+
+  const folded = foldName(name);
+  const ranked = withEmail
+    .map((c) => ({ c, t: scoreTuple(c, folded) }))
+    .sort((a, b) => cmpTuple(a.t, b.t));
+
+  const top = ranked[0];
+  const tiedTop = ranked.filter((r) => cmpTuple(r.t, top.t) === 0);
+  if (tiedTop.length === 1) {
+    return { query: name, resolved: projectCandidate(top.c) };
+  }
+  return {
+    query: name,
+    ambiguous: true as const,
+    candidates: tiedTop.slice(0, maxCandidates).map((r) => projectCandidate(r.c)),
+  };
+}
+
+/** People person -> ResolveCandidate projection. */
+function toCandidate(person: any, source: 'contacts' | 'otherContacts'): ResolveCandidate {
+  return {
+    resourceName: person?.resourceName ?? '',
+    displayName: person?.names?.[0]?.displayName ?? '',
+    source,
+    emails: (person?.emailAddresses ?? []).map((e: any) => ({
+      value: e.value ?? '',
+      type: e.type ?? '',
+      primary: e.metadata?.primary === true,
+    })),
+    hasOrg: (person?.organizations?.length ?? 0) > 0,
+  };
+}
+
+/** Merge saved + other contacts, deduped by resourceName (a saved match wins
+ * over the same person surfaced as an other-contact). */
+function dedupeCandidates(list: ResolveCandidate[]): ResolveCandidate[] {
+  const byResource = new Map<string, ResolveCandidate>();
+  for (const c of list) {
+    const key = c.resourceName || `${c.source}:${c.displayName}:${c.emails[0]?.value ?? ''}`;
+    const existing = byResource.get(key);
+    if (!existing || (existing.source === 'otherContacts' && c.source === 'contacts')) {
+      byResource.set(key, c);
+    }
+  }
+  return [...byResource.values()];
 }
 
 export function registerContactsTools(server: ToolRegistry): void {
@@ -69,6 +175,57 @@ export function registerContactsTools(server: ToolRegistry): void {
         const contacts = (res.data.results ?? []).map((r: any) => formatContact(r.person));
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(contacts, null, 2) }],
+        };
+      } catch (error: any) {
+        return handleContactsError(error, account as Account);
+      }
+    },
+  );
+
+  server.registerTool(
+    'contacts_resolve',
+    {
+      annotations: { openWorldHint: true },
+      description: 'Resolve a free-text name/alias to ONE canonical email address (ranked + tie-broken), so you need not hand-expand transliteration OR-queries. Returns a single confident match, an explicit ambiguous candidate list, or null when nothing matches. For picking a recipient before gmail_send.',
+      inputSchema: {
+        account: accountEnum.describe('Google account alias'),
+        name: z.string().min(1).describe('Free-text name or alias to resolve (e.g. "Rym")'),
+        maxCandidates: z.number().min(1).max(10).default(5).optional()
+          .describe('Max candidates to return when ambiguous (1-10, default: 5)'),
+        includeOtherContacts: coerceBoolean.optional()
+          .describe('Also search auto-saved "other contacts" (people you have emailed but not saved). Default true.'),
+      },
+    },
+    async ({ account, name, maxCandidates, includeOtherContacts }) => {
+      try {
+        const auth = await getClient(account as Account);
+        const people = peopleClient({ version: 'v1', auth });
+
+        // Warmup request required by the People API before searchContacts returns hits.
+        await people.people.searchContacts({ query: '', readMask: 'names' });
+
+        const saved = await people.people.searchContacts({
+          query: name,
+          readMask: 'names,emailAddresses,organizations',
+        });
+        const candidates: ResolveCandidate[] = (saved.data.results ?? [])
+          .map((r: any) => toCandidate(r.person, 'contacts'));
+
+        if (includeOtherContacts !== false) {
+          try {
+            const other = await people.otherContacts.search({
+              query: name,
+              readMask: 'names,emailAddresses',
+            });
+            candidates.push(...(other.data.results ?? []).map((r: any) => toCandidate(r.person, 'otherContacts')));
+          } catch {
+            // otherContacts unavailable (scope/5xx): degrade to saved-contacts only.
+          }
+        }
+
+        const result = resolveContacts(dedupeCandidates(candidates), name, maxCandidates ?? 5);
+        return {
+          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
         };
       } catch (error: any) {
         return handleContactsError(error, account as Account);

--- a/tests/contact-resolver.test.ts
+++ b/tests/contact-resolver.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { resolveContacts, type ResolveCandidate } from '../src/tools/contacts.js';
+
+function cand(p: Partial<ResolveCandidate> & { displayName: string; email?: string }): ResolveCandidate {
+  return {
+    resourceName: p.resourceName ?? `people/${p.displayName}-${p.email ?? 'x'}`,
+    displayName: p.displayName,
+    source: p.source ?? 'contacts',
+    emails: p.emails ?? (p.email ? [{ value: p.email }] : []),
+    hasOrg: p.hasOrg ?? false,
+  };
+}
+
+describe('resolveContacts (A10 tie-break)', () => {
+  it('exact name beats prefix match', () => {
+    const out = resolveContacts(
+      [cand({ displayName: 'Rymond', email: 'rymond@x.com' }), cand({ displayName: 'Rym', email: 'rym@x.com' })],
+      'Rym', 5,
+    );
+    expect(out.resolved?.email).toBe('rym@x.com');
+    expect(out.ambiguous).toBeUndefined();
+  });
+
+  it('accent-folds the name comparison (Rÿm == Rym)', () => {
+    const out = resolveContacts(
+      [cand({ displayName: 'Rÿm', email: 'accent@x.com' }), cand({ displayName: 'Rymond', email: 'p@x.com' })],
+      'Rym', 5,
+    );
+    expect(out.resolved?.email).toBe('accent@x.com');
+  });
+
+  it('saved connection beats an other-contact when names tie', () => {
+    const out = resolveContacts(
+      [
+        cand({ displayName: 'Rym', email: 'other@x.com', source: 'otherContacts' }),
+        cand({ displayName: 'Rym', email: 'saved@x.com', source: 'contacts' }),
+      ],
+      'Rym', 5,
+    );
+    expect(out.resolved?.email).toBe('saved@x.com');
+    expect(out.resolved?.source).toBe('contacts');
+  });
+
+  it('returns ambiguous (capped) when a real tie survives all rules', () => {
+    const out = resolveContacts(
+      [
+        cand({ displayName: 'Rym', email: 'rym1@x.com' }),
+        cand({ displayName: 'Rym', email: 'rym2@x.com' }),
+        cand({ displayName: 'Rym', email: 'rym3@x.com' }),
+      ],
+      'Rym', 2,
+    );
+    expect(out.ambiguous).toBe(true);
+    expect(out.candidates).toHaveLength(2); // capped to maxCandidates
+    expect(out.resolved).toBeUndefined();
+  });
+
+  it('recall: an other-contact-only match still resolves', () => {
+    const out = resolveContacts(
+      [cand({ displayName: 'Faycal', email: 'faycal@auto.com', source: 'otherContacts' })],
+      'Faycal', 5,
+    );
+    expect(out.resolved?.email).toBe('faycal@auto.com');
+    expect(out.resolved?.source).toBe('otherContacts');
+  });
+
+  it('picks the primary email within a chosen contact (else type order)', () => {
+    const out = resolveContacts(
+      [cand({ displayName: 'Rym', emails: [
+        { value: 'home@x.com', type: 'home' },
+        { value: 'canon@x.com', primary: true },
+        { value: 'work@x.com', type: 'work' },
+      ] })],
+      'Rym', 5,
+    );
+    expect(out.resolved?.email).toBe('canon@x.com');
+  });
+
+  it('no candidates → resolved:null (not an error)', () => {
+    expect(resolveContacts([], 'Nobody', 5)).toEqual({ query: 'Nobody', resolved: null });
+  });
+
+  it('candidates with no email are dropped → resolved:null', () => {
+    const out = resolveContacts([cand({ displayName: 'Rym', emails: [] })], 'Rym', 5);
+    expect(out).toEqual({ query: 'Rym', resolved: null });
+  });
+
+  it('a fuller record (has org) breaks a name/source tie', () => {
+    const out = resolveContacts(
+      [
+        cand({ displayName: 'Rym', email: 'bare@x.com' }),
+        cand({ displayName: 'Rym', email: 'full@x.com', hasOrg: true }),
+      ],
+      'Rym', 5,
+    );
+    expect(out.resolved?.email).toBe('full@x.com');
+  });
+});


### PR DESCRIPTION
## A10 / A.4d — `contacts_resolve`

Final A.4d convenience (completes the email cluster). New **read-only** tool: free-text name in, **one canonical email** out — so the agent stops hand-expanding transliteration OR-queries (`Rym OR Rim OR Reem`) against `contacts_search`.

### Query + recall
1. People API warmup (mandatory) → `people.searchContacts` (saved connections).
2. Unless `includeOtherContacts:false`, also `otherContacts.search` (people you've emailed but not saved) — the recall delta over `contacts_search`. Merged + deduped by `resourceName` (saved wins).
3. Candidates with no email are dropped.

### Deterministic tie-break (first discriminating rule wins)
1. Exact `displayName` (accent-folded, case-insensitive) over prefix.
2. Saved connection over other-contact.
3. Canonical address — `metadata.primary`, else People type order `work > home > other`.
4. Fuller record (has organization) over bare name+email.

Within the chosen contact the returned `email` is its primary (else first). If a real tie survives, returns **ambiguous** rather than guessing.

### Output
- `{ query, resolved: { name, email, resourceName, source } }` — confident match.
- `{ query, ambiguous: true, candidates: [...] }` — tie survived (≤ `maxCandidates`).
- `{ query, resolved: null }` — no match (**not** an error).

### Classification / degrade
- `cud=read` via `CUD_OVERRIDES` (the `resolve` verb would otherwise infer `update` and gate it under write-control). `readOnlyHint` + `openWorldHint`.
- A missing other-contacts scope (`insufficient_scope`) degrades to saved-contacts-only, never fails the call.

### Tests / verification
- `tests/contact-resolver.test.ts` — 9 tests: exact-over-prefix, accent-fold, saved-over-other, ambiguous+cap, other-contact-only recall, primary-email pick, no-match/no-email → null, org breaks a tie.
- 481 tests green; typecheck + lint + build clean.
- Verified the live People `searchContacts` shape (`names[].displayName`, `emailAddresses[].value/type/metadata.primary`, `organizations[].name`) against a real account; and confirmed `otherContacts.search` returns `insufficient_scope` on that account — the exact real-world case the degrade path handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)