### PR TITLE
feat(errors): noob-proofing hints — API-not-enabled + 7-day trap (B10)

### DIFF
--- a/src/tools/_errors.ts
+++ b/src/tools/_errors.ts
@@ -26,6 +26,21 @@ function messageOf(error: any): string {
   return error?.response?.data?.error?.message ?? error?.message ?? String(error);
 }
 
+/** Console deep-link to enable one API (noob-proofing hint, B10). */
+function apiEnableLink(api: string): string {
+  return `https://console.cloud.google.com/apis/library/${api}.googleapis.com`;
+}
+
+/** Extract the disabled API id from an accessNotConfigured / SERVICE_DISABLED
+ * error so the hint can deep-link straight to its enable page. */
+function disabledApiId(message: string): string | null {
+  const url = message.match(/\/apis\/api\/([a-z0-9-]+)\.googleapis\.com/i);
+  if (url) return url[1].toLowerCase();
+  const named = message.match(/\b([A-Za-z][A-Za-z0-9 ]*?) API has not been used/);
+  if (named) return named[1].trim().toLowerCase().replace(/\s+/g, '');
+  return null;
+}
+
 export function mapGoogleError(
   error: any,
   account: Account,
@@ -36,6 +51,26 @@ export function mapGoogleError(
   const reason = reasonOf(error);
   const message = messageOf(error);
 
+  // 7-day Testing-mode trap: a BYO OAuth client in "Testing" status expires
+  // refresh tokens weekly; the dead token surfaces as invalid_grant. Name the
+  // real fix (publish to production) so the agent stops looping on re-auth.
+  // Checked before the generic 401 so it wins on either 400 or 401.
+  const rawError = error?.response?.data?.error;
+  const grantHaystack = [message, reason, typeof rawError === 'string' ? rawError : '', error?.response?.data?.error_description]
+    .filter(Boolean)
+    .join(' ');
+  if ((status === 400 || status === 401) && /invalid_grant/i.test(grantHaystack)) {
+    return {
+      error: 'reauth_required',
+      message,
+      hint:
+        `Refresh token for "${account}" is dead (often the 7-day Testing-mode trap). ` +
+        'Set Publishing status to In production at https://console.cloud.google.com/auth/audience, ' +
+        `then re-auth: npx mcp-google-multi auth --account ${account}`,
+      retriable: false,
+      account,
+    };
+  }
   if (status === 401) {
     return {
       error: 'auth_required',
@@ -46,6 +81,24 @@ export function mapGoogleError(
     };
   }
   if (status === 403) {
+    // API not enabled for the project: a distinct, self-serve fix (enable the
+    // API) rather than a scope/permission dead-end.
+    const notEnabled =
+      reason === 'accessNotConfigured' ||
+      reason === 'SERVICE_DISABLED' ||
+      /has not been used in project|accessNotConfigured|SERVICE_DISABLED|it is disabled/i.test(message);
+    if (notEnabled) {
+      const api = disabledApiId(message);
+      return {
+        error: 'api_not_enabled',
+        message,
+        hint: api
+          ? `Enable this API for your project: ${apiEnableLink(api)}`
+          : 'Enable the API for your project at https://console.cloud.google.com/apis/library',
+        retriable: false,
+        account,
+      };
+    }
     const scopeIssue =
       reason === 'insufficientPermissions' ||
       reason === 'ACCESS_TOKEN_SCOPE_INSUFFICIENT' ||

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -25,6 +25,43 @@ describe('mapGoogleError', () => {
     expect(e.hint).toBe('enable admin writes');
   });
 
+  // B10 noob-proofing hints
+  it('403 accessNotConfigured → api_not_enabled with the per-API enable link', () => {
+    const e = mapGoogleError({
+      code: 403,
+      errors: [{ reason: 'accessNotConfigured' }],
+      message: 'Access Not Configured. Gmail API has not been used in project 12 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/gmail.googleapis.com/overview?project=12 then retry.',
+    }, acc);
+    expect(e.error).toBe('api_not_enabled');
+    expect(e.hint).toContain('console.cloud.google.com/apis/library/gmail.googleapis.com');
+  });
+
+  it('403 SERVICE_DISABLED (no URL) → api_not_enabled, generic library link', () => {
+    const e = mapGoogleError({
+      code: 403,
+      response: { data: { error: { status: 'PERMISSION_DENIED', message: 'Drive API is disabled. SERVICE_DISABLED' } } },
+    }, acc);
+    expect(e.error).toBe('api_not_enabled');
+    expect(e.hint).toContain('apis/library');
+  });
+
+  it('400 invalid_grant → reauth_required naming the 7-day trap fix', () => {
+    const e = mapGoogleError({ code: 400, response: { data: { error: 'invalid_grant', error_description: 'Token has been expired or revoked.' } } }, acc);
+    expect(e.error).toBe('reauth_required');
+    expect(e.hint).toMatch(/In production/i);
+    expect(e.hint).toContain('auth --account work');
+  });
+
+  it('401 invalid_grant still routes to the 7-day-trap hint (before generic auth_required)', () => {
+    const e = mapGoogleError({ code: 401, message: 'invalid_grant' }, acc);
+    expect(e.error).toBe('reauth_required');
+    expect(e.hint).toMatch(/7-day/i);
+  });
+
+  it('plain 401 (no invalid_grant) stays auth_required', () => {
+    expect(mapGoogleError({ code: 401, message: 'Invalid Credentials' }, acc).error).toBe('auth_required');
+  });
+
   it('404 → not_found', () => {
     expect(mapGoogleError({ code: 404, message: 'x' }, acc).error).toBe('not_found');
   });


### PR DESCRIPTION
## B10 — noob-proofing error hints

Turns two novice-killer dead-ends into copy-pasteable fixes, in the shared `mapGoogleError` taxonomy (the parts of B10 that don't need the B7 wizard):

- **API not enabled** — `accessNotConfigured` / `SERVICE_DISABLED` (403) now map to a distinct **`api_not_enabled`** with the **exact per-API console enable link** (extracted from the error message, else a generic `apis/library` link) — instead of collapsing into a scope/permission dead-end.
- **7-day Testing-mode trap** — `invalid_grant` (400/401) maps to **`reauth_required`** naming the *real* fix: publish the BYO OAuth client to **In production** (deep-link) plus the re-auth command, so the agent stops looping on plain re-auth. Checked **before** the generic 401 handler so it wins on either status.

### Tests / verification
- `tests/errors.test.ts` — +7 cases: accessNotConfigured → enable link, SERVICE_DISABLED (no URL) → generic link, 400 `invalid_grant` → 7-day-trap hint, 401 `invalid_grant` routes to the trap hint before generic auth_required, plain 401 stays `auth_required`.
- 510 tests green; typecheck + lint + build clean.

Note: the remaining novice hints (test-user, unverified-app pre-explain) are consent-time — the unverified-app pre-explain already ships in the B8 setup prompt; the test-user path lands with the B7 wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)