### PR TITLE
feat(wizard): account_add / account_reauth elicitation wizard (B7)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -89,3 +89,13 @@ Any value you pass explicitly wins over the derived one (`to`, `cc`, `subject` a
 The same engine is exposed to agents as the read-only **`diagnose`** tool, returning the structured report so an agent can self-diagnose an auth/config failure and surface the fix. (HTTP-transport checks and the live per-service API-enablement probe land with the OAuth authorization server.)
 
 `mcp-google-multi reset` recovers a bricked or stale install: it wipes encrypted token files (all accounts, or `--account <alias>`) — **config.json is always kept** — and with `--regenerate-key` also drops the generated `MASTER_KEY` (refused while any account still holds a token, since a fresh key would brick it). It is confirmation-gated (`--yes` for non-interactive) and, after a wipe, prints the exact re-auth command per account.
+
+
+## Interactive account management: `account_add` / `account_reauth`
+
+Two always-visible, human-approved tools (`anthropic/requiresUserInteraction`) manage accounts on a running server — no file editing, no restart:
+
+- **`account_add`** collects the account (alias, email, scope-bundle checkboxes incl. an "all optional scopes" option, and a Workspace-admin toggle) via an elicitation **form**, writes the registry through the atomic path, then runs Google consent in the browser (URL-mode elicitation, or a printed link as a fallback). The new alias is callable immediately. When the server can't reach the granted scopes you asked for (granular consent), it reports `E_SCOPE_NOT_GRANTED` naming what to re-grant. If accounts are pinned via the legacy `GOOGLE_ACCOUNTS` env, `account_add` refuses with `E_ENV_ACCOUNTS_MODE` (config.json is ignored while that env is set) — migrate with `mcp-google-multi migrate-config` to use it.
+- **`account_reauth <alias>`** re-runs consent for an existing account: recover a dead refresh token (the 7-day-trap fix) or grant scopes after a profile change. It works regardless of how the account was defined.
+
+Both reuse the loopback consent flow (your own OAuth client), so tokens never leave your machine. (HTTP-transport consent lands with the OAuth authorization server.)

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { registerDiscoverTools } from './discover.js';
 import { registerEscapeTools } from './tools/google-api.js';
 import { registerAccountTools } from './tools/accounts-tool.js';
 import { registerDiagnoseTool } from './doctor.js';
+import { registerAccountWizardTools } from './tools/account-wizard.js';
 import { getToolsets, toolsetEnabled } from './toolsets.js';
 import { isAllowed, describePolicy } from './write-control.js';
 import { buildIdentityContext, type IdentityContext } from './identity.js';
@@ -68,6 +69,7 @@ function buildRegistry(server: McpServer, ctx: IdentityContext): ToolRegistry {
   registerEscapeTools(registry, policy);
   registerAccountTools(registry);
   registerDiagnoseTool(registry);
+  registerAccountWizardTools(registry, server);
   return registry;
 }
 

--- a/src/oauth-consent.ts
+++ b/src/oauth-consent.ts
@@ -1,0 +1,117 @@
+import { OAuth2Client } from 'googleapis-common';
+import http from 'node:http';
+import { URL } from 'node:url';
+
+// Shared loopback OAuth consent (leg C of cc-auth), used by the account wizard
+// (B7). The `auth --account` CLI keeps its own inline copy for now; this module
+// is the reusable, live-server-safe form (throws typed errors instead of
+// process.exit, and times out so a never-completed consent can't wedge a tool
+// call forever). The redirect matches the CLI exactly so an existing registered
+// Desktop client keeps working.
+
+export const LOOPBACK_PORT = 4242;
+export const LOOPBACK_REDIRECT = `http://localhost:${LOOPBACK_PORT}/oauth2callback`;
+
+/** GOOGLE_CLIENT_ID/SECRET absent — caller maps to E_CLIENT_CREDENTIALS_MISSING. */
+export class ClientCredentialsMissingError extends Error {
+  constructor() {
+    super('E_CLIENT_CREDENTIALS_MISSING: GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are not set.');
+  }
+}
+export class LoopbackPortInUseError extends Error {
+  constructor() {
+    super(`E_LOOPBACK_PORT_IN_USE: port ${LOOPBACK_PORT} is already in use; close the other process and retry.`);
+  }
+}
+export class ConsentTimeoutError extends Error {
+  constructor() {
+    super('E_CONSENT_TIMEOUT: no OAuth redirect arrived before the timeout.');
+  }
+}
+export class ConsentDeniedError extends Error {
+  constructor(reason: string) {
+    super(`E_CONSENT_DENIED: ${reason}`);
+  }
+}
+
+export function hasClientCredentials(): boolean {
+  return Boolean(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
+}
+
+/** Build the loopback OAuth2 client from env credentials (throws if unset). */
+export function buildConsentClient(): OAuth2Client {
+  if (!hasClientCredentials()) throw new ClientCredentialsMissingError();
+  return new OAuth2Client(process.env.GOOGLE_CLIENT_ID, process.env.GOOGLE_CLIENT_SECRET, LOOPBACK_REDIRECT);
+}
+
+/**
+ * Start the loopback server, await the OAuth redirect, validate the CSRF
+ * `state` (RFC 6749 §10.12), and exchange the code. Returns the token set for
+ * the caller to persist. Never process.exit's (safe inside a live server) and
+ * times out so a stalled consent can't wedge a tool call.
+ */
+export function awaitLoopbackConsent(
+  client: OAuth2Client,
+  expectedState: string,
+  opts: { timeoutMs?: number } = {},
+): Promise<Record<string, unknown>> {
+  const timeoutMs = opts.timeoutMs ?? 5 * 60_000;
+  return new Promise((resolve, reject) => {
+    let timer: NodeJS.Timeout | undefined;
+    const server = http.createServer(async (req, res) => {
+      if (!req.url || !req.url.startsWith('/oauth2callback')) {
+        res.writeHead(404).end();
+        return;
+      }
+      const done = (code: number, body: string) => {
+        res.writeHead(code, { 'Content-Type': 'text/html' });
+        res.end(body);
+        if (timer) clearTimeout(timer);
+        server.close();
+        server.closeAllConnections();
+      };
+      try {
+        const qs = new URL(req.url, LOOPBACK_REDIRECT).searchParams;
+        const error = qs.get('error');
+        if (error) {
+          done(400, `<p>Authorization denied: ${error}</p>`);
+          reject(new ConsentDeniedError(error));
+          return;
+        }
+        const returnedState = qs.get('state');
+        if (returnedState !== expectedState) {
+          done(400, '<p>State mismatch — possible CSRF attempt. Aborting.</p>');
+          reject(new Error('E_OAUTH_STATE_MISMATCH: OAuth state token mismatch'));
+          return;
+        }
+        const code = qs.get('code');
+        if (!code) {
+          done(400, '<p>No authorization code received.</p>');
+          reject(new ConsentDeniedError('no authorization code received'));
+          return;
+        }
+        const { tokens } = await client.getToken(code);
+        done(200, '<h2>Authentication successful!</h2><p>You can close this tab.</p>');
+        resolve(tokens as Record<string, unknown>);
+      } catch (e) {
+        done(500, '<p>Internal error during authentication.</p>');
+        reject(e);
+      }
+    });
+
+    server.on('error', (err: NodeJS.ErrnoException) => {
+      if (timer) clearTimeout(timer);
+      reject(err.code === 'EADDRINUSE' ? new LoopbackPortInUseError() : err);
+    });
+
+    server.listen(LOOPBACK_PORT, '127.0.0.1', () => {
+      timer = setTimeout(() => {
+        server.close();
+        server.closeAllConnections();
+        reject(new ConsentTimeoutError());
+      }, timeoutMs);
+      // unref so a pending consent never keeps the process alive on its own.
+      timer.unref?.();
+    });
+  });
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -66,6 +66,11 @@ const CUD_OVERRIDES: Record<string, Cud> = {
   drive_transfer: 'create',
   // read-only resolver; the name's "resolve" verb would otherwise infer update.
   contacts_resolve: 'read',
+  // Account management is gated by anthropic/requiresUserInteraction (forced
+  // human approval), NOT the Google-data write-control profile — so onboarding
+  // works under any profile. cud=read also keeps them off the fan-out path.
+  account_add: 'read',
+  account_reauth: 'read',
 };
 
 const SERVICE_OVERRIDES: Record<string, string> = {

--- a/src/tools/account-wizard.ts
+++ b/src/tools/account-wizard.ts
@@ -1,0 +1,259 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { ToolRegistry } from '../registry.js';
+import { getAccountSet, invalidateAccountSet } from '../accounts.js';
+import { mutateConfigFile } from '../config-file.js';
+import { writeToken } from '../token-store.js';
+import { resolveScopesForAccount } from '../auth.js';
+import { BUNDLE_CATALOG, closestBundle, resolveBundleAliases } from '../scope-catalog.js';
+import { openUrl } from '../open-url.js';
+import {
+  buildConsentClient, awaitLoopbackConsent, hasClientCredentials,
+} from '../oauth-consent.js';
+
+// B7: the elicitation-driven account_add / account_reauth wizard. It rebuilds
+// interactive account management on the mutable config.json registry so a
+// running server can add an account without the deployer editing env + running
+// a CLI. Google consent reuses the loopback flow (leg C); the HTTP-transport
+// consent path (${BASE}/authorize) is owned by the OAuth AS and lands with that
+// cluster — account_add over http is gated behind it.
+
+const ALIAS_RE = /^[a-zA-Z0-9_-]+$/;
+
+export interface AddForm {
+  alias: string;
+  email: string;
+  allBundles: boolean;
+  forms: boolean;
+  chat: boolean;
+  otherBundles: string;
+  admin: boolean;
+}
+
+// The common optional bundles get their own checkbox (MCP elicitation has no
+// multi-select, so a boolean per bundle IS the checklist); the long tail stays
+// a comma-separated field for power users, and `allBundles` grants every one.
+const CHECKBOX_BUNDLES = ['forms', 'chat'] as const;
+
+/** Every optional bundle (admin is granted via its own checkbox, not here). */
+export function allOptionalBundles(): string[] {
+  return Object.keys(BUNDLE_CATALOG).filter((n) => n !== 'admin');
+}
+
+/** elicitation/create form schema (flat primitives only, per the MCP spec). */
+export function addFormSchema(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      alias: { type: 'string', title: 'Account alias', description: 'Short id, e.g. "work" (letters, digits, _ or -).' },
+      email: { type: 'string', title: 'Google email', description: 'The account\'s Google address (used as the login hint).' },
+      allBundles: { type: 'boolean', title: 'All optional scopes', description: 'Grant every optional bundle (biggest consent screen). Overrides the individual choices below.', default: false },
+      forms: { type: 'boolean', title: 'Google Forms', description: 'Build forms and read their responses.', default: false },
+      chat: { type: 'boolean', title: 'Google Chat', description: 'Read/send Chat messages and manage spaces (Workspace only).', default: false },
+      otherBundles: { type: 'string', title: 'Other scope bundles (comma-separated)', description: 'Advanced, optional: e.g. "slides,gmail_settings". See docs for the full list. Leave blank for base + the checkboxes above.' },
+      admin: { type: 'boolean', title: 'Grant Workspace admin scopes', description: 'Only for a Workspace super-admin account. Adds admin scopes.', default: false },
+    },
+    required: ['alias', 'email'],
+  };
+}
+
+export type AddValidation =
+  | { ok: true; alias: string; email: string; bundles: string[]; admin: boolean }
+  | { ok: false; slug: string; message: string };
+
+/** Validate the collected form against the alias rules, dup check, and the
+ * bundle catalog. Pure (no I/O) for unit testing. */
+export function validateAddForm(input: Partial<AddForm>, existingAliases: string[]): AddValidation {
+  const alias = (input.alias ?? '').trim();
+  const email = (input.email ?? '').trim();
+  if (!ALIAS_RE.test(alias)) {
+    return { ok: false, slug: 'E_VALIDATION', message: `Invalid alias "${alias}". Use letters, digits, "_" or "-".` };
+  }
+  if (existingAliases.includes(alias)) {
+    return { ok: false, slug: 'E_ALIAS_EXISTS', message: `Alias "${alias}" already exists; use account_reauth to re-authenticate it, or pick another name.` };
+  }
+  if (email === '') {
+    return { ok: false, slug: 'E_VALIDATION', message: 'Email is required (used as the Google login hint).' };
+  }
+  if (input.allBundles === true) {
+    // "All optional scopes" supersedes the individual picks.
+    return { ok: true, alias, email, bundles: allOptionalBundles(), admin: input.admin === true };
+  }
+  const picked = CHECKBOX_BUNDLES.filter((b) => input[b] === true);
+  const rawOther = (input.otherBundles ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+  const bundles = [...new Set(resolveBundleAliases([...picked, ...rawOther]))];
+  for (const b of bundles) {
+    if (b === 'admin') {
+      return { ok: false, slug: 'E_UNKNOWN_BUNDLE', message: '"admin" is not a bundle — use the admin checkbox instead.' };
+    }
+    if (!(b in BUNDLE_CATALOG)) {
+      const hint = closestBundle(b);
+      return { ok: false, slug: 'E_UNKNOWN_BUNDLE', message: `Unknown bundle "${b}"${hint ? ` — did you mean "${hint}"?` : ''}. Known: ${Object.keys(BUNDLE_CATALOG).filter((n) => n !== 'admin').join(', ')}.` };
+    }
+  }
+  return { ok: true, alias, email, bundles, admin: input.admin === true };
+}
+
+/** Scopes requested by the profile but NOT granted at consent (granular
+ * consent / unchecked bundles). Pure. */
+export function scopeGrantDiff(requested: string[], grantedScope: string | undefined): string[] {
+  const granted = new Set((grantedScope ?? '').split(' ').filter(Boolean));
+  return requested.filter((s) => !granted.has(s));
+}
+
+/** Persist a new account row (+ a per-account scope profile when bundles/admin
+ * were chosen) through the atomic registry mutation path (BR2). */
+function writeAccountRow(alias: string, email: string, bundles: string[], admin: boolean): void {
+  mutateConfigFile((current) => {
+    const next = { ...current, accounts: { ...(current.accounts ?? {}) } };
+    const row: { email: string; scopeProfile?: string; admin?: boolean } = { email };
+    if (bundles.length > 0) {
+      next.scopeProfiles = { ...(next.scopeProfiles ?? {}), [alias]: { bundles } };
+      row.scopeProfile = alias;
+    }
+    if (admin) row.admin = true;
+    next.accounts[alias] = row;
+    return next;
+  });
+}
+
+function textResult(text: string, isError = false) {
+  return { content: [{ type: 'text' as const, text }], ...(isError ? { isError: true } : {}) };
+}
+
+/** Run Google consent for `alias` and persist the token. Opens the browser via
+ * URL-mode elicitation when the client supports it, else server-side + prints
+ * the URL. Returns the granted-scope diff for the S4 report. */
+async function runConsent(server: McpServer, alias: string): Promise<{ ok: true; missing: string[] } | { ok: false; text: string }> {
+  const { randomBytes } = await import('node:crypto');
+  const cfg = getAccountSet().configs[alias];
+  if (!cfg) return { ok: false, text: `E_VALIDATION: account "${alias}" is not in the live registry (env-sourced accounts are not editable here).` };
+  const client = buildConsentClient();
+  const expectedState = randomBytes(32).toString('hex');
+  const scopes = resolveScopesForAccount(alias);
+  const url = client.generateAuthUrl({ access_type: 'offline', prompt: 'consent', scope: scopes, login_hint: cfg.email, state: expectedState });
+
+  // Start the loopback listener BEFORE opening the browser so it can't miss the
+  // redirect. Any startup error (e.g. port in use) surfaces synchronously.
+  const consent = awaitLoopbackConsent(client, expectedState);
+
+  const caps = server.server.getClientCapabilities?.();
+  let opened = false;
+  if ((caps as { elicitation?: { url?: boolean } } | undefined)?.elicitation?.url) {
+    try {
+      const r = await server.server.elicitInput({ mode: 'url', message: `Authorize the "${alias}" Google account in your browser.`, url } as never);
+      if ((r as { action?: string }).action !== 'accept') {
+        return { ok: false, text: 'confirmation_declined: consent was cancelled; the account row was kept but no token was stored (doctor will show it as "missing").' };
+      }
+      opened = true;
+    } catch {
+      // fall through to server-side open
+    }
+  }
+  if (!opened) {
+    openUrl(url);
+  }
+
+  let tokens: Record<string, unknown>;
+  try {
+    tokens = await consent;
+  } catch (e: unknown) {
+    return { ok: false, text: `${(e as Error).message}${opened ? '' : `\nOpen this URL to authorize:\n${url}`}` };
+  }
+  writeToken(alias, tokens);
+  return { ok: true, missing: scopeGrantDiff(scopes, typeof tokens.scope === 'string' ? tokens.scope : undefined) };
+}
+
+function s4Text(alias: string, missing: string[]): string {
+  if (missing.length === 0) return `✔ "${alias}" authenticated; all requested scopes granted. It is now usable without a restart.`;
+  return `⚠ "${alias}" authenticated, but ${missing.length} requested scope(s) were NOT granted (E_SCOPE_NOT_GRANTED) — you may have unchecked some on the consent screen. Re-run account_reauth to grant them. The account is usable for the granted scopes.`;
+}
+
+const REQUIRES_INTERACTION = { 'anthropic/requiresUserInteraction': true };
+
+export function registerAccountWizardTools(registry: ToolRegistry, server: McpServer): void {
+  // Registered as META (always-visible, like account_list) so onboarding tools
+  // are reachable in lazy mode without discover_all first; registerMeta still
+  // preserves the requiresUserInteraction clientMeta and skips the fan-out path.
+  const registerMeta = registry.registerMeta as unknown as (
+    name: string,
+    config: { description: string; inputSchema: Record<string, unknown>; annotations?: Record<string, unknown>; _meta?: Record<string, unknown> },
+    handler: (...a: unknown[]) => unknown,
+  ) => void;
+
+  registerMeta(
+    'account_add',
+    {
+      _meta: REQUIRES_INTERACTION,
+      annotations: { openWorldHint: true },
+      description: 'Add a new Google account interactively: collects alias/email/scope bundles via a form, writes the registry, and runs Google consent in the browser — no file editing or restart needed. Requires GOOGLE_CLIENT_ID/SECRET (run the `setup` prompt first if missing).',
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        // Env-sourced registry: GOOGLE_ACCOUNTS is the exclusive source and
+        // config.json accounts are ignored, so a wizard add would be a phantom
+        // write. Refuse up front (BR-10) rather than write a row nothing reads.
+        if (process.env.GOOGLE_ACCOUNTS?.trim()) {
+          return textResult('E_ENV_ACCOUNTS_MODE: accounts are defined by the GOOGLE_ACCOUNTS environment variable, so new accounts cannot be added interactively (config.json is ignored while it is set). Either add the alias to GOOGLE_ACCOUNTS and run account_reauth, or run `mcp-google-multi migrate-config` to move accounts into config.json and unset GOOGLE_ACCOUNTS.', true);
+        }
+        if (!hasClientCredentials()) {
+          return textResult('E_CLIENT_CREDENTIALS_MISSING: GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET are not set. Run the `setup` prompt (/mcp__google-multi__setup) to create an OAuth client, then set them.', true);
+        }
+        const caps = server.server.getClientCapabilities?.() as { elicitation?: { form?: boolean } } | undefined;
+        if (!caps?.elicitation?.form) {
+          return textResult('This client does not support form elicitation. Add the account from the CLI instead: `npx mcp-google-multi account add --alias <alias> --email <email> [--profile a,b] [--admin]`.', true);
+        }
+
+        // S1: collect the registry row.
+        const form = await server.server.elicitInput({ message: 'Add a Google account', requestedSchema: addFormSchema() } as never);
+        if ((form as { action?: string }).action !== 'accept') {
+          return textResult('confirmation_declined: no account was added.');
+        }
+        const validated = validateAddForm((form as { content?: Partial<AddForm> }).content ?? {}, getAccountSet().aliases);
+        if (!validated.ok) return textResult(`${validated.slug}: ${validated.message}`, true);
+
+        // S2: atomic write + make the alias callable without a restart (BR3).
+        writeAccountRow(validated.alias, validated.email, validated.bundles, validated.admin);
+        invalidateAccountSet();
+
+        // S3 + S4: consent + validate.
+        const consent = await runConsent(server, validated.alias);
+        if (!consent.ok) return textResult(consent.text, true);
+        return textResult(s4Text(validated.alias, consent.missing));
+      } catch (e: unknown) {
+        return textResult(`account_add failed: ${(e as Error).message}`, true);
+      }
+    },
+  );
+
+  registerMeta(
+    'account_reauth',
+    {
+      _meta: REQUIRES_INTERACTION,
+      annotations: { openWorldHint: true },
+      description: 'Re-authenticate an existing Google account (recover a dead refresh token, or grant scopes after a profile change). Runs Google consent in the browser. Pass the account alias.',
+      inputSchema: {
+        // Plain string (NOT the account enum) so this never joins the
+        // multi-account fan-out path; validated against the registry below.
+        alias: z.string().describe('Existing account alias to re-authenticate'),
+      },
+    },
+    async (args: unknown) => {
+      try {
+        const alias = (args as { alias?: string }).alias ?? '';
+        if (!hasClientCredentials()) {
+          return textResult('E_CLIENT_CREDENTIALS_MISSING: GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET are not set.', true);
+        }
+        if (!getAccountSet().aliases.includes(alias)) {
+          return textResult(`E_VALIDATION: unknown account "${alias}". Known: ${getAccountSet().aliases.join(', ')}. Use account_add for a new one.`, true);
+        }
+        const consent = await runConsent(server, alias);
+        if (!consent.ok) return textResult(consent.text, true);
+        return textResult(s4Text(alias, consent.missing));
+      } catch (e: unknown) {
+        return textResult(`account_reauth failed: ${(e as Error).message}`, true);
+      }
+    },
+  );
+}

--- a/tests/account-wizard.test.ts
+++ b/tests/account-wizard.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { addFormSchema, validateAddForm, scopeGrantDiff, allOptionalBundles } from '../src/tools/account-wizard.js';
+
+describe('addFormSchema', () => {
+  it('is a flat object schema with alias+email required and bundle checkboxes', () => {
+    const s = addFormSchema() as any;
+    expect(s.type).toBe('object');
+    expect(Object.keys(s.properties)).toEqual(['alias', 'email', 'allBundles', 'forms', 'chat', 'otherBundles', 'admin']);
+    expect(s.required).toEqual(['alias', 'email']);
+    expect(s.properties.allBundles.type).toBe('boolean'); // "all optional scopes" checkbox
+    expect(s.properties.forms.type).toBe('boolean'); // checklist, not CSV
+    expect(s.properties.chat.type).toBe('boolean');
+    // MCP elicitation forbids nested/array fields — all primitives.
+    for (const p of Object.values(s.properties) as any[]) {
+      expect(['string', 'boolean']).toContain(p.type);
+    }
+  });
+});
+
+describe('validateAddForm', () => {
+  const existing = ['ic', 'personal'];
+
+  it('accepts a clean row and collects checkbox bundles', () => {
+    const r = validateAddForm({ alias: 'work', email: 'a@b.com', forms: true, chat: true, admin: false }, existing);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.alias).toBe('work');
+      expect(r.bundles.sort()).toEqual(['chat', 'forms']);
+      expect(r.admin).toBe(false);
+    }
+  });
+
+  it('merges checkboxes with otherBundles, deduped', () => {
+    const r = validateAddForm({ alias: 'work', email: 'a@b.com', forms: true, otherBundles: 'slides, forms' }, existing);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.bundles.sort()).toEqual(['forms', 'slides']);
+  });
+
+  it('base-only when nothing selected', () => {
+    const r = validateAddForm({ alias: 'work', email: 'a@b.com' }, existing);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.bundles).toEqual([]);
+  });
+
+  it('allBundles grants every optional bundle and supersedes individual picks', () => {
+    const r = validateAddForm({ alias: 'work', email: 'a@b.com', allBundles: true, forms: false }, existing);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.bundles.sort()).toEqual(allOptionalBundles().sort());
+      expect(r.bundles).not.toContain('admin'); // admin stays its own checkbox
+      expect(r.bundles.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('rejects a bad alias', () => {
+    const r = validateAddForm({ alias: 'has space', email: 'a@b.com' }, existing);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.slug).toBe('E_VALIDATION');
+  });
+
+  it('rejects a duplicate alias with E_ALIAS_EXISTS', () => {
+    const r = validateAddForm({ alias: 'ic', email: 'a@b.com' }, existing);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.slug).toBe('E_ALIAS_EXISTS');
+  });
+
+  it('requires an email', () => {
+    const r = validateAddForm({ alias: 'work', email: '  ' }, existing);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.slug).toBe('E_VALIDATION');
+  });
+
+  it('rejects an unknown otherBundles entry with a did-you-mean', () => {
+    const r = validateAddForm({ alias: 'work', email: 'a@b.com', otherBundles: 'form' }, existing);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.slug).toBe('E_UNKNOWN_BUNDLE');
+      expect(r.message).toContain('forms');
+    }
+  });
+
+  it('rejects "admin" as a bundle (use the checkbox)', () => {
+    const r = validateAddForm({ alias: 'work', email: 'a@b.com', otherBundles: 'admin' }, existing);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.slug).toBe('E_UNKNOWN_BUNDLE');
+  });
+});
+
+describe('scopeGrantDiff (BR5)', () => {
+  it('returns the requested scopes that were not granted', () => {
+    const requested = ['a', 'b', 'c'];
+    expect(scopeGrantDiff(requested, 'a c')).toEqual(['b']);
+  });
+  it('empty when all granted', () => {
+    expect(scopeGrantDiff(['a', 'b'], 'a b extra')).toEqual([]);
+  });
+  it('all missing when scope absent', () => {
+    expect(scopeGrantDiff(['a', 'b'], undefined)).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## B7 — interactive account wizard

Rebuilds account management on the mutable config.json registry so a **running** server can add / re-authenticate a Google account with no file editing and no restart. Two always-visible, human-approved tools (`anthropic/requiresUserInteraction`).

### `account_add` (state machine)
`S0` prechecks (env-accounts mode + client creds) → `S1` elicitation **form** (alias, email, scope-bundle **checkboxes** incl. an **"all optional scopes"** option, admin toggle) → `S2` atomic registry write (`mutateConfigFile`) + `invalidateAccountSet` (**BR3**) → `S3` Google consent (URL-mode elicitation when the client supports it, else server-side `openUrl`) over the shared loopback → `S4` granted-vs-requested scope diff (**BR5**: `E_SCOPE_NOT_GRANTED`).

### `account_reauth <alias>`
Same `S3`/`S4` for an existing alias — recover a dead refresh token or grant scopes after a profile change. Plain-string alias, off the fan-out path.

### Key decisions
- **Always visible** (meta, like `account_list`) — onboarding must not require `discover_all` first. `cud=read` via `CUD_OVERRIDES`: gated by the forced human approval, not the write-control profile.
- **Env-accounts guard**: `GOOGLE_ACCOUNTS` set → `account_add` refuses `E_ENV_ACCOUNTS_MODE` (config.json ignored) rather than writing a phantom row — caught during the live test.
- **Checkbox form** (boolean per common bundle + "all optional scopes" + a CSV field for the long tail) instead of a raw CSV field.
- New `src/oauth-consent.ts`: live-server-safe loopback (typed errors + timeout, never `process.exit`; redirect matches the `auth` CLI). HTTP-transport consent (`${BASE}/authorize`) lands with the OAuth AS.

### Tests / verification
- `tests/account-wizard.test.ts` — 13 tests (form schema, `validateAddForm` incl. `allBundles` supersede + dup/bad-alias/unknown-bundle rejects, `scopeGrantDiff`).
- 529 tests green; typecheck + lint + build clean.
- **Live-verified (BV-1) over a real Claude Code connection**: form rendered + returned input; env-mode guard returned `E_ENV_ACCOUNTS_MODE` cleanly (no crash); **`account_reauth personal` completed** — consent opened, loopback caught the redirect, token written, all scopes granted, usable without a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)