### PR TITLE
feat: public-base-URL override + Origin/host config plumbing (B11)

### DIFF
--- a/src/http-config.ts
+++ b/src/http-config.ts
@@ -1,0 +1,142 @@
+// Transport selection + public-base-URL / Origin / host config plumbing (B11).
+// Pure, resolved once at boot; the HTTP host that consumes this lands in B12
+// (cc-transport-hosting) and the AS metadata in B13 (oauth-authorization-server).
+// Owns the canonicalization rule (cc-transport-hosting BR4): a single mismatch
+// between the advertised resource URI and the client's `resource`/`aud` = a
+// perpetual 401 loop (the #1 interop bug), so it is normalized exactly once.
+
+export type Transport = 'stdio' | 'http' | 'both';
+
+export const DEFAULT_HTTP_HOST = '127.0.0.1';
+export const DEFAULT_HTTP_PORT = 4243;
+export const CLAUDE_AI_ORIGIN = 'https://claude.ai';
+
+/** Slug-carrying boot-time config failure; caller surfaces the message. */
+export class HttpConfigError extends Error {
+  constructor(
+    readonly slug: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'HttpConfigError';
+  }
+}
+
+export interface HttpConfig {
+  transport: Transport;
+  host: string;
+  port: number;
+  /** Canonical public base URL (BR4): lowercase scheme+host, no default port,
+   *  no trailing slash, no fragment/query. The issuer and every advertised
+   *  endpoint derive from this. */
+  publicUrl: string;
+  /** `${publicUrl}/mcp` — the canonical resource URI (JWT `aud` / PRM `resource`). */
+  resourceUri: string;
+  /** DNS-rebind Host allowlist. Both host[:port] and bare-host forms are
+   *  included: the Host header may or may not carry the port depending on the
+   *  client/proxy, and a too-narrow allowlist is a silent 403. */
+  allowedHosts: string[];
+  /** Origin allowlist for the front guard (publicUrl origin + claude.ai + extras). */
+  allowedOrigins: string[];
+}
+
+export function transportIncludesHttp(t: Transport): boolean {
+  return t === 'http' || t === 'both';
+}
+
+export function resolveTransport(env: NodeJS.ProcessEnv = process.env): Transport {
+  const raw = (env.MCP_TRANSPORT ?? '').trim().toLowerCase();
+  if (raw === '') return 'stdio';
+  if (raw === 'stdio' || raw === 'http' || raw === 'both') return raw;
+  // Load-bearing (decides whether a port opens): fail fast rather than silently
+  // downgrade — a user who set `http` and got stdio would be badly confused.
+  throw new HttpConfigError(
+    'E_INVALID_TRANSPORT',
+    `MCP_TRANSPORT must be one of stdio|http|both (got "${env.MCP_TRANSPORT}")`,
+  );
+}
+
+/**
+ * Canonicalize a public base URL per BR4. WHATWG `URL` already lowercases the
+ * scheme+host and omits a default port from `.host`; this adds the HTTPS-only
+ * scheme check, strips fragment/query/userinfo, and removes a trailing slash.
+ */
+export function canonicalizePublicUrl(raw: string): string {
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    throw new HttpConfigError('E_PUBLIC_URL_INVALID', `MCP_PUBLIC_URL is not a valid absolute URL: "${raw}"`);
+  }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+    throw new HttpConfigError('E_PUBLIC_URL_INVALID', `MCP_PUBLIC_URL must be http(s) (got "${raw}")`);
+  }
+  u.hash = '';
+  u.search = '';
+  u.username = '';
+  u.password = '';
+  const path = u.pathname.replace(/\/+$/, '');
+  return `${u.protocol}//${u.host}${path}`;
+}
+
+function resolvePort(raw: string | undefined): number {
+  const s = (raw ?? '').trim();
+  if (s === '') return DEFAULT_HTTP_PORT;
+  const n = Number(s);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new HttpConfigError('E_INVALID_HTTP_PORT', `MCP_HTTP_PORT must be an integer 1-65535 (got "${raw}")`);
+  }
+  return n;
+}
+
+/** `host:port`, bracketing a bare IPv6 literal so it is a valid URL authority. */
+function hostPort(host: string, port: number): string {
+  const h = host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+  return `${h}:${port}`;
+}
+
+function deriveAllowedHosts(publicUrl: string, host: string, port: number): string[] {
+  const pu = new URL(publicUrl);
+  const set = new Set<string>();
+  set.add(pu.host); // hostname[:port]
+  set.add(pu.hostname); // bare hostname
+  set.add(host);
+  set.add(hostPort(host, port));
+  return [...set];
+}
+
+function deriveAllowedOrigins(publicUrl: string, extra: string | undefined): string[] {
+  const set = new Set<string>();
+  set.add(new URL(publicUrl).origin);
+  set.add(CLAUDE_AI_ORIGIN);
+  for (const raw of (extra ?? '').split(',').map((s) => s.trim()).filter(Boolean)) {
+    let o: string;
+    try {
+      o = new URL(raw).origin;
+    } catch {
+      throw new HttpConfigError('E_INVALID_ORIGIN', `MCP_ALLOWED_ORIGINS entry is not a valid URL: "${raw}"`);
+    }
+    if (o === 'null') {
+      throw new HttpConfigError('E_INVALID_ORIGIN', `MCP_ALLOWED_ORIGINS entry has no usable origin: "${raw}"`);
+    }
+    set.add(o);
+  }
+  return [...set];
+}
+
+export function resolveHttpConfig(env: NodeJS.ProcessEnv = process.env): HttpConfig {
+  const transport = resolveTransport(env);
+  const host = (env.MCP_HTTP_HOST ?? '').trim() || DEFAULT_HTTP_HOST;
+  const port = resolvePort(env.MCP_HTTP_PORT);
+  const rawPublic = (env.MCP_PUBLIC_URL ?? '').trim() || `http://${hostPort(host, port)}`;
+  const publicUrl = canonicalizePublicUrl(rawPublic);
+  return {
+    transport,
+    host,
+    port,
+    publicUrl,
+    resourceUri: `${publicUrl}/mcp`,
+    allowedHosts: deriveAllowedHosts(publicUrl, host, port),
+    allowedOrigins: deriveAllowedOrigins(publicUrl, env.MCP_ALLOWED_ORIGINS),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,19 @@ async function main() {
     const { peekMasterKeyProvenance } = await import('./master-key.js');
     const prov = peekMasterKeyProvenance();
     console.log(`MASTER_KEY: ${prov === 'unprovisioned' ? 'unprovisioned (will be generated on first use)' : prov}`);
+    try {
+      const { resolveHttpConfig, transportIncludesHttp } = await import('./http-config.js');
+      const http = resolveHttpConfig();
+      console.log(`Transport: ${http.transport}`);
+      if (transportIncludesHttp(http.transport)) {
+        console.log(`  HTTP bind: ${http.host}:${http.port}`);
+        console.log(`  Public URL: ${http.publicUrl} (resource ${http.resourceUri})`);
+        console.log(`  Allowed hosts: ${http.allowedHosts.join(', ')}`);
+        console.log(`  Allowed origins: ${http.allowedOrigins.join(', ')}`);
+      }
+    } catch (e) {
+      console.log(`Transport: (config error) ${(e as Error).message}`);
+    }
     return;
   }
 

--- a/tests/http-config.test.ts
+++ b/tests/http-config.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canonicalizePublicUrl,
+  resolveTransport,
+  transportIncludesHttp,
+  resolveHttpConfig,
+  HttpConfigError,
+  CLAUDE_AI_ORIGIN,
+} from '../src/http-config.js';
+
+describe('resolveTransport', () => {
+  it('defaults to stdio when unset or blank', () => {
+    expect(resolveTransport({})).toBe('stdio');
+    expect(resolveTransport({ MCP_TRANSPORT: '' })).toBe('stdio');
+    expect(resolveTransport({ MCP_TRANSPORT: '   ' })).toBe('stdio');
+  });
+
+  it('accepts stdio|http|both, case-insensitive and trimmed', () => {
+    expect(resolveTransport({ MCP_TRANSPORT: 'stdio' })).toBe('stdio');
+    expect(resolveTransport({ MCP_TRANSPORT: 'HTTP' })).toBe('http');
+    expect(resolveTransport({ MCP_TRANSPORT: '  Both ' })).toBe('both');
+  });
+
+  it('fails fast on an unknown value rather than silently downgrading', () => {
+    expect(() => resolveTransport({ MCP_TRANSPORT: 'sse' })).toThrow(HttpConfigError);
+    try {
+      resolveTransport({ MCP_TRANSPORT: 'sse' });
+    } catch (e) {
+      expect((e as HttpConfigError).slug).toBe('E_INVALID_TRANSPORT');
+    }
+  });
+
+  it('transportIncludesHttp is true only for http/both', () => {
+    expect(transportIncludesHttp('stdio')).toBe(false);
+    expect(transportIncludesHttp('http')).toBe(true);
+    expect(transportIncludesHttp('both')).toBe(true);
+  });
+});
+
+describe('canonicalizePublicUrl (BR4)', () => {
+  it('strips a trailing slash', () => {
+    expect(canonicalizePublicUrl('https://mcp.example.com/')).toBe('https://mcp.example.com');
+    expect(canonicalizePublicUrl('https://mcp.example.com///')).toBe('https://mcp.example.com');
+  });
+
+  it('drops the default port for the scheme', () => {
+    expect(canonicalizePublicUrl('https://mcp.example.com:443')).toBe('https://mcp.example.com');
+    expect(canonicalizePublicUrl('http://mcp.example.com:80')).toBe('http://mcp.example.com');
+  });
+
+  it('keeps a non-default port', () => {
+    expect(canonicalizePublicUrl('http://127.0.0.1:4243')).toBe('http://127.0.0.1:4243');
+    expect(canonicalizePublicUrl('https://mcp.example.com:8443')).toBe('https://mcp.example.com:8443');
+  });
+
+  it('lowercases scheme and host', () => {
+    expect(canonicalizePublicUrl('HTTPS://MCP.EXAMPLE.COM')).toBe('https://mcp.example.com');
+  });
+
+  it('strips fragment, query, and userinfo', () => {
+    expect(canonicalizePublicUrl('https://mcp.example.com/#frag')).toBe('https://mcp.example.com');
+    expect(canonicalizePublicUrl('https://mcp.example.com/?a=1')).toBe('https://mcp.example.com');
+    expect(canonicalizePublicUrl('https://user:pass@mcp.example.com')).toBe('https://mcp.example.com');
+  });
+
+  it('preserves a non-root path but strips its trailing slash (case-sensitive path)', () => {
+    expect(canonicalizePublicUrl('https://mcp.example.com/Base/')).toBe('https://mcp.example.com/Base');
+  });
+
+  it('rejects a non-absolute or non-http(s) URL', () => {
+    for (const bad of ['not a url', 'ftp://x.com', 'ws://x.com', '/mcp', 'mcp.example.com']) {
+      expect(() => canonicalizePublicUrl(bad)).toThrow(HttpConfigError);
+    }
+    try {
+      canonicalizePublicUrl('ftp://x.com');
+    } catch (e) {
+      expect((e as HttpConfigError).slug).toBe('E_PUBLIC_URL_INVALID');
+    }
+  });
+
+  it('is idempotent: the canonical form re-canonicalizes to itself', () => {
+    const c = canonicalizePublicUrl('https://mcp.example.com/');
+    expect(canonicalizePublicUrl(c)).toBe(c);
+  });
+
+  it('NEGATIVE TEST: trailing-slash / default-port / wrong-case all collapse to ONE URI (the 401-loop guard)', () => {
+    const variants = [
+      'https://mcp.example.com',
+      'https://mcp.example.com/',
+      'https://mcp.example.com:443',
+      'https://mcp.example.com:443/',
+      'HTTPS://MCP.Example.com/',
+      'https://mcp.example.com/#x',
+    ];
+    const canon = variants.map(canonicalizePublicUrl);
+    expect(new Set(canon).size).toBe(1);
+    expect(canon[0]).toBe('https://mcp.example.com');
+  });
+});
+
+describe('resolveHttpConfig', () => {
+  it('stdio defaults: loopback bind, port 4243, loopback public URL', () => {
+    const c = resolveHttpConfig({});
+    expect(c.transport).toBe('stdio');
+    expect(c.host).toBe('127.0.0.1');
+    expect(c.port).toBe(4243);
+    expect(c.publicUrl).toBe('http://127.0.0.1:4243');
+    expect(c.resourceUri).toBe('http://127.0.0.1:4243/mcp');
+  });
+
+  it('derives allowlists behind a tunnel from MCP_PUBLIC_URL', () => {
+    const c = resolveHttpConfig({
+      MCP_TRANSPORT: 'http',
+      MCP_HTTP_HOST: '127.0.0.1',
+      MCP_HTTP_PORT: '4243',
+      MCP_PUBLIC_URL: 'https://mcp.example.com/',
+    });
+    expect(c.publicUrl).toBe('https://mcp.example.com');
+    expect(c.resourceUri).toBe('https://mcp.example.com/mcp');
+    expect(c.allowedHosts).toContain('mcp.example.com');
+    expect(c.allowedHosts).toContain('127.0.0.1');
+    expect(c.allowedHosts).toContain('127.0.0.1:4243');
+    expect(c.allowedOrigins).toContain('https://mcp.example.com');
+    expect(c.allowedOrigins).toContain(CLAUDE_AI_ORIGIN);
+  });
+
+  it('always includes claude.ai in the Origin allowlist and appends MCP_ALLOWED_ORIGINS', () => {
+    const c = resolveHttpConfig({
+      MCP_TRANSPORT: 'http',
+      MCP_PUBLIC_URL: 'https://mcp.example.com',
+      MCP_ALLOWED_ORIGINS: 'https://foo.example, https://bar.example:8443',
+    });
+    expect(c.allowedOrigins).toEqual(
+      expect.arrayContaining([
+        'https://mcp.example.com',
+        CLAUDE_AI_ORIGIN,
+        'https://foo.example',
+        'https://bar.example:8443',
+      ]),
+    );
+  });
+
+  it('dedupes allowed hosts for a default-port public URL', () => {
+    const c = resolveHttpConfig({
+      MCP_TRANSPORT: 'http',
+      MCP_HTTP_HOST: 'mcp.example.com',
+      MCP_HTTP_PORT: '443',
+      MCP_PUBLIC_URL: 'https://mcp.example.com',
+    });
+    // no duplicate entries
+    expect(new Set(c.allowedHosts).size).toBe(c.allowedHosts.length);
+    expect(c.allowedHosts).toContain('mcp.example.com');
+  });
+
+  it('brackets an IPv6 bind host in the default public URL and host allowlist', () => {
+    const c = resolveHttpConfig({ MCP_TRANSPORT: 'http', MCP_HTTP_HOST: '::1', MCP_HTTP_PORT: '4243' });
+    expect(c.publicUrl).toBe('http://[::1]:4243');
+    expect(c.resourceUri).toBe('http://[::1]:4243/mcp');
+    expect(c.allowedHosts).toContain('[::1]:4243');
+    expect(c.allowedHosts).toContain('::1');
+  });
+
+  it('rejects a bad port', () => {
+    for (const bad of ['0', '70000', 'abc', '-1', '80.5']) {
+      expect(() => resolveHttpConfig({ MCP_HTTP_PORT: bad })).toThrow(HttpConfigError);
+    }
+    try {
+      resolveHttpConfig({ MCP_HTTP_PORT: '0' });
+    } catch (e) {
+      expect((e as HttpConfigError).slug).toBe('E_INVALID_HTTP_PORT');
+    }
+  });
+
+  it('rejects a bad MCP_ALLOWED_ORIGINS entry', () => {
+    expect(() =>
+      resolveHttpConfig({ MCP_TRANSPORT: 'http', MCP_PUBLIC_URL: 'https://x.com', MCP_ALLOWED_ORIGINS: 'not a url' }),
+    ).toThrow(HttpConfigError);
+    try {
+      resolveHttpConfig({ MCP_TRANSPORT: 'http', MCP_PUBLIC_URL: 'https://x.com', MCP_ALLOWED_ORIGINS: 'garbage' });
+    } catch (e) {
+      expect((e as HttpConfigError).slug).toBe('E_INVALID_ORIGIN');
+    }
+  });
+});


### PR DESCRIPTION
**Slice B11** (`v6/2a-public-base-url`) — the config foundation for the HTTP/AS cluster. Stacks on `v6`.

## What

New `src/http-config.ts`, pure and resolved once at boot:

- `resolveTransport(env)` — `MCP_TRANSPORT` → `stdio | http | both` (default stdio); fails fast on an unknown value rather than silently downgrading `http`→stdio.
- `canonicalizePublicUrl(raw)` — the **BR4 canonicalization rule** (cc-transport-hosting): lowercase scheme+host, drop default port, strip trailing slash / fragment / query / userinfo, HTTPS-or-HTTP only. This is the guard against the #1 HTTP interop bug — a single mismatch between the advertised resource URI and the client's `resource`/`aud` is a perpetual 401 loop.
- `resolveHttpConfig(env)` — bundles `{transport, host, port, publicUrl, resourceUri, allowedHosts, allowedOrigins}`. Defaults: bind `127.0.0.1:4243`, public URL `http://127.0.0.1:4243`. Derives the DNS-rebind Host allowlist (with/without port; IPv6-bracketed) and the front-guard Origin allowlist (`publicUrl` origin + `https://claude.ai` + `MCP_ALLOWED_ORIGINS`).

`config check` now surfaces the resolved transport and (when http) the canonical public URL + allowlists.

No server is started here — B12 (`HttpTransportHost`) and B13 (OAuth AS) consume this. User-facing env docs land with B12 where the transport becomes functional.

## Tests

`tests/http-config.test.ts` (20): transport parsing + fail-fast, full canonicalization matrix incl. the **BR4 negative test** (trailing-slash / default-port / wrong-case all collapse to one URI), IPv6 bracketing, allowlist derivation + dedupe, bad-port / bad-origin rejection.

Gate: typecheck + lint clean, 548 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)