### PR TITLE
feat: Streamable HTTP transport (HttpTransportHost) (B12)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,21 @@ Each account can point at a named **scope profile** so consent is exactly what t
 
 Inspect the resolved setup any time: `mcp-google-multi config check`.
 
+## Transport
+
+By default the server speaks **stdio** (`MCP_TRANSPORT=stdio`), the zero-network local transport every example uses. It can also serve **Streamable HTTP** for MCP clients that connect over a URL.
+
+| Variable | Default | Notes |
+|---|---|---|
+| `MCP_TRANSPORT` | `stdio` | `stdio`, `http`, or `both` |
+| `MCP_HTTP_HOST` | `127.0.0.1` | bind address (loopback) |
+| `MCP_HTTP_PORT` | `4243` | bind port |
+| `MCP_PUBLIC_URL` | `http://<host>:<port>` | the canonical public base URL; `${MCP_PUBLIC_URL}/mcp` is the endpoint clients connect to |
+| `MCP_OWNER_EMAILS` | — | required for `http`: the Google email(s) allowed to authenticate |
+| `MCP_ALLOWED_ORIGINS` | — | extra Origins to allow beyond `MCP_PUBLIC_URL` and `https://claude.ai` |
+
+> **HTTP is currently loopback-only.** Until the built-in OAuth authorization server ships, the server refuses to start any exposed HTTP shape (a non-loopback bind, or a non-loopback `MCP_PUBLIC_URL` — i.e. a tunnel/reverse proxy in front). Loopback callers are trusted as the owner, the same trust model as stdio, so do not run HTTP mode on a shared host. Register the local URL with your client using `mcp-google-multi write-client-config --url http://127.0.0.1:4243/mcp`.
+
 ## Write-control (deny-by-default)
 
 Reads are never gated. **Every create/update/delete is off until you opt in** — pick a profile:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@googleapis/slides": "^6.0.0",
         "@googleapis/tasks": "^13.0.0",
         "@googleapis/webmasters": "^4.0.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "googleapis-common": "^8.0.3",
         "markdown-it": "15.0.0",
         "mime-types": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@googleapis/slides": "^6.0.0",
     "@googleapis/tasks": "^13.0.0",
     "@googleapis/webmasters": "^4.0.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "googleapis-common": "^8.0.3",
     "markdown-it": "15.0.0",
     "mime-types": "^3.0.2",

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -1,0 +1,325 @@
+// B12: the Streamable HTTP transport host (cc-transport-hosting T2/T3). Owns the
+// node:http server, the route table, the front guard (Host / Origin / DNS-rebind),
+// and the stateless per-request /mcp dispatch. The OAuth AS endpoints and Bearer
+// verification are a seam filled by B13 (oauth-authorization-server); B12 ships a
+// loopback-owner authenticator so the local-HTTP model works before the AS lands.
+
+import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { HttpConfig } from './http-config.js';
+
+export type AuthOutcome =
+  | { ok: true }
+  | { ok: false; status: number; body: string; headers?: Record<string, string> };
+
+/** Bearer / owner check for POST /mcp. B12 default = loopback-owner; B13 swaps in JWT verify. */
+export type Authenticator = (req: IncomingMessage) => AuthOutcome | Promise<AuthOutcome>;
+
+/** A mounted extra route (the AS endpoints, B13). Return true if it wrote a response. */
+export type RouteHandler = (req: IncomingMessage, res: ServerResponse, url: URL) => boolean | Promise<boolean>;
+
+export interface HttpHostOptions {
+  /** The ONE McpServer + registry built at boot (P1 / BV gap #4: never per request). */
+  server: McpServer;
+  config: HttpConfig;
+  version: string;
+  ownerConfigured: boolean;
+  authenticate: Authenticator;
+  /** Extra routes keyed by exact pathname (AS endpoints mount here in B13). */
+  routes?: Record<string, RouteHandler>;
+  log?: (line: string) => void;
+  /** Max /mcp JSON body bytes (DoS guard). */
+  maxBodyBytes?: number;
+}
+
+const LOOPBACK_LITERALS = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1', 'localhost']);
+
+export function isLoopbackAddress(addr: string | undefined | null): boolean {
+  if (!addr) return false;
+  return LOOPBACK_LITERALS.has(addr) || addr.startsWith('127.') || addr.startsWith('::ffff:127.');
+}
+
+/** True for a loopback bind/host literal. `0.0.0.0` / `::` (all interfaces) are
+ * deliberately NOT loopback — exposing them needs real auth (B13). */
+export function isLoopbackHost(host: string): boolean {
+  const h = host.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+  return h === 'localhost' || h === '::1' || h === '::ffff:127.0.0.1' || /^127\./.test(h);
+}
+
+/**
+ * B12 has no real MCP-client authentication yet (that is B13's OAuth AS), so it
+ * may only serve a purely-LOCAL loopback deployment where the trust model is the
+ * same as stdio: local processes on this machine are the owner. Any exposed
+ * shape — a non-loopback bind, or a non-loopback public URL (i.e. a tunnel /
+ * reverse proxy in front) — would let forwarded internet traffic arrive from
+ * 127.0.0.1 and be trusted as the owner, so it is refused until the AS lands.
+ * Returns an actionable error string, or null if the deployment is local-safe.
+ */
+export function remoteHttpRefusal(config: { host: string; publicUrl: string }): string | null {
+  let publicHost: string;
+  try {
+    publicHost = new URL(config.publicUrl).hostname;
+  } catch {
+    publicHost = config.publicUrl;
+  }
+  if (isLoopbackHost(config.host) && isLoopbackHost(publicHost)) return null;
+  return (
+    `E_HTTP_REMOTE_UNSUPPORTED: exposed HTTP (bind "${config.host}", public "${config.publicUrl}") is refused because this build has no MCP-client authentication yet — that is the OAuth authorization server (a later slice). ` +
+    'Serve loopback-only (MCP_HTTP_HOST=127.0.0.1 with a loopback MCP_PUBLIC_URL) and do NOT place a tunnel/reverse proxy in front until the AS is enabled.'
+  );
+}
+
+export function parseOwnerEmails(env: NodeJS.ProcessEnv = process.env): string[] {
+  return (env.MCP_OWNER_EMAILS ?? '')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+/** Front guard: an Origin, if present, must be allowlisted; a Host must be
+ * allowlisted. Absent Origin passes (native/CLI/backend clients — the claude.ai
+ * connector calls /mcp server-to-server with no Origin, BV-4). */
+export function originAllowed(origin: string | undefined, allowed: string[]): boolean {
+  if (!origin) return true;
+  return allowed.includes(origin);
+}
+
+export function hostAllowed(host: string | undefined, allowed: string[]): boolean {
+  if (allowed.length === 0) return true;
+  if (!host) return false;
+  // Port-agnostic, matching the SDK's DNS-rebind guard: allow an exact match or
+  // the bare hostname (allowedHosts carries both host[:port] and bare forms).
+  const bare = host.replace(/:\d+$/, '');
+  return allowed.includes(host) || allowed.includes(bare);
+}
+
+/**
+ * B12 default authenticator (no OAuth AS yet): trust loopback callers as the
+ * owner — the DM1/DM2 local model where the local process IS the owner — and
+ * reject remote callers with a 401 pointing at the not-yet-enabled AS. B13
+ * replaces this with HS256 Bearer verification for the remote (tunnel) path.
+ *
+ * This is only ever wired for a loopback-only deployment (remoteHttpRefusal
+ * guards the bootstrap), so every caller is local. Like stdio, loopback binding
+ * does NOT isolate between local users: any process on this host that can reach
+ * 127.0.0.1:PORT is treated as the owner. That is the accepted single-user
+ * trust model; a shared host should not run this in HTTP mode.
+ */
+export function loopbackOwnerAuthenticator(base: string): Authenticator {
+  return (req) => {
+    if (isLoopbackAddress(req.socket.remoteAddress)) return { ok: true };
+    return {
+      ok: false,
+      status: 401,
+      headers: {
+        'WWW-Authenticate': `Bearer resource_metadata="${base}/.well-known/oauth-protected-resource", scope="mcp:use"`,
+      },
+      body: JSON.stringify({
+        error: 'unauthorized',
+        message: 'Remote access requires the OAuth authorization server, which is not enabled in this build.',
+      }),
+    };
+  };
+}
+
+export class HttpTransportHost {
+  private httpServer?: Server;
+  // Serialize the connect→dispatch critical section: the shared McpServer
+  // captures its transport per request (protocol.js), but the gap between
+  // connect() and the dispatch capturing it would still race under true
+  // concurrency. Single-owner HTTP traffic is effectively serial, so a mutex
+  // keeps correctness at negligible cost (and never rebuilds the registry).
+  private lock: Promise<unknown> = Promise.resolve();
+
+  constructor(private readonly opts: HttpHostOptions) {}
+
+  private serialize<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.lock.then(fn, fn);
+    this.lock = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run as Promise<T>;
+  }
+
+  private log(line: string): void {
+    this.opts.log?.(line);
+  }
+
+  async start(): Promise<void> {
+    const { config } = this.opts;
+    const server = createServer((req, res) => {
+      this.handle(req, res).catch((e) => this.fail(res, 500, 'internal_error', (e as Error).message));
+    });
+    // Slow-loris mitigation behind the tunnel.
+    server.headersTimeout = 15_000;
+    server.requestTimeout = 30_000;
+    this.httpServer = server;
+    await new Promise<void>((resolve, reject) => {
+      const onErr = (e: Error) => reject(e);
+      server.once('error', onErr);
+      server.listen(config.port, config.host, () => {
+        server.off('error', onErr);
+        resolve();
+      });
+    });
+    this.log(`listening on ${config.host}:${config.port} (public ${config.publicUrl}, transport ${config.transport})`);
+  }
+
+  async close(): Promise<void> {
+    const s = this.httpServer;
+    if (!s) return;
+    await new Promise<void>((resolve) => {
+      s.close(() => resolve());
+      s.closeAllConnections?.();
+    });
+    this.httpServer = undefined;
+  }
+
+  /** The bound port (useful when listening on port 0 in tests). */
+  address(): { port: number } | undefined {
+    const a = this.httpServer?.address();
+    return a && typeof a === 'object' ? { port: a.port } : undefined;
+  }
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // req.url is the path+query; parse against a FIXED base so a malformed/hostile
+    // Host header can't throw here (the Host is validated in the front guard).
+    const url = new URL(req.url ?? '/', 'http://localhost');
+    const path = url.pathname;
+
+    if (path === '/health') {
+      if (req.method !== 'GET') {
+        res.setHeader('Allow', 'GET');
+        return this.fail(res, 405, 'method_not_allowed', 'GET /health only');
+      }
+      return this.health(res);
+    }
+
+    const route = this.opts.routes?.[path];
+    if (route) {
+      if (!this.frontGuard(req, res)) return;
+      const handled = await route(req, res, url);
+      if (!handled && !res.writableEnded) this.fail(res, 404, 'not_found', `No handler for ${path}`);
+      return;
+    }
+
+    if (path === '/mcp') return this.mcp(req, res);
+
+    this.fail(res, 404, 'not_found', `Unknown path ${path}`);
+  }
+
+  private frontGuard(req: IncomingMessage, res: ServerResponse): boolean {
+    const { allowedHosts, allowedOrigins } = this.opts.config;
+    if (!hostAllowed(req.headers.host, allowedHosts)) {
+      this.log(`403 host_rejected host=${req.headers.host ?? ''}`);
+      this.fail(res, 403, 'host_rejected', 'Host not allowed (DNS-rebinding guard).');
+      return false;
+    }
+    if (!originAllowed(req.headers.origin, allowedOrigins)) {
+      this.log(`403 origin_rejected origin=${req.headers.origin ?? ''}`);
+      this.fail(res, 403, 'origin_rejected', 'Origin not allowed.');
+      return false;
+    }
+    return true;
+  }
+
+  private async mcp(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (req.method !== 'POST') {
+      res.setHeader('Allow', 'POST');
+      return this.fail(res, 405, 'method_not_allowed', 'POST /mcp only (stateless mode; no GET SSE).');
+    }
+    if (!this.frontGuard(req, res)) return;
+
+    const auth = await this.opts.authenticate(req);
+    if (!auth.ok) {
+      for (const [k, v] of Object.entries(auth.headers ?? {})) res.setHeader(k, v);
+      res.writeHead(auth.status, { 'Content-Type': 'application/json' });
+      res.end(auth.body);
+      this.log(`${auth.status} auth_failed path=/mcp`);
+      return;
+    }
+
+    let body: unknown;
+    try {
+      body = await this.readJson(req);
+    } catch (e) {
+      return this.fail(res, 400, 'invalid_body', (e as Error).message);
+    }
+
+    // Host/Origin are enforced by the front guard above (uniformly for /mcp and
+    // the mounted AS routes), so the SDK's own DNS-rebind guard is disabled: its
+    // exact-Host match is stricter than the front guard and would 403 valid
+    // Hosts (double enforcement, differing rules).
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+      enableDnsRebindingProtection: false,
+    });
+    // The shared McpServer holds exactly one connected transport at a time, so
+    // connect + dispatch + DISCONNECT all run inside the mutex: the next request
+    // can never hit "Already connected", and a client disconnect can't wedge the
+    // lock — dispatch is raced against res 'close' so it always settles, and the
+    // transport is closed in a finally (which resets server._transport) before
+    // the lock releases. (A shared initialized-state persists across stateless
+    // requests; benign for the single-owner design.)
+    await this.serialize(async () => {
+      const disconnected = new Promise<void>((resolve) => res.once('close', resolve));
+      await this.opts.server.connect(transport);
+      try {
+        await Promise.race([transport.handleRequest(req, res, body), disconnected]);
+      } finally {
+        await transport.close().catch(() => undefined);
+      }
+    });
+  }
+
+  private health(res: ServerResponse): void {
+    const { config, ownerConfigured, version } = this.opts;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    // No secrets, no owner emails (cc-transport-hosting /health rule).
+    res.end(
+      JSON.stringify({
+        status: 'ok',
+        transport: config.transport,
+        publicUrl: config.publicUrl,
+        ownerConfigured,
+        version,
+      }),
+    );
+  }
+
+  private readJson(req: IncomingMessage): Promise<unknown> {
+    const max = this.opts.maxBodyBytes ?? 4_000_000;
+    return new Promise((resolve, reject) => {
+      let size = 0;
+      const chunks: Buffer[] = [];
+      req.on('data', (c: Buffer) => {
+        size += c.length;
+        if (size > max) {
+          reject(new Error('request body too large'));
+          req.destroy();
+          return;
+        }
+        chunks.push(c);
+      });
+      req.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf-8');
+        if (raw.trim() === '') return resolve(undefined);
+        try {
+          resolve(JSON.parse(raw));
+        } catch {
+          reject(new Error('request body is not valid JSON'));
+        }
+      });
+      req.on('error', reject);
+    });
+  }
+
+  private fail(res: ServerResponse, status: number, error: string, message: string): void {
+    if (res.writableEnded) return;
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error, message }));
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { GENERATED_SERVICES } from './tools/generated/index.js';
 import { GENERATED_GATES, SERVICES } from './services.js';
-import { ToolRegistry } from './registry.js';
+import { ToolRegistry, type DiscoveryMode } from './registry.js';
 import { registerDiscoverTools } from './discover.js';
 import { registerEscapeTools } from './tools/google-api.js';
 import { registerAccountTools } from './tools/accounts-tool.js';
@@ -22,9 +22,9 @@ import { registerSetupPrompt } from './setup-prompt.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, '..', 'package.json'), 'utf-8'));
 
-function buildRegistry(server: McpServer, ctx: IdentityContext): ToolRegistry {
+function buildRegistry(server: McpServer, ctx: IdentityContext, mode?: DiscoveryMode): ToolRegistry {
   const policy = ctx.policy;
-  const registry = new ToolRegistry(server, policy);
+  const registry = new ToolRegistry(server, policy, mode);
   const toolsets = getToolsets();
   if (toolsets !== 'all') {
     const known = new Set([...SERVICES.map((s) => s.name), ...GENERATED_SERVICES.map((s) => s.name)]);
@@ -165,16 +165,74 @@ async function main() {
   // specced "fatal at startup", never mid-dispatch.
   const { resolveMasterKey } = await import('./master-key.js');
   resolveMasterKey();
-  const server = new McpServer({
-    name: 'mcp-google-multi',
-    version: pkg.version,
-  });
-  const registry = buildRegistry(server, ctx);
-  registry.installListHandler();
-  registerSetupPrompt(server);
 
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  const { resolveHttpConfig, transportIncludesHttp } = await import('./http-config.js');
+  let httpCfg;
+  try {
+    httpCfg = resolveHttpConfig();
+  } catch (e) {
+    process.stderr.write(`Fatal: ${(e as Error).message}\n`);
+    process.exit(1);
+  }
+  const wantStdio = httpCfg.transport === 'stdio' || httpCfg.transport === 'both';
+  const wantHttp = transportIncludesHttp(httpCfg.transport);
+
+  // Build one McpServer + registry per transport at boot (P1 / BV gap #4:
+  // never rebuilt per request); `both` runs the two concurrently.
+  if (wantStdio) {
+    const server = new McpServer({ name: 'mcp-google-multi', version: pkg.version });
+    const registry = buildRegistry(server, ctx);
+    registry.installListHandler();
+    registerSetupPrompt(server);
+    await server.connect(new StdioServerTransport());
+  }
+
+  if (wantHttp) {
+    const { HttpTransportHost, loopbackOwnerAuthenticator, parseOwnerEmails, remoteHttpRefusal } = await import(
+      './http-transport.js'
+    );
+    // Until the OAuth AS (B13) lands there is no MCP-client authentication, so
+    // refuse any exposed/tunnelled HTTP shape and serve loopback-only.
+    const refusal = remoteHttpRefusal(httpCfg);
+    if (refusal) {
+      process.stderr.write(`${refusal}\n`);
+      process.exit(1);
+    }
+    // BR3: the owner allowlist is the entire multi-tenant collapse; refuse to
+    // open an ungated HTTP endpoint.
+    const owners = parseOwnerEmails(process.env);
+    if (owners.length === 0) {
+      process.stderr.write(
+        'E_OWNER_EMAILS_REQUIRED: MCP_TRANSPORT includes http but MCP_OWNER_EMAILS is empty. Set MCP_OWNER_EMAILS to the Google email(s) allowed to authenticate.\n',
+      );
+      process.exit(1);
+    }
+    // BR7: stateless HTTP cannot push tools/list_changed, so it forces curated.
+    const configuredMode = (process.env.GOOGLE_DISCOVERY ?? '').trim().toLowerCase();
+    if (configuredMode && configuredMode !== 'curated') {
+      process.stderr.write(`GOOGLE_DISCOVERY="${configuredMode}" is ignored over HTTP; the stateless transport forces "curated".\n`);
+    }
+    const httpServer = new McpServer({ name: 'mcp-google-multi', version: pkg.version });
+    const registry = buildRegistry(httpServer, ctx, 'curated');
+    registry.installListHandler();
+    registerSetupPrompt(httpServer);
+    const host = new HttpTransportHost({
+      server: httpServer,
+      config: httpCfg,
+      version: pkg.version,
+      ownerConfigured: owners.length > 0,
+      authenticate: loopbackOwnerAuthenticator(httpCfg.publicUrl),
+      log: (l) => process.stderr.write(`[http] ${l}\n`),
+    });
+    await host.start();
+    process.stderr.write(`HTTP transport listening on http://${httpCfg.host}:${httpCfg.port} (public ${httpCfg.publicUrl})\n`);
+    // Graceful shutdown so `docker run --init` (B16) forwards SIGTERM cleanly.
+    const shutdown = () => {
+      host.close().finally(() => process.exit(0));
+    };
+    process.once('SIGTERM', shutdown);
+    process.once('SIGINT', shutdown);
+  }
 }
 
 main().catch((err) => {

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import http from 'node:http';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { resolveHttpConfig } from '../src/http-config.js';
+import {
+  HttpTransportHost,
+  isLoopbackAddress,
+  isLoopbackHost,
+  remoteHttpRefusal,
+  parseOwnerEmails,
+  originAllowed,
+  hostAllowed,
+  loopbackOwnerAuthenticator,
+  type Authenticator,
+} from '../src/http-transport.js';
+
+// ---- pure helpers -----------------------------------------------------------
+
+describe('http-transport pure helpers', () => {
+  it('isLoopbackAddress', () => {
+    for (const a of ['127.0.0.1', '::1', '::ffff:127.0.0.1', '127.0.0.5', 'localhost']) {
+      expect(isLoopbackAddress(a)).toBe(true);
+    }
+    for (const a of ['10.0.0.1', '203.0.113.4', '', undefined, null]) {
+      expect(isLoopbackAddress(a)).toBe(false);
+    }
+  });
+
+  it('parseOwnerEmails: CSV, trims, lowercases, drops blanks', () => {
+    expect(parseOwnerEmails({ MCP_OWNER_EMAILS: ' Me@Ex.com , you@ex.com , ' })).toEqual(['me@ex.com', 'you@ex.com']);
+    expect(parseOwnerEmails({})).toEqual([]);
+  });
+
+  it('originAllowed: absent passes, present must be allowlisted', () => {
+    expect(originAllowed(undefined, ['https://claude.ai'])).toBe(true);
+    expect(originAllowed('https://claude.ai', ['https://claude.ai'])).toBe(true);
+    expect(originAllowed('https://evil.example', ['https://claude.ai'])).toBe(false);
+  });
+
+  it('hostAllowed: exact or bare hostname, port-agnostic', () => {
+    const allowed = ['mcp.example.com', '127.0.0.1:4243', '127.0.0.1'];
+    expect(hostAllowed('mcp.example.com', allowed)).toBe(true);
+    expect(hostAllowed('127.0.0.1:4243', allowed)).toBe(true);
+    expect(hostAllowed('127.0.0.1:9999', allowed)).toBe(true); // bare match
+    expect(hostAllowed('evil.example', allowed)).toBe(false);
+    expect(hostAllowed(undefined, allowed)).toBe(false);
+    expect(hostAllowed('anything', [])).toBe(true); // no allowlist configured
+  });
+
+  it('isLoopbackHost: loopback literals only; 0.0.0.0 / :: / public are NOT', () => {
+    for (const h of ['127.0.0.1', 'localhost', '::1', '127.5.5.5', '[::1]']) expect(isLoopbackHost(h)).toBe(true);
+    for (const h of ['0.0.0.0', '::', 'mcp.example.com', '10.0.0.1']) expect(isLoopbackHost(h)).toBe(false);
+  });
+
+  it('remoteHttpRefusal: null for loopback, error for any exposed shape', () => {
+    expect(remoteHttpRefusal({ host: '127.0.0.1', publicUrl: 'http://127.0.0.1:4243' })).toBeNull();
+    expect(remoteHttpRefusal({ host: '0.0.0.0', publicUrl: 'http://127.0.0.1:4243' })).toContain('E_HTTP_REMOTE_UNSUPPORTED');
+    expect(remoteHttpRefusal({ host: '127.0.0.1', publicUrl: 'https://mcp.example.com' })).toContain('E_HTTP_REMOTE_UNSUPPORTED');
+  });
+
+  it('loopbackOwnerAuthenticator: loopback ok, remote 401 with WWW-Authenticate', () => {
+    const auth = loopbackOwnerAuthenticator('https://mcp.example.com');
+    expect(auth({ socket: { remoteAddress: '127.0.0.1' } } as never)).toEqual({ ok: true });
+    const remote = auth({ socket: { remoteAddress: '203.0.113.5' } } as never) as { ok: false; status: number; headers: Record<string, string> };
+    expect(remote.ok).toBe(false);
+    expect(remote.status).toBe(401);
+    expect(remote.headers['WWW-Authenticate']).toContain('oauth-protected-resource');
+  });
+});
+
+// ---- integration: real McpServer over the host (BV-3) ------------------------
+
+const hosts: HttpTransportHost[] = [];
+afterEach(async () => {
+  await Promise.all(hosts.splice(0).map((h) => h.close()));
+});
+
+function makeServer(): McpServer {
+  const s = new McpServer({ name: 'test-http', version: '0.0.0' });
+  s.registerTool('ping', { description: 'ping the server', inputSchema: {} }, async () => ({
+    content: [{ type: 'text' as const, text: 'pong' }],
+  }));
+  s.registerTool('slow', { description: 'slow tool', inputSchema: {} }, async () => {
+    await new Promise((r) => setTimeout(r, 300));
+    return { content: [{ type: 'text' as const, text: 'done' }] };
+  });
+  return s;
+}
+
+async function startHost(authenticate: Authenticator = () => ({ ok: true })): Promise<number> {
+  const config = { ...resolveHttpConfig({ MCP_TRANSPORT: 'http' }), port: 0 };
+  const host = new HttpTransportHost({ server: makeServer(), config, version: '9.9.9', ownerConfigured: true, authenticate });
+  await host.start();
+  hosts.push(host);
+  return host.address()!.port;
+}
+
+function request(
+  port: number,
+  method: string,
+  path: string,
+  opts: { headers?: Record<string, string>; body?: unknown; signal?: AbortSignal } = {},
+): Promise<{ status: number; headers: http.IncomingHttpHeaders; text: string }> {
+  return new Promise((resolve, reject) => {
+    const data = opts.body !== undefined ? Buffer.from(JSON.stringify(opts.body)) : undefined;
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        method,
+        path,
+        signal: opts.signal,
+        headers: {
+          host: '127.0.0.1', // an allowlisted bare host
+          ...(data ? { 'content-type': 'application/json', 'content-length': String(data.length) } : {}),
+          ...opts.headers,
+        },
+      },
+      (res) => {
+        let text = '';
+        res.on('data', (c) => (text += c));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, headers: res.headers, text }));
+      },
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+const MCP_ACCEPT = 'application/json, text/event-stream';
+const initBody = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'test', version: '0' } },
+};
+
+describe('HttpTransportHost (BV-3: stateless dispatch)', () => {
+  it('POST /mcp initialize returns a JSON-RPC result', async () => {
+    const port = await startHost();
+    const res = await request(port, 'POST', '/mcp', { headers: { accept: MCP_ACCEPT }, body: initBody });
+    expect(res.status).toBe(200);
+    const json = JSON.parse(res.text);
+    expect(json.jsonrpc).toBe('2.0');
+    expect(json.result.serverInfo.name).toBe('test-http');
+  });
+
+  it('POST /mcp tools/list advertises registered tools', async () => {
+    const port = await startHost();
+    await request(port, 'POST', '/mcp', { headers: { accept: MCP_ACCEPT }, body: initBody });
+    const res = await request(port, 'POST', '/mcp', {
+      headers: { accept: MCP_ACCEPT },
+      body: { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+    });
+    expect(res.status).toBe(200);
+    const json = JSON.parse(res.text);
+    const names = (json.result.tools as { name: string }[]).map((t) => t.name);
+    expect(names).toContain('ping');
+  });
+
+  it('GET /mcp is 405 (no SSE in stateless mode)', async () => {
+    const port = await startHost();
+    const res = await request(port, 'GET', '/mcp');
+    expect(res.status).toBe(405);
+    expect(res.headers.allow).toBe('POST');
+  });
+
+  it('GET /health returns status + no secrets', async () => {
+    const port = await startHost();
+    const res = await request(port, 'GET', '/health');
+    expect(res.status).toBe(200);
+    const json = JSON.parse(res.text);
+    expect(json).toMatchObject({ status: 'ok', transport: 'http', ownerConfigured: true });
+    expect(res.text).not.toMatch(/MASTER_KEY|token|secret|@/i);
+  });
+
+  it('rejects a present-but-invalid Origin with 403', async () => {
+    const port = await startHost();
+    const res = await request(port, 'POST', '/mcp', {
+      headers: { accept: MCP_ACCEPT, origin: 'https://evil.example' },
+      body: initBody,
+    });
+    expect(res.status).toBe(403);
+    expect(JSON.parse(res.text).error).toBe('origin_rejected');
+  });
+
+  it('rejects a bad Host with 403', async () => {
+    const port = await startHost();
+    const res = await request(port, 'POST', '/mcp', {
+      headers: { accept: MCP_ACCEPT, host: 'evil.example' },
+      body: initBody,
+    });
+    expect(res.status).toBe(403);
+    expect(JSON.parse(res.text).error).toBe('host_rejected');
+  });
+
+  it('rejects unauthenticated callers (401 from the authenticator)', async () => {
+    const port = await startHost(() => ({ ok: false, status: 401, body: JSON.stringify({ error: 'unauthorized' }) }));
+    const res = await request(port, 'POST', '/mcp', { headers: { accept: MCP_ACCEPT }, body: initBody });
+    expect(res.status).toBe(401);
+    expect(JSON.parse(res.text).error).toBe('unauthorized');
+  });
+
+  it('unknown path is 404', async () => {
+    const port = await startHost();
+    const res = await request(port, 'GET', '/nope');
+    expect(res.status).toBe(404);
+  });
+
+  it('handles many concurrent /mcp requests without "Already connected" 500s', async () => {
+    const port = await startHost();
+    await request(port, 'POST', '/mcp', { headers: { accept: MCP_ACCEPT }, body: initBody });
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, i) =>
+        request(port, 'POST', '/mcp', {
+          headers: { accept: MCP_ACCEPT },
+          body: { jsonrpc: '2.0', id: 100 + i, method: 'tools/list', params: {} },
+        }),
+      ),
+    );
+    for (const r of results) {
+      expect(r.status).toBe(200);
+      expect(JSON.parse(r.text).result.tools).toBeDefined();
+    }
+  });
+
+  it('recovers after a client disconnects mid-dispatch (mutex not deadlocked)', async () => {
+    const port = await startHost();
+    await request(port, 'POST', '/mcp', { headers: { accept: MCP_ACCEPT }, body: initBody });
+    // Start a slow (300ms) tool call and abort it ~40ms in.
+    const ac = new AbortController();
+    const slow = request(port, 'POST', '/mcp', {
+      headers: { accept: MCP_ACCEPT },
+      body: { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'slow', arguments: {} } },
+      signal: ac.signal,
+    }).catch(() => undefined);
+    await new Promise((r) => setTimeout(r, 40));
+    ac.abort();
+    await slow;
+    // If the lock wedged on disconnect this would hang; it must return promptly.
+    const after = await request(port, 'POST', '/mcp', {
+      headers: { accept: MCP_ACCEPT },
+      body: { jsonrpc: '2.0', id: 6, method: 'tools/list', params: {} },
+    });
+    expect(after.status).toBe(200);
+    expect(JSON.parse(after.text).result.tools).toBeDefined();
+  });
+});


### PR DESCRIPTION
**Slice B12** (`v6/2b-http-transport`) — the net-new Streamable HTTP transport. Stacks on B1 (registry/IdentityContext) + B11 (transport config).

## What
`src/http-transport.ts` — `HttpTransportHost` over `node:http`:
- **Stateless dispatch**: a fresh `StreamableHTTPServerTransport` (SDK 1.30, `sessionIdGenerator:undefined`, `enableJsonResponse:true`) per `POST /mcp`; the one `McpServer`+registry is built **once at boot** (P1 / BV gap#4), never per request.
- **Front guard**: Host allowlist (DNS-rebind) + Origin allowlist (absent Origin passes — the claude.ai backend calls server-to-server, BV-4) + method (`GET /mcp` → 405). Single enforcement point.
- **Routes**: `POST /mcp`, `GET /health` (status only, no secrets), and a `routes` seam where B13 mounts the AS endpoints + Bearer verification.
- **Bootstrap**: `MCP_TRANSPORT` = `stdio`|`http`|`both`; BR3 requires `MCP_OWNER_EMAILS`; BR7 forces `curated` over HTTP; graceful SIGTERM shutdown (B16). SDK floor → `^1.30.0`.

## BV-3 — discharged live
The real SDK 1.30 stateless transport dispatches `initialize` + `tools/list` over the shared server, advertising the full curated surface (180 tools, metas visible as already-present). Verified end-to-end against `dist`.

## Adversarial review (multi-lens workflow) — 10 confirmed findings fixed pre-merge
- **CRITICAL auth-bypass**: loopback==owner is unsafe behind a tunnel (forwarded traffic arrives from `127.0.0.1`). **B12 now refuses any exposed HTTP shape** (non-loopback bind or non-loopback `MCP_PUBLIC_URL`) and serves **loopback-local only** until the OAuth AS (B13) lands. Live-verified: `0.0.0.0` bind and tunnel-shaped public URL both refused; loopback still works.
- **CRITICAL deadlock**: a client disconnect mid-dispatch wedged the serialize mutex forever (JSON-mode `handleRequest` never settles after abort). Fixed: dispatch raced against `res 'close'`, transport closed in a `finally` **inside** the lock — the lock always releases and the next connect never hits "Already connected". Concurrency + disconnect-recovery tests added.
- DNS-rebind: single enforcement (front guard); the SDK's stricter exact-Host duplicate disabled.

## Tests
`tests/http-transport.test.ts` (17): pure helpers, loopback/remote-refusal, real-server BV-3 integration (initialize/tools-list/405/health/403-origin/403-host/401/404), **8-way concurrency** (no "Already connected"), **disconnect recovery** (mutex not deadlocked).

Gate: typecheck + lint clean, **581 tests** pass (rebased on B15), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)