### PR TITLE
feat: encrypted account registry export/import (B19)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -100,4 +100,12 @@ Two always-visible, human-approved tools (`anthropic/requiresUserInteraction`) m
 
 Both reuse the loopback consent flow (your own OAuth client), so tokens never leave your machine. (HTTP-transport consent lands with the OAuth authorization server.)
 
+### Move a setup to another machine: `account export` / `account import`
+
+`mcp-google-multi account export --out bundle.enc` packs your registry (`config.json` accounts + scope profiles) and every encrypted `<alias>.enc` token file into a single bundle, encrypted under a **passphrase** you choose (set `MCP_TRANSFER_PASSPHRASE` or you'll be prompted). Secrets like `MASTER_KEY` and your client secret are never in the bundle.
+
+`mcp-google-multi account import bundle.enc` decrypts it and **merges** the accounts into the target's registry — new aliases are added, and an alias that already exists is skipped (never clobbering local tokens) unless you pass `--replace`. It backs the choice on collision, then points you at `doctor` to check token health.
+
+Two caveats: the bundled token files stay encrypted under the **source** machine's `MASTER_KEY`, so set the same `MASTER_KEY` on the target to use them (otherwise re-authenticate with `account_reauth`); and the target must already have at least one account configured (the server won't start with an empty registry), so configure the target first, then import to bring the rest.
+
 - **`account_write_config`** registers this server with your MCP client so you don't hand-edit JSON. It detects Claude Code, Claude Desktop, and Cursor, then returns the exact entry to add — a `claude mcp add …` command for Claude Code, or an `mcpServers` JSON snippet for the file-based clients. Pass `write:true` to write the detected file configs in place; it backs the file up first, updates any existing entry rather than duplicating, and refuses to clobber a malformed config (it prints the snippet instead). Secrets are never inlined — the server loads its own `.env`, so the entry carries none. The same flow is available on the CLI: `mcp-google-multi write-client-config [--client claude-code|claude-desktop|cursor] [--url <https://…/mcp>] [--print] [--yes]` (prints instead of writing when non-interactive or `--print`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,18 @@ async function main() {
     return;
   }
 
+  if (process.argv.includes('account') && process.argv.includes('export')) {
+    const { runExportCli } = await import('./registry-transfer.js');
+    process.exitCode = await runExportCli(process.argv);
+    return;
+  }
+
+  if (process.argv.includes('account') && process.argv.includes('import')) {
+    const { runImportCli } = await import('./registry-transfer.js');
+    process.exitCode = await runImportCli(process.argv);
+    return;
+  }
+
   if (process.argv.includes('config') && process.argv.includes('check')) {
     const ctx = buildIdentityContext();
     const policy = ctx.policy;

--- a/src/registry-transfer.ts
+++ b/src/registry-transfer.ts
@@ -1,0 +1,272 @@
+// B19: encrypted registry export / import (account-registry.md). Moves a whole
+// setup to another machine. The bundle is encrypted under a user PASSPHRASE
+// (portable across machines with different MASTER_KEYs) via the token-store AES
+// primitives; the bundled <alias>.enc token files stay encrypted under the
+// SOURCE MASTER_KEY (double-locked), so the target needs the same MASTER_KEY to
+// use them. Secrets (MASTER_KEY / client secret) are never in the bundle.
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import * as readline from 'node:readline';
+import path from 'node:path';
+import { encryptToken, decryptToken } from './token-store.js';
+import { atomicWriteFileSync, atomicWriteWithLock } from './fs-atomic.js';
+import { configFilePath, CONFIG_VERSION } from './config-file.js';
+import { getTokenDir } from './accounts.js';
+
+const ALIAS_RE = /^[a-zA-Z0-9_-]+$/;
+
+export interface TransferBundle {
+  manifest: { v: 1; exportedAt: string; aliases: string[] };
+  /** Raw config.json contents (plaintext registry; no secrets). */
+  config: string | null;
+  /** alias -> raw <alias>.enc contents (still under the SOURCE MASTER_KEY). */
+  tokens: Record<string, string>;
+}
+
+export interface TransferDeps {
+  configPath?: string;
+  tokenDir?: string;
+  fileExists?: (p: string) => boolean;
+  readFile?: (p: string) => string;
+  listDir?: (p: string) => string[];
+}
+
+interface ResolvedDeps {
+  configPath: string;
+  tokenDir: string;
+  fileExists: (p: string) => boolean;
+  readFile: (p: string) => string;
+  listDir: (p: string) => string[];
+}
+
+function resolveDeps(deps: TransferDeps): ResolvedDeps {
+  return {
+    configPath: deps.configPath ?? configFilePath(),
+    tokenDir: deps.tokenDir ?? getTokenDir(),
+    fileExists: deps.fileExists ?? existsSync,
+    readFile: deps.readFile ?? ((p) => readFileSync(p, 'utf-8')),
+    listDir: deps.listDir ?? ((p) => (existsSync(p) ? readdirSync(p) : [])),
+  };
+}
+
+/** Collect the config + every `<alias>.enc` token file present in the token dir. */
+export function buildTransferBundle(exportedAt: string, deps: TransferDeps = {}): TransferBundle {
+  const r = resolveDeps(deps);
+  const config = r.fileExists(r.configPath) ? r.readFile(r.configPath) : null;
+  const tokens: Record<string, string> = {};
+  for (const name of r.listDir(r.tokenDir)) {
+    if (!name.endsWith('.enc')) continue;
+    const alias = name.slice(0, -'.enc'.length);
+    if (!ALIAS_RE.test(alias)) continue; // never trust a stray filename as an alias
+    tokens[alias] = r.readFile(path.join(r.tokenDir, name));
+  }
+  // Alias list = token-authed aliases plus any account defined only in config.
+  const aliasSet = new Set(Object.keys(tokens));
+  if (config) {
+    try {
+      const accounts = (JSON.parse(config) as { accounts?: Record<string, unknown> }).accounts ?? {};
+      for (const a of Object.keys(accounts)) aliasSet.add(a);
+    } catch {
+      // malformed config is passed through as-is; import will re-validate it.
+    }
+  }
+  return { manifest: { v: 1, exportedAt, aliases: [...aliasSet].sort() }, config, tokens };
+}
+
+export function encryptBundle(bundle: TransferBundle, passphrase: string): string {
+  return encryptToken(bundle, passphrase);
+}
+
+export class BundleDecryptError extends Error {}
+
+export function decryptBundle(contents: string, passphrase: string): TransferBundle {
+  let obj: unknown;
+  try {
+    obj = decryptToken(contents, passphrase) as unknown;
+  } catch {
+    throw new BundleDecryptError('Could not decrypt the bundle — wrong passphrase or the file is corrupt.');
+  }
+  const b = obj as Partial<TransferBundle>;
+  if (!b || typeof b !== 'object' || !b.manifest || b.manifest.v !== 1 || typeof b.tokens !== 'object') {
+    throw new BundleDecryptError('Bundle decrypted but is not a valid registry export (bad manifest).');
+  }
+  return b as TransferBundle;
+}
+
+export interface ImportPlan {
+  mergedConfig: string;
+  tokenWrites: Record<string, string>;
+  added: string[];
+  replaced: string[];
+  skipped: string[];
+}
+
+interface ConfigShape {
+  version: number;
+  accounts: Record<string, unknown>;
+  scopeProfiles?: Record<string, unknown>;
+  [k: string]: unknown;
+}
+
+function parseConfig(raw: string | null): ConfigShape {
+  if (!raw || raw.trim() === '') return { version: CONFIG_VERSION, accounts: {} };
+  const parsed = JSON.parse(raw) as ConfigShape;
+  if (typeof parsed !== 'object' || parsed === null) throw new Error('config is not an object');
+  parsed.accounts ??= {};
+  parsed.version ??= CONFIG_VERSION;
+  return parsed;
+}
+
+/**
+ * Merge the bundle into the local registry. Default MERGE = add non-colliding
+ * aliases; a collision is skipped (never clobbers a local account's tokens)
+ * unless `replace` is set. Pure for unit testing.
+ */
+export function planImport(
+  bundle: TransferBundle,
+  localConfigRaw: string | null,
+  opts: { replace?: boolean } = {},
+): ImportPlan {
+  const local = parseConfig(localConfigRaw);
+  const incoming = parseConfig(bundle.config);
+  const replace = opts.replace === true;
+
+  const added: string[] = [];
+  const replaced: string[] = [];
+  const skipped: string[] = [];
+  const nextAccounts: Record<string, unknown> = { ...local.accounts };
+  const nextProfiles: Record<string, unknown> = { ...(local.scopeProfiles ?? {}) };
+  const tokenWrites: Record<string, string> = {};
+
+  const incomingAccounts = incoming.accounts ?? {};
+  const incomingProfiles = incoming.scopeProfiles ?? {};
+
+  for (const alias of Object.keys(incomingAccounts)) {
+    const collides = Object.prototype.hasOwnProperty.call(local.accounts, alias);
+    if (collides && !replace) {
+      skipped.push(alias);
+      continue;
+    }
+    nextAccounts[alias] = incomingAccounts[alias];
+    // carry the account's scope profile if it points at one
+    const row = incomingAccounts[alias] as { scopeProfile?: string };
+    if (row?.scopeProfile && Object.prototype.hasOwnProperty.call(incomingProfiles, row.scopeProfile)) {
+      nextProfiles[row.scopeProfile] = incomingProfiles[row.scopeProfile];
+    }
+    if (bundle.tokens[alias]) tokenWrites[alias] = bundle.tokens[alias];
+    (collides ? replaced : added).push(alias);
+  }
+
+  // Token files with no config account (authed but registry-less) follow the
+  // same collision rule keyed on whether we already wrote/kept that alias.
+  for (const alias of Object.keys(bundle.tokens)) {
+    if (alias in tokenWrites || added.includes(alias) || replaced.includes(alias)) continue;
+    if (Object.prototype.hasOwnProperty.call(local.accounts, alias) && !replace) continue;
+    tokenWrites[alias] = bundle.tokens[alias];
+  }
+
+  const merged: ConfigShape = { ...local, version: local.version ?? CONFIG_VERSION, accounts: nextAccounts };
+  if (Object.keys(nextProfiles).length > 0) merged.scopeProfiles = nextProfiles;
+  return {
+    mergedConfig: `${JSON.stringify(merged, null, 2)}\n`,
+    tokenWrites,
+    added: added.sort(),
+    replaced: replaced.sort(),
+    skipped: skipped.sort(),
+  };
+}
+
+// ---- CLI -------------------------------------------------------------------
+
+function argFlag(argv: string[], name: string): string | undefined {
+  const i = argv.indexOf(name);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+/** Passphrase from MCP_TRANSFER_PASSPHRASE (automation) or a TTY prompt; never
+ * a CLI flag (would leak in the process list). */
+async function resolvePassphrase(prompt: string): Promise<string | null> {
+  const fromEnv = process.env.MCP_TRANSFER_PASSPHRASE;
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
+  if (!process.stdin.isTTY) return null;
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+  try {
+    const answer: string = await new Promise((resolve) => rl.question(prompt, resolve));
+    return answer.trim() || null;
+  } finally {
+    rl.close();
+  }
+}
+
+export async function runExportCli(argv: string[]): Promise<number> {
+  const out = argFlag(argv, '--out');
+  if (!out) {
+    console.error('Usage: mcp-google-multi account export --out <bundle.enc>');
+    return 2;
+  }
+  const passphrase = await resolvePassphrase('Choose a passphrase to encrypt the export: ');
+  if (!passphrase) {
+    console.error('E_INPUT_REQUIRED: a passphrase is required. Set MCP_TRANSFER_PASSPHRASE or run in a terminal.');
+    return 2;
+  }
+  const bundle = buildTransferBundle(new Date().toISOString());
+  atomicWriteFileSync(path.resolve(out), encryptBundle(bundle, passphrase), 0o600);
+  console.error(`Exported ${bundle.manifest.aliases.length} account(s) to ${out} (0600).`);
+  console.error(
+    'Note: the bundled token files stay encrypted under this machine\'s MASTER_KEY. To use the tokens on the target, set the same MASTER_KEY there; otherwise re-authenticate with account_reauth.',
+  );
+  return 0;
+}
+
+export async function runImportCli(argv: string[]): Promise<number> {
+  const file = argv[argv.indexOf('import') + 1];
+  if (!file || file.startsWith('--')) {
+    console.error('Usage: mcp-google-multi account import <bundle.enc> [--replace]');
+    return 2;
+  }
+  const replace = argv.includes('--replace');
+  if (!existsSync(path.resolve(file))) {
+    console.error(`E_NOT_FOUND: ${file}`);
+    return 2;
+  }
+  const passphrase = await resolvePassphrase('Passphrase to decrypt the bundle: ');
+  if (!passphrase) {
+    console.error('E_INPUT_REQUIRED: a passphrase is required. Set MCP_TRANSFER_PASSPHRASE or run in a terminal.');
+    return 2;
+  }
+  let bundle: TransferBundle;
+  try {
+    bundle = decryptBundle(readFileSync(path.resolve(file), 'utf-8'), passphrase);
+  } catch (e) {
+    console.error((e as Error).message);
+    return 1;
+  }
+
+  const cfgPath = configFilePath();
+  const localRaw = existsSync(cfgPath) ? readFileSync(cfgPath, 'utf-8') : null;
+  let plan: ImportPlan;
+  try {
+    plan = planImport(bundle, localRaw, { replace });
+  } catch (e) {
+    console.error(`E_CONFIG_INVALID: the bundle's config could not be merged: ${(e as Error).message}`);
+    return 1;
+  }
+
+  atomicWriteWithLock(cfgPath, plan.mergedConfig, 0o600);
+  const tokenDir = getTokenDir();
+  for (const [alias, contents] of Object.entries(plan.tokenWrites)) {
+    atomicWriteFileSync(path.join(tokenDir, `${alias}.enc`), contents, 0o600);
+  }
+  if (process.env.GOOGLE_ACCOUNTS?.trim()) {
+    console.error(
+      'Note: GOOGLE_ACCOUNTS is set, so config.json is ignored (env-sourced mode). The imported registry takes effect once you unset GOOGLE_ACCOUNTS. Token files were still placed.',
+    );
+  }
+  console.error(
+    `Imported: ${plan.added.length} added${plan.added.length ? ` (${plan.added.join(', ')})` : ''}, ` +
+      `${plan.replaced.length} replaced${plan.replaced.length ? ` (${plan.replaced.join(', ')})` : ''}, ` +
+      `${plan.skipped.length} skipped${plan.skipped.length ? ` (${plan.skipped.join(', ')}; re-run with --replace to overwrite)` : ''}.`,
+  );
+  console.error('Run `mcp-google-multi doctor` to verify token health (tokens need the source MASTER_KEY; otherwise account_reauth).');
+  return 0;
+}

--- a/tests/registry-transfer.test.ts
+++ b/tests/registry-transfer.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import {
+  buildTransferBundle,
+  encryptBundle,
+  decryptBundle,
+  BundleDecryptError,
+  planImport,
+  type TransferBundle,
+  type TransferDeps,
+} from '../src/registry-transfer.js';
+
+// Token paths are built with the module's native path.join, so the fake store
+// keys them the same way (keeps the test correct on Windows runners too).
+function fakeDeps(opts: {
+  config?: string | null;
+  tokens?: Record<string, string>;
+  strayNames?: string[];
+  tokenDir?: string;
+  configPath?: string;
+}): TransferDeps {
+  const tokenDir = opts.tokenDir ?? path.join('/cfg', 'tokens');
+  const configPath = opts.configPath ?? path.join('/cfg', 'config.json');
+  const store = new Map<string, string>();
+  if (opts.config != null) store.set(configPath, opts.config);
+  const names: string[] = [];
+  for (const [alias, contents] of Object.entries(opts.tokens ?? {})) {
+    names.push(`${alias}.enc`);
+    store.set(path.join(tokenDir, `${alias}.enc`), contents);
+  }
+  names.push(...(opts.strayNames ?? []));
+  return {
+    configPath,
+    tokenDir,
+    fileExists: (p) => store.has(p),
+    readFile: (p) => {
+      const v = store.get(p);
+      if (v === undefined) throw new Error(`ENOENT ${p}`);
+      return v;
+    },
+    listDir: () => names,
+  };
+}
+
+const CONFIG = JSON.stringify({
+  version: 1,
+  accounts: { work: { email: 'w@x.example', scopeProfile: 'work' }, personal: { email: 'p@x.example' } },
+  scopeProfiles: { work: { bundles: ['forms'] } },
+});
+
+describe('buildTransferBundle', () => {
+  it('collects config + every <alias>.enc token file, aliases sorted', () => {
+    const b = buildTransferBundle(
+      '2026-01-01T00:00:00Z',
+      fakeDeps({ config: CONFIG, tokens: { work: 'ENC-work', personal: 'ENC-personal' }, strayNames: ['notes.txt'] }),
+    );
+    expect(b.manifest).toEqual({ v: 1, exportedAt: '2026-01-01T00:00:00Z', aliases: ['personal', 'work'] });
+    expect(b.tokens).toEqual({ 'work': 'ENC-work', 'personal': 'ENC-personal' });
+    expect(b.config).toBe(CONFIG);
+  });
+
+  it('includes a config-only account that has no token file', () => {
+    const b = buildTransferBundle('t', fakeDeps({ config: CONFIG }));
+    expect(b.manifest.aliases).toEqual(['personal', 'work']);
+    expect(b.tokens).toEqual({});
+  });
+
+  it('ignores stray filenames that are not valid aliases', () => {
+    const b = buildTransferBundle('t', fakeDeps({ config: null, tokens: { ok: 'y' }, strayNames: ['../evil.enc'] }));
+    expect(Object.keys(b.tokens)).toEqual(['ok']);
+  });
+});
+
+describe('encrypt/decrypt bundle (passphrase)', () => {
+  const bundle: TransferBundle = {
+    manifest: { v: 1, exportedAt: 't', aliases: ['work'] },
+    config: CONFIG,
+    tokens: { work: 'ENC-work' },
+  };
+
+  it('round-trips under the correct passphrase', () => {
+    const blob = encryptBundle(bundle, 'correct horse battery staple');
+    const back = decryptBundle(blob, 'correct horse battery staple');
+    expect(back).toEqual(bundle);
+  });
+
+  it('the ciphertext contains no plaintext account data', () => {
+    const blob = encryptBundle(bundle, 'pw');
+    expect(blob).not.toContain('w@x.example');
+    expect(blob).not.toContain('ENC-work');
+  });
+
+  it('a wrong passphrase throws BundleDecryptError, not a raw crypto error', () => {
+    const blob = encryptBundle(bundle, 'right');
+    expect(() => decryptBundle(blob, 'wrong')).toThrow(BundleDecryptError);
+  });
+
+  it('rejects a decrypted blob that is not a valid bundle', () => {
+    // encrypt an arbitrary object with the passphrase, then try to import it
+    const blob = encryptBundle({ nope: true } as unknown as TransferBundle, 'pw');
+    expect(() => decryptBundle(blob, 'pw')).toThrow(BundleDecryptError);
+  });
+});
+
+describe('planImport', () => {
+  const bundle: TransferBundle = {
+    manifest: { v: 1, exportedAt: 't', aliases: ['work', 'personal'] },
+    config: CONFIG,
+    tokens: { work: 'ENC-work', personal: 'ENC-personal' },
+  };
+
+  it('merges into an empty local registry (all added)', () => {
+    const plan = planImport(bundle, null);
+    expect(plan.added).toEqual(['personal', 'work']);
+    expect(plan.replaced).toEqual([]);
+    expect(plan.skipped).toEqual([]);
+    const merged = JSON.parse(plan.mergedConfig);
+    expect(Object.keys(merged.accounts)).toEqual(['work', 'personal']);
+    expect(merged.scopeProfiles.work).toEqual({ bundles: ['forms'] });
+    expect(plan.tokenWrites).toEqual({ work: 'ENC-work', personal: 'ENC-personal' });
+  });
+
+  it('skips a colliding alias by default (never clobbers local tokens)', () => {
+    const local = JSON.stringify({ version: 1, accounts: { work: { email: 'local@x.example' } } });
+    const plan = planImport(bundle, local);
+    expect(plan.skipped).toEqual(['work']);
+    expect(plan.added).toEqual(['personal']);
+    // local work account + tokens untouched
+    expect(JSON.parse(plan.mergedConfig).accounts.work.email).toBe('local@x.example');
+    expect(plan.tokenWrites).toEqual({ personal: 'ENC-personal' });
+  });
+
+  it('--replace overwrites the colliding alias and its tokens', () => {
+    const local = JSON.stringify({ version: 1, accounts: { work: { email: 'local@x.example' } } });
+    const plan = planImport(bundle, local, { replace: true });
+    expect(plan.replaced).toEqual(['work']);
+    expect(plan.skipped).toEqual([]);
+    expect(JSON.parse(plan.mergedConfig).accounts.work.email).toBe('w@x.example');
+    expect(plan.tokenWrites.work).toBe('ENC-work');
+  });
+
+  it('imports a token-only alias absent from any config account', () => {
+    const tokenOnly: TransferBundle = { manifest: { v: 1, exportedAt: 't', aliases: ['x'] }, config: null, tokens: { x: 'ENC-x' } };
+    const plan = planImport(tokenOnly, null);
+    expect(plan.tokenWrites).toEqual({ x: 'ENC-x' });
+  });
+
+  it('preserves unrelated local accounts and top-level keys', () => {
+    const local = JSON.stringify({ version: 1, accounts: { other: { email: 'o@x.example' } }, discovery: 'curated' });
+    const plan = planImport(bundle, local);
+    const merged = JSON.parse(plan.mergedConfig);
+    expect(merged.accounts.other).toEqual({ email: 'o@x.example' });
+    expect(merged.discovery).toBe('curated');
+    expect(Object.keys(merged.accounts).sort()).toEqual(['other', 'personal', 'work']);
+  });
+});


### PR DESCRIPTION
**Slice B19** (`v6/2i-registry-export`) — move a whole setup to another machine. Stacks on B1 (registry) + B5 (key provisioning).

## What
`src/registry-transfer.ts` + `account export --out <bundle.enc>` / `account import <bundle.enc>` CLIs:
- **Export** packs `config.json` (accounts + scope profiles) + every `<alias>.enc` token file + a manifest into one bundle, encrypted under a **user passphrase** (portable across machines with different `MASTER_KEY`s) via the token-store AES primitives. Secrets (`MASTER_KEY` / client secret) are never in the bundle.
- **Import** decrypts and **merges**: new aliases added, a colliding alias skipped (never clobbering local tokens) unless `--replace`; atomic-writes `config.json`, places token files `0600`.
- Bundled token files stay encrypted under the **source** `MASTER_KEY` (double-locked) — the target needs the same `MASTER_KEY` to use them (else `account_reauth`). Passphrase via `MCP_TRANSFER_PASSPHRASE` or a TTY prompt — never a CLI flag (process-list leak).

## Tests / verification
`tests/registry-transfer.test.ts` (12): bundle build (token glob + stray-filename guard), passphrase encrypt/decrypt round-trip + no-plaintext-leak + wrong-passphrase, and the merge/collision-skip/`--replace`/token-only-alias plan logic. Live-smoked a real export→import round-trip across two temp dirs + wrong-passphrase rejection.

## Scope note (foundation limitation, documented not fixed here)
The live smoke surfaced that `import` (and `doctor`/`reset`) can't run on a **truly-empty** registry — `index.ts` loads `accounts.js` (eager `resolveAccounts()` that fails on empty) + `z.enum(ACCOUNTS)` across 20+ tool files at module init. So B19 ships for the **configured-target merge/consolidate** case (the spec's primary flow); a brand-new target needs ≥1 account configured first. Making the CLIs empty-tolerant is a separate foundation follow-up (also fixes doctor/reset on a fresh install).

Gate: typecheck + lint clean, **593 tests** pass (rebased on B12), build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)