### PR TITLE
feat: thread transport into resolvePolicy (HTTP write-control seam) (B14)

### DIFF
--- a/src/identity.ts
+++ b/src/identity.ts
@@ -2,7 +2,7 @@ import type { AccountSet } from './accounts.js';
 import { getAccountSet } from './accounts.js';
 import { getClient } from './client.js';
 import { hasToken, readToken, updateToken, writeToken } from './token-store.js';
-import { resolvePolicy, type Policy } from './write-control.js';
+import { resolvePolicy, type Policy, type Transport } from './write-control.js';
 
 /**
  * The one forward-compat seam (frozen public API): the free core builds
@@ -22,7 +22,10 @@ export interface IdentityContext {
   };
 }
 
-export function buildIdentityContext(env: NodeJS.ProcessEnv = process.env): IdentityContext {
+export function buildIdentityContext(
+  env: NodeJS.ProcessEnv = process.env,
+  opts: { transport?: Transport } = {},
+): IdentityContext {
   return {
     subject: 'owner',
     // Live getter: the seam must always see the current registry, never a
@@ -30,7 +33,9 @@ export function buildIdentityContext(env: NodeJS.ProcessEnv = process.env): Iden
     get accounts() {
       return getAccountSet();
     },
-    policy: resolvePolicy(env),
+    // The dispatch transport rides into the resolved policy as a reserved seam
+    // (cc-write-control B14); it does not change any write-control verdict.
+    policy: resolvePolicy(env, { transport: opts.transport }),
     getClient,
     tokenStore: { readToken, writeToken, updateToken, hasToken },
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,6 @@ async function main() {
     return;
   }
 
-  const ctx = buildIdentityContext();
   // Resolve (or provision) the master key BEFORE serving: the hard guard is
   // specced "fatal at startup", never mid-dispatch.
   const { resolveMasterKey } = await import('./master-key.js');
@@ -193,7 +192,7 @@ async function main() {
   // never rebuilt per request); `both` runs the two concurrently.
   if (wantStdio) {
     const server = new McpServer({ name: 'mcp-google-multi', version: pkg.version });
-    const registry = buildRegistry(server, ctx);
+    const registry = buildRegistry(server, buildIdentityContext(process.env, { transport: 'stdio' }));
     registry.installListHandler();
     registerSetupPrompt(server);
     await server.connect(new StdioServerTransport());
@@ -225,7 +224,7 @@ async function main() {
       process.stderr.write(`GOOGLE_DISCOVERY="${configuredMode}" is ignored over HTTP; the stateless transport forces "curated".\n`);
     }
     const httpServer = new McpServer({ name: 'mcp-google-multi', version: pkg.version });
-    const registry = buildRegistry(httpServer, ctx, 'curated');
+    const registry = buildRegistry(httpServer, buildIdentityContext(process.env, { transport: 'http' }), 'curated');
     registry.installListHandler();
     registerSetupPrompt(httpServer);
     const host = new HttpTransportHost({

--- a/src/write-control.ts
+++ b/src/write-control.ts
@@ -1,12 +1,24 @@
 import type { Cud } from './registry.js';
 
 export type Profile = 'read-only' | 'safe-writes' | 'full-writes';
+export type Transport = 'stdio' | 'http';
 
 export interface Policy {
   profile: Profile;
   readOnly: boolean;
   allow: string[];
   deny: string[];
+  /**
+   * B14 reserved seam (cc-write-control "HTTP posture", LOCKED to OQ-5
+   * "annotations only"): the dispatch transport is threaded into the resolved
+   * policy for the EE/future seam, but in v6 alpha it does NOT stiffen the
+   * profile or alter any `isAllowed` verdict. "Stricter on HTTP" is achieved
+   * entirely by the `anthropic/requiresUserInteraction` annotation on the
+   * irreversible set (A12), emitted identically on both transports.
+   * Optional so existing Policy literals (codegen/tests) need no change;
+   * resolvePolicy always populates it.
+   */
+  transport?: Transport;
 }
 
 interface ToolRef {
@@ -45,7 +57,10 @@ function parseGlobs(value: string | undefined): string[] {
   return (value ?? '').split(',').map((s) => s.trim()).filter(Boolean);
 }
 
-export function resolvePolicy(env: NodeJS.ProcessEnv = process.env): Policy {
+export function resolvePolicy(
+  env: NodeJS.ProcessEnv = process.env,
+  opts: { transport?: Transport } = {},
+): Policy {
   const raw = (env.GOOGLE_PROFILE ?? 'read-only').trim() as Profile;
   if (raw && !PROFILES.includes(raw)) {
     // Fail-closed to read-only, but say so — a typo'd profile otherwise looks
@@ -57,6 +72,8 @@ export function resolvePolicy(env: NodeJS.ProcessEnv = process.env): Policy {
     readOnly: /^(1|true|yes)$/i.test(env.GOOGLE_READ_ONLY ?? ''),
     allow: parseGlobs(env.GOOGLE_WRITE_ALLOW),
     deny: parseGlobs(env.GOOGLE_WRITE_DENY),
+    // Reserved seam only (see Policy.transport): does not affect the verdict.
+    transport: opts.transport ?? 'stdio',
   };
 }
 

--- a/tests/write-control.test.ts
+++ b/tests/write-control.test.ts
@@ -9,7 +9,7 @@ const tool = (name: string, cud: 'read' | 'create' | 'update' | 'delete') => ({
 
 describe('resolvePolicy', () => {
   it('defaults to read-only, no globs', () => {
-    expect(resolvePolicy({})).toEqual({ profile: 'read-only', readOnly: false, allow: [], deny: [] });
+    expect(resolvePolicy({})).toEqual({ profile: 'read-only', readOnly: false, allow: [], deny: [], transport: 'stdio' });
   });
   it('parses profile, readOnly, and glob lists', () => {
     const p = resolvePolicy({
@@ -23,10 +23,33 @@ describe('resolvePolicy', () => {
       readOnly: true,
       allow: ['calendar:*', 'sheets:update*'],
       deny: ['*:delete*'],
+      transport: 'stdio',
     });
   });
   it('falls back to read-only on an invalid profile', () => {
     expect(resolvePolicy({ GOOGLE_PROFILE: 'bogus' }).profile).toBe('read-only');
+  });
+
+  // B14: transport is a reserved seam threaded into the policy.
+  it('threads the transport (default stdio; http when passed)', () => {
+    expect(resolvePolicy({}).transport).toBe('stdio');
+    expect(resolvePolicy({}, { transport: 'http' }).transport).toBe('http');
+    expect(resolvePolicy({}, { transport: 'stdio' }).transport).toBe('stdio');
+  });
+
+  it('transport does NOT change any write-control verdict (LOCKED annotations-only)', () => {
+    const cases: Array<[string, 'read' | 'create' | 'update' | 'delete', NodeJS.ProcessEnv]> = [
+      ['gmail_search', 'read', {}],
+      ['gmail_send', 'create', { GOOGLE_PROFILE: 'safe-writes' }],
+      ['drive_delete', 'delete', { GOOGLE_PROFILE: 'full-writes' }],
+      ['drive_delete', 'delete', { GOOGLE_PROFILE: 'safe-writes' }],
+      ['sheets_update', 'update', { GOOGLE_WRITE_DENY: 'sheets:*' }],
+    ];
+    for (const [name, cud, env] of cases) {
+      const stdio = isAllowed(tool(name, cud), resolvePolicy(env, { transport: 'stdio' }));
+      const http = isAllowed(tool(name, cud), resolvePolicy(env, { transport: 'http' }));
+      expect(http).toBe(stdio);
+    }
   });
 });
 


### PR DESCRIPTION
**Slice B14** (`v6/2d-http-write-control`) — the transport-aware write-control seam. Stacks on B12.

## What
Per the spec, HTTP write-control is **LOCKED to OQ-5 "annotations only"**: the server verdict is transport-agnostic; "stricter on HTTP" is achieved entirely by the `anthropic/requiresUserInteraction` annotation on the irreversible set (A12), emitted identically on both transports.

So B14 threads the dispatch transport into the resolved policy as a **reserved seam** that changes no behavior:
- `resolvePolicy(env, { transport })` + `buildIdentityContext(env, { transport })` carry `transport` into `Policy`.
- The stdio / http serve paths build their context with `'stdio'` / `'http'` respectively.
- `Policy.transport` is optional so existing literals (codegen/tests) need no change; `resolvePolicy` always populates it (default `stdio`).

It does **not** stiffen the profile or alter any `isAllowed` verdict — that's the point of the lock.

## Tests
`tests/write-control.test.ts` (+2): asserts the transport is threaded (default `stdio`, `http` when passed) and — the key guarantee — that `isAllowed` verdicts are **transport-invariant** across a matrix of profiles/globs (read/create/delete under safe-writes/full-writes/deny). Boot-smoked stdio config-check + http initialize with the per-transport context.

Gate: typecheck + lint clean, **583 tests** pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)