### PR TITLE
build: distroless Node 22 Docker image (non-root, --init) (B16)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Never enter an image layer.
+node_modules
+dist
+coverage
+
+# Secrets / local state — MUST never be copied into a layer.
+.env
+.env.*
+*.enc
+master.key
+mcp-tokens.enc
+config.json
+
+# Build/test/dev cruft not needed to compile dist/.
+.git
+.github
+.gitignore
+tests
+discovery
+*.log
+*.mcpb
+.claude
+.vscode
+.idea
+npm-debug.log*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,51 @@
+name: docker
+
+# Builds and smoke-checks the distroless image (B16). Scoped to Docker changes
+# so it does not run on every slice. Non-required check (only `ci` gates merges).
+on:
+  push:
+    branches: [main, staging, dev, v6, 'v6-**']
+    paths: [Dockerfile, .dockerignore, .github/workflows/docker.yml]
+  pull_request:
+    branches: [main, staging, dev, v6, 'v6-**']
+    paths: [Dockerfile, .dockerignore, .github/workflows/docker.yml]
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build image
+        run: docker build -t mcp-google-multi:ci .
+
+      - name: Runtime user is non-root
+        run: |
+          uid=$(docker run --rm --entrypoint /nodejs/bin/node mcp-google-multi:ci -e 'process.stdout.write(String(process.getuid()))')
+          echo "runtime uid: $uid"
+          test "$uid" != "0"
+
+      - name: No secret files baked into any layer
+        run: |
+          docker create --name gmci mcp-google-multi:ci
+          docker export gmci -o image.tar
+          docker rm gmci
+          if tar -tf image.tar | grep -Eq '(\.enc$|/master\.key$|/\.env$|/config\.json$)'; then
+            echo "::error::secret file present in image layers"; exit 1
+          fi
+          echo "no secret files in image layers"
+
+      - name: Clean SIGTERM shutdown via --init
+        run: |
+          key=$(openssl rand -base64 32)
+          docker run -d --init --name gmrun \
+            -e GOOGLE_ACCOUNTS=p:x@example.com -e MASTER_KEY="$key" -e MCP_OWNER_EMAILS=x@example.com \
+            mcp-google-multi:ci
+          sleep 3
+          t0=$(date +%s); docker stop -t 10 gmrun; t1=$(date +%s)
+          docker rm -f gmrun || true
+          echo "stop took $((t1 - t0))s"
+          test $((t1 - t0)) -lt 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+# B16: distroless Node 22, non-root. Multi-stage: build dist/ with full deps,
+# prune to runtime deps, copy into a distroless runtime that has no shell and
+# runs as `nonroot`. No secrets are ever baked in — pass them at `docker run`
+# via --env-file / orchestrator secrets (see docs/configuration.md, B17 tunnel
+# guide). Run with `docker run --init` so SIGTERM reaches node for a clean
+# shutdown (distroless has no init to reap PID 1).
+
+# --- build stage -----------------------------------------------------------
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+RUN npm ci --omit=dev
+
+# --- runtime stage ---------------------------------------------------------
+FROM gcr.io/distroless/nodejs22-debian12:nonroot
+WORKDIR /app
+ENV NODE_ENV=production
+# HTTP transport by default. The bind stays loopback (MCP_HTTP_HOST=127.0.0.1)
+# and the server refuses any exposed HTTP shape until the OAuth authorization
+# server ships, so reach it from a tunnel that shares the container's network
+# namespace (compose `network_mode: "service:mcp"`), never by publishing the
+# port to a routable host interface.
+ENV MCP_TRANSPORT=http
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+EXPOSE 4243
+# The distroless nodejs image's ENTRYPOINT is ["/nodejs/bin/node"]; pass only
+# the entry script. Keychain (@napi-rs/keyring) is unavailable here (no D-Bus), so
+# key provisioning degrades to the 0600 file under a mounted config volume —
+# persist that volume across restarts or MASTER_KEY regenerates and bricks tokens.
+CMD ["dist/index.js"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,22 @@ By default the server speaks **stdio** (`MCP_TRANSPORT=stdio`), the zero-network
 
 > **HTTP is currently loopback-only.** Until the built-in OAuth authorization server ships, the server refuses to start any exposed HTTP shape (a non-loopback bind, or a non-loopback `MCP_PUBLIC_URL` — i.e. a tunnel/reverse proxy in front). Loopback callers are trusted as the owner, the same trust model as stdio, so do not run HTTP mode on a shared host. Register the local URL with your client using `mcp-google-multi write-client-config --url http://127.0.0.1:4243/mcp`.
 
+### Docker
+
+A distroless, non-root image is provided (`Dockerfile`). Build and run it, passing secrets at runtime (never baked into the image):
+
+```sh
+docker build -t mcp-google-multi .
+docker run --init --rm \
+  -e GOOGLE_ACCOUNTS="work:me@company.example,personal:me@gmail.example" \
+  -e MASTER_KEY="$(openssl rand -base64 32)" \
+  -e MCP_OWNER_EMAILS="me@company.example" \
+  -v mcp-config:/home/nonroot/.config/mcp-google-multi \
+  mcp-google-multi
+```
+
+`--init` forwards SIGTERM for a clean shutdown. Persist the config volume across restarts — the OS keychain is unavailable in distroless, so `MASTER_KEY` falls back to a `0600` file there and a regenerated key would brick existing tokens. The image defaults to `MCP_TRANSPORT=http` bound to loopback; the full tunnel/remote recipe lands with the authorization server.
+
 ## Write-control (deny-by-default)
 
 Reads are never gated. **Every create/update/delete is off until you opt in** — pick a profile:


### PR DESCRIPTION
**Slice B16** (`v6/2f-docker`) — distroless container image. Stacks on S0.1 (Node ≥22) + B12 (HTTP transport). Non-releasing (`build:`).

## What
- **`Dockerfile`** — multi-stage: build `dist/` with full deps, prune to runtime deps, copy into `gcr.io/distroless/nodejs22-debian12:nonroot` (no shell, no package manager, non-root uid 65532). Entry `/nodejs/bin/node dist/index.js`. Defaults to `MCP_TRANSPORT=http` on loopback; run with `docker run --init` for clean SIGTERM.
- **`.dockerignore`** — keeps `node_modules`/`.git`/`tests` and **every secret shape** (`.env`, `*.enc`, `master.key`, `config.json`) out of the build context.
- **`.github/workflows/docker.yml`** — a scoped `docker` CI job (runs only when the Dockerfile changes, non-required check) that builds the image and asserts: **non-root** runtime user, **no secret files in any layer**, and a **clean <10s SIGTERM** shutdown.
- Docs: a `docker run` recipe in `docs/configuration.md` (secrets at runtime, persist the config volume, keychain→0600-file fallback caveat).

## Verified locally
Image builds; runs as **uid 65532**; boots the HTTP server (`/health` → `ok http ownerConfigured=true`); no `.enc`/`.env`/`master.key`/`config.json` in any exported layer; `docker stop` (SIGTERM via `--init`) exits cleanly in ~0s.

No `src/`/`tests/` changes, so `ci` is unaffected; the new `docker` job is the added verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)