### PR TITLE
docs: sync tool/service counts (874/28) + remote-HTTP onboarding (Rz2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ The most complete **local Google Workspace MCP server**: Gmail, Drive, Calendar,
 
 [![npm](https://img.shields.io/npm/v/mcp-google-multi?label=npm&color=cb3837)](https://www.npmjs.com/package/mcp-google-multi)
 
-- 🧰 **Exhaustive** — 872 tools across 28 services + an escape hatch for anything else → [COVERAGE.md](./COVERAGE.md)
+- 🧰 **Exhaustive** — 874 tools across 28 services + an escape hatch for anything else → [COVERAGE.md](./COVERAGE.md)
 - 🔑 **Multi-account** — drive any number of Google accounts by alias, or fan one call out across all of them
 - 🔒 **Private by design** — your own OAuth app, tokens encrypted at rest (AES-256-GCM), writes deny-by-default, no telemetry, no metering — it talks only to Google
+- 🌐 **Local or remote** — runs locally over stdio, or self-hosted over HTTP with its own built-in OAuth 2.1 server (Claude Code's `/mcp` login and the claude.ai connector, zero custom UI) → [remote setup](./docs/http-setup.md)
 
 ## Quick setup
 
@@ -46,7 +47,9 @@ You don't need to know anything about MCP or OAuth — five steps, all copy-past
 
 Restart your client and the tools appear. Check everything with `mcp-google-multi config check`.
 
-**Go deeper:** [Configuration reference](./docs/configuration.md) · [What's covered](./COVERAGE.md) · [Features tour](./docs/features.md) · [Secrets in a vault](./docs/secrets.md) · [Upgrading from v4](./docs/upgrading-v4.md) · [Security policy](./SECURITY.md) · [Roadmap](https://github.com/bakissation/mcp-google-multi/milestones)
+**Running it remotely?** To reach the server from [claude.ai](https://claude.ai) as a custom connector or from another machine, run it over HTTP — it ships its own OAuth 2.1 server, so no bearer tokens to paste. Follow [Remote HTTP setup](./docs/http-setup.md) (Cloudflare named tunnel, Docker, or one-click Render/Railway). Coming from v5? See the [v6 migration guide](./MIGRATION-v6.md).
+
+**Go deeper:** [Configuration reference](./docs/configuration.md) · [What's covered](./COVERAGE.md) · [Features tour](./docs/features.md) · [Remote / HTTP setup](./docs/http-setup.md) · [Secrets in a vault](./docs/secrets.md) · [Migrating to v6](./MIGRATION-v6.md) · [Upgrading from v4](./docs/upgrading-v4.md) · [Security policy](./SECURITY.md) · [Roadmap](https://github.com/bakissation/mcp-google-multi/milestones)
 
 ## Maintainer & credits
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,6 @@
 # Features tour
 
-How the server keeps 872 tools usable, fast, and safe. Back to the [README](../README.md).
+How the server keeps 874 tools usable, fast, and safe. Back to the [README](../README.md).
 
 ## Discover-first tools (tiny idle context)
 
@@ -112,4 +112,4 @@ Two caveats: the bundled token files stay encrypted under the **source** machine
 
 ## Remote access over HTTP (built-in OAuth)
 
-Set `MCP_TRANSPORT=http` and the server becomes its own **OAuth 2.1 authorization server**, so Claude Code's native `/mcp` authenticate flow and the claude.ai custom connector work with zero custom UI. A connecting client is sent through Google login; only an email in `MCP_OWNER_EMAILS` (the owner gate) is admitted, and the server then mints its own short-lived, audience-bound token for the client. The two credential families never cross: your per-account Google tokens are never handed to the client, and a client token is never presented to Google (federate-and-hold). It advertises PRM + AS metadata (`S256` PKCE, no JWKS — the server is its own resource server), federates via CIMD (`MCP_CIMD_ALLOWED_ISSUERS`, default `claude.ai`) with a minimal DCR fallback, SSRF-guards every metadata fetch, and rotates refresh tokens. Behind a Cloudflare named tunnel keep the bind on loopback and set `MCP_PUBLIC_URL` to the public HTTPS host. See [configuration.md](./configuration.md#transport).
+Set `MCP_TRANSPORT=http` and the server becomes its own **OAuth 2.1 authorization server**, so Claude Code's native `/mcp` authenticate flow and the claude.ai custom connector work with zero custom UI. A connecting client is sent through Google login; only an email in `MCP_OWNER_EMAILS` (the owner gate) is admitted, and the server then mints its own short-lived, audience-bound token for the client. The two credential families never cross: your per-account Google tokens are never handed to the client, and a client token is never presented to Google (federate-and-hold). It advertises PRM + AS metadata (`S256` PKCE, no JWKS — the server is its own resource server), federates via CIMD (`MCP_CIMD_ALLOWED_ISSUERS`, default `claude.ai`) with a minimal DCR fallback, SSRF-guards every metadata fetch, and rotates refresh tokens. Behind a Cloudflare named tunnel keep the bind on loopback and set `MCP_PUBLIC_URL` to the public HTTPS host. See [configuration.md](./configuration.md#transport) for the keys, or [http-setup.md](./http-setup.md) for the full named-tunnel, Docker, and one-click Render/Railway walkthrough.


### PR DESCRIPTION
Rz2 — the final v6 docs slice. Non-releasing (docs:).

- `gen:coverage` confirms COVERAGE.md is already authoritative at **874 tools** (184 curated + 690 generated) across **28 services** (regen is a no-op). This syncs the two human-maintained counts that had drifted to 872: **README.md** and **docs/features.md**.
- **Onboarding rewrite** for the v6 remote surface: README gains a *Local or remote* SEO bullet + a *Running it remotely?* pointer, and the Go-deeper row links `docs/http-setup.md` and `MIGRATION-v6.md`; features.md links the full http-setup walkthrough.

Pure markdown — `lint`/`typecheck`/`test`/`build` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)