### PR TITLE
fix: let the bootstrap/diagnostic CLIs run on an empty registry

### DIFF
--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import fs from 'node:fs';
+import { z } from 'zod';
 import { loadEnvFiles } from './env-load.js';
 import { CONFIG_VERSION, configDir, configFilePath, failStartup, loadConfigFile, mutateConfigFile } from './config-file.js';
 import type { ConfigFile } from './config-file.js';
@@ -27,7 +28,11 @@ export interface AccountConfig {
 }
 
 export interface AccountSet {
-  aliases: [string, ...string[]];
+  // May be empty: a fresh install has zero accounts, and the bootstrap /
+  // diagnostic CLIs (doctor, reset, account import, migrate-config, config
+  // check) must run on it. The SERVER refuses to boot empty — see
+  // assertServerAccountsConfigured (BR-4).
+  aliases: string[];
   configs: Record<string, AccountConfig>;
   scopeProfiles: Record<string, ScopeProfile>;
   source: 'env' | 'file' | 'merged';
@@ -168,7 +173,7 @@ export function resolveAccounts(
     materializeFirstRun(aliases, configs, filePath);
     const def = resolveDefaultAccount(env, null, aliases, fail);
     return {
-      aliases: aliases as [string, ...string[]],
+      aliases,
       configs,
       // Env-sourced accounts cannot reference file profiles; the legacy
       // GOOGLE_OPTIONAL_SCOPES override is applied live in auth.ts.
@@ -186,10 +191,22 @@ export function resolveAccounts(
   const config = loadConfigFile(filePath, onInvalid);
   const entries = Object.entries(config?.accounts ?? {});
   if (entries.length === 0) {
+    // Gap #23: an empty registry is NOT fatal at resolve time — the bootstrap and
+    // diagnostic CLIs (doctor/reset/account import/migrate-config/config check)
+    // must run on a fresh install. Only the stdio/http SERVER refuses to boot
+    // empty (BR-4), enforced by assertServerAccountsConfigured() in index.ts.
+    // The dispatch-path reload ('throw') still throws so a mid-session emptied
+    // config.json keeps the last-good registry (BR-7) instead of dropping tools.
     if (onInvalid === 'throw') {
       throw new Error(`E_NO_ACCOUNTS_CONFIGURED: ${noAccountsMessage()}`);
     }
-    failStartup('E_NO_ACCOUNTS_CONFIGURED', noAccountsMessage());
+    return {
+      aliases: [],
+      configs: {},
+      scopeProfiles: { base: { bundles: [] } },
+      source: 'file',
+      stamp: `${config?.version ?? CONFIG_VERSION}:${preStamp.split(':')[1]}`,
+    };
   }
 
   // BR3: unknown bundle names fail loudly (a mis-scoped token is worse than a
@@ -238,7 +255,7 @@ export function resolveAccounts(
 
   const def = resolveDefaultAccount(env, config?.defaultAccount ?? null, aliases, fail);
   return {
-    aliases: aliases as [string, ...string[]],
+    aliases,
     configs,
     scopeProfiles,
     source: 'file',
@@ -352,10 +369,35 @@ export function isAccountSetStale(): boolean {
   return current.stamp !== fileStamp(configFilePath(), Number(version));
 }
 
-/** Tuple of account aliases (at least one) — usable with z.enum().
+/** Account aliases (possibly empty on a fresh install).
  * Snapshot from the initial load; enums widen only when the registry is
  * rebuilt after a mutation (account_add, later slice). */
 export const ACCOUNTS = current.aliases;
 
-/** Valid account alias (string union isn't static, so tools use z.enum(ACCOUNTS)) */
+/**
+ * The `account` param schema, empty-registry-safe. A `z.enum` requires at least
+ * one value, so a fresh install (zero aliases) would throw at schema-build time
+ * (module load) and take down every CLI — including `doctor`, which is meant to
+ * REPORT the empty registry (gap #23). Fall back to a plain string when there
+ * are no aliases: no alias exists to enumerate, the server refuses to boot empty
+ * anyway, and dispatch validates the account against the live set. */
+export function accountAliasSchemaFor(aliases: readonly string[]): z.ZodType<string> {
+  return aliases.length > 0 ? z.enum(aliases as [string, ...string[]]) : z.string();
+}
+
+/** Shared, load-time snapshot used by every tool's `account` field. */
+export const accountAliasSchema: z.ZodType<string> = accountAliasSchemaFor(ACCOUNTS);
+
+/**
+ * BR-4: the stdio/http SERVER never boots with an empty registry — a fresh user
+ * bootstraps via env / `migrate-config` / `account import` / `auth` first. The
+ * bootstrap and diagnostic CLIs return before this guard, so it gates only the
+ * server path (called from index.ts after the CLI branches). */
+export function assertServerAccountsConfigured(): void {
+  if (current.aliases.length === 0) {
+    failStartup('E_NO_ACCOUNTS_CONFIGURED', noAccountsMessage());
+  }
+}
+
+/** Valid account alias (string union isn't static, so tools use accountAliasSchema) */
 export type Account = string;

--- a/src/fanout.ts
+++ b/src/fanout.ts
@@ -8,7 +8,9 @@ const FANOUT_CONCURRENCY = 5;
 export function fanoutAccountField(description: string): z.ZodType {
   const csvExample = ACCOUNTS.length > 1 ? `; or a CSV subset like "${ACCOUNTS.slice(0, 2).join(',')}"` : '';
   return z
-    .union([z.enum([...ACCOUNTS, '*'] as [string, ...string[]]), z.string().regex(CSV_RE)])
+    // '*' first so the tuple is statically non-empty even when ACCOUNTS is empty
+    // (a fresh install): z.enum requires [string, ...string[]].
+    .union([z.enum(['*', ...ACCOUNTS]), z.string().regex(CSV_RE)])
     .optional()
     .describe(`${description}; "*" = all accounts${csvExample}; omit for the default account`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
-import './accounts.js';
+// First import: triggers accounts.js module load (env files + registry) before
+// anything else. Named to also pull the server-only empty-registry guard (BR-4).
+import { assertServerAccountsConfigured } from './accounts.js';
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -171,6 +173,11 @@ async function main() {
     }
     return;
   }
+
+  // BR-4: the SERVER never boots with an empty registry. The bootstrap and
+  // diagnostic CLIs above already returned; a fresh user configures accounts
+  // (env / migrate-config / account import / auth) before the server runs.
+  assertServerAccountsConfigured();
 
   // Resolve (or provision) the master key BEFORE serving: the hard guard is
   // specced "fatal at startup", never mid-dispatch.

--- a/src/tools/admin.ts
+++ b/src/tools/admin.ts
@@ -2,12 +2,12 @@ import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceBoolean } from './_coerce.js';
 import { admin as adminClient } from '@googleapis/admin';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 // Admin SDK requires Workspace super-admin (or delegated admin) on the account — personal @gmail.com accounts 403 on every endpoint.
 export function registerAdminTools(server: ToolRegistry): void {

--- a/src/tools/calendar.ts
+++ b/src/tools/calendar.ts
@@ -2,13 +2,13 @@ import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean } from './_coerce.js';
 import { calendar as calendarClient } from '@googleapis/calendar';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
 import { sliceClean } from '../trim.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 export function registerCalendarTools(server: ToolRegistry): void {
   server.registerTool(

--- a/src/tools/chat.ts
+++ b/src/tools/chat.ts
@@ -2,12 +2,12 @@ import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceJson } from './_coerce.js';
 import { chat as chatClient } from '@googleapis/chat';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 export function registerChatTools(server: ToolRegistry): void {
   server.registerTool(

--- a/src/tools/contacts.ts
+++ b/src/tools/contacts.ts
@@ -1,13 +1,13 @@
 import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { people as peopleClient } from '@googleapis/people';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { coerceBoolean } from './_coerce.js';
 import { handleGoogleApiError } from './_errors.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 const PERSON_FIELDS = 'names,emailAddresses,phoneNumbers,organizations,addresses,photos,memberships';
 

--- a/src/tools/docs.ts
+++ b/src/tools/docs.ts
@@ -2,13 +2,13 @@ import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceBoolean, coerceJson } from './_coerce.js';
 import { docs as docsClient } from '@googleapis/docs';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
 import { capText } from '../trim.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 function extractPlainText(body: any): string {
   return extractPlainTextInRange(body, 0, Infinity);

--- a/src/tools/drive.ts
+++ b/src/tools/drive.ts
@@ -2,7 +2,7 @@ import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean } from './_coerce.js';
 import { drive as driveClient, type drive_v3 } from '@googleapis/drive';
-import { ACCOUNTS, getAccountSet } from '../accounts.js';
+import { accountAliasSchema, getAccountSet } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
@@ -15,10 +15,10 @@ import * as crypto from 'crypto';
 import { pipeline } from 'node:stream/promises';
 import mime from 'mime-types';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 // drive_transfer's two-account form is the sanctioned schema exception and
 // stays REQUIRED: omission must fail at the schema, not as a runtime riddle.
-const requiredAccountEnum = z.enum(ACCOUNTS);
+const requiredAccountEnum = accountAliasSchema;
 
 const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
 const FALLBACK_MAX_BYTES = 1024 * 1024 * 1024; // 1GB

--- a/src/tools/forms.ts
+++ b/src/tools/forms.ts
@@ -1,13 +1,13 @@
 import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { forms as formsClient } from '@googleapis/forms';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
 import { coerceArray, coerceBoolean, coerceJson } from './_coerce.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 export function registerFormsTools(server: ToolRegistry): void {
   server.registerTool(

--- a/src/tools/generated/_shared.ts
+++ b/src/tools/generated/_shared.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ACCOUNTS } from '../../accounts.js';
+import { accountAliasSchema } from '../../accounts.js';
 import { executeApiMethod, type ApiMethodRef, type ExecuteDeps, type QueryParams } from '../../executor.js';
 import type { Cud, ToolRegistry } from '../../registry.js';
 
@@ -22,7 +22,7 @@ export interface GeneratedToolDef {
 }
 
 export function accountField() {
-  return z.enum(ACCOUNTS).optional().describe('Google account alias (omit for the default account)');
+  return accountAliasSchema.optional().describe('Google account alias (omit for the default account)');
 }
 
 interface GeneratedToolConfig {

--- a/src/tools/gmail.ts
+++ b/src/tools/gmail.ts
@@ -2,7 +2,7 @@ import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean, coerceJson } from './_coerce.js';
 import { gmail as gmailClient } from '@googleapis/gmail';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError, mapGoogleError } from './_errors.js';
@@ -16,7 +16,7 @@ import type { GmailMessageHeader, GmailMessageFull, GmailAttachment } from '../t
 import * as path from 'path';
 import * as fs from 'fs';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 function getHeader(
   headers: { name?: string | null; value?: string | null }[] | undefined,

--- a/src/tools/google-api.ts
+++ b/src/tools/google-api.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { ToolRegistry } from '../registry.js';
 import { isAllowed, writeDisabledResult, type Policy } from '../write-control.js';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import { getClient } from '../client.js';
 import { coerceJson } from './_coerce.js';
 import { getToolsets, toolsetEnabled, type Toolsets } from '../toolsets.js';
@@ -15,7 +15,7 @@ import {
   searchMethods,
 } from '../discovery-client.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 // Policy/toolset namespace for each API alias must match the NAMED tools' service
 // names, or user deny globs and GOOGLE_TOOLSETS silently miss escape-hatch calls.

--- a/src/tools/meet.ts
+++ b/src/tools/meet.ts
@@ -1,12 +1,12 @@
 import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { meet as meetClient } from '@googleapis/meet';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 export function registerMeetTools(server: ToolRegistry): void {
   // ─── Conference records (past meetings) ────────────────────────────────

--- a/src/tools/searchconsole.ts
+++ b/src/tools/searchconsole.ts
@@ -3,12 +3,12 @@ import { z } from 'zod';
 import { coerceArray, coerceJson } from './_coerce.js';
 import { searchconsole as searchconsoleClient } from '@googleapis/searchconsole';
 import { webmasters as webmastersClient } from '@googleapis/webmasters';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 export function registerSearchConsoleTools(server: ToolRegistry): void {
   // ─── Sites ───────────────────────────────────────────────

--- a/src/tools/sheets.ts
+++ b/src/tools/sheets.ts
@@ -2,12 +2,12 @@ import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceArray, coerceBoolean, coerceJson } from './_coerce.js';
 import { sheets as sheetsClient } from '@googleapis/sheets';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 export function registerSheetsTools(server: ToolRegistry): void {
   server.registerTool(

--- a/src/tools/slides.ts
+++ b/src/tools/slides.ts
@@ -1,14 +1,14 @@
 import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { slides as slidesClient } from '@googleapis/slides';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
 import { coerceArray, coerceBoolean, coerceJson } from './_coerce.js';
 import { sliceClean } from '../trim.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 const SLIDE_TEXT_DIGEST_CHARS = 200;
 

--- a/src/tools/tasks.ts
+++ b/src/tools/tasks.ts
@@ -2,12 +2,12 @@ import type { ToolRegistry } from '../registry.js';
 import { z } from 'zod';
 import { coerceBoolean } from './_coerce.js';
 import { tasks as tasksClient } from '@googleapis/tasks';
-import { ACCOUNTS } from '../accounts.js';
+import { accountAliasSchema } from '../accounts.js';
 import type { Account } from '../accounts.js';
 import { getClient } from '../client.js';
 import { handleGoogleApiError } from './_errors.js';
 
-const accountEnum = z.enum(ACCOUNTS).optional();
+const accountEnum = accountAliasSchema.optional();
 
 export function registerTasksTools(server: ToolRegistry): void {
   // ─── Tasklists ─────────────────────────────────────────────────────────

--- a/tests/config-registry.test.ts
+++ b/tests/config-registry.test.ts
@@ -69,11 +69,17 @@ describe('resolveAccounts', () => {
     expect(set.configs.b.admin).toBe(true);
   });
 
-  it('E_NO_ACCOUNTS_CONFIGURED: neither env nor file refuses to start', () => {
-    const { stderr } = spyExit();
-    expect(() => resolveAccounts({} as NodeJS.ProcessEnv, cfgPath)).toThrow('exit-called');
-    expect(String(stderr.mock.calls[0]?.[0])).toContain('E_NO_ACCOUNTS_CONFIGURED');
-    expect(String(stderr.mock.calls[0]?.[0])).toContain('migrate-config');
+  it('empty registry is non-fatal at module-load severity (gap #23): returns an empty set, never exits', () => {
+    // The refuse-to-start moved off module load so the bootstrap/diagnostic CLIs
+    // (doctor/reset/import/config check) can run on a fresh install. The SERVER
+    // still refuses empty via assertServerAccountsConfigured(); the dispatch
+    // reload ('throw') still raises (see the reload-safety test below).
+    const { exit } = spyExit();
+    const set = resolveAccounts({} as NodeJS.ProcessEnv, cfgPath);
+    expect(set.aliases).toEqual([]);
+    expect(set.configs).toEqual({});
+    expect(set.source).toBe('file');
+    expect(exit).not.toHaveBeenCalled();
   });
 
   it('first-run shim materializes config.json from env, and only once', () => {

--- a/tests/empty-registry.test.ts
+++ b/tests/empty-registry.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveAccounts, accountAliasSchemaFor } from '../src/accounts.js';
+
+// Gap #23: a fresh install (zero accounts) must NOT crash the bootstrap/diagnostic
+// CLIs at module load. resolveAccounts and the account-field schema are the two
+// module-load choke points; both are exercised here without a subprocess.
+
+const nonexistent = () => path.join(mkdtempSync(path.join(tmpdir(), 'mcp-gm-empty-')), 'config.json');
+
+describe('resolveAccounts on an empty registry (gap #23)', () => {
+  it('returns an empty AccountSet (not a process exit) at module-load severity', () => {
+    // env with NO GOOGLE_ACCOUNTS + an absent config.json => zero accounts.
+    const set = resolveAccounts({}, nonexistent(), 'exit');
+    expect(set.aliases).toEqual([]);
+    expect(set.configs).toEqual({});
+    expect(set.source).toBe('file');
+    expect(set.defaultAccount).toBeUndefined();
+    // the always-present base profile survives so scope resolution stays valid
+    expect(set.scopeProfiles.base).toEqual({ bundles: [] });
+  });
+
+  it('also tolerates a present-but-accountless config.json', () => {
+    const file = nonexistent();
+    writeFileSync(file, JSON.stringify({ version: 1, accounts: {} }));
+    const set = resolveAccounts({}, file, 'exit');
+    expect(set.aliases).toEqual([]);
+  });
+
+  it('STILL throws on the reload path so a mid-session empty keeps the last-good set (BR-7)', () => {
+    // onInvalid: 'throw' is the dispatch-reload contract — it must not silently
+    // drop a running server to zero accounts.
+    expect(() => resolveAccounts({}, nonexistent(), 'throw')).toThrowError(/E_NO_ACCOUNTS_CONFIGURED/);
+  });
+
+  it('resolves normally when accounts are present (no regression)', () => {
+    const set = resolveAccounts({ GOOGLE_ACCOUNTS: 'work:w@example.com,personal:p@example.com' }, nonexistent(), 'exit');
+    expect(set.aliases).toEqual(['work', 'personal']);
+    expect(set.configs.work.email).toBe('w@example.com');
+  });
+});
+
+describe('accountAliasSchemaFor: empty-safe account field (gap #23)', () => {
+  it('falls back to a plain string when there are no aliases (z.enum would throw)', () => {
+    const schema = accountAliasSchemaFor([]);
+    // any string parses — there is nothing to enumerate, and dispatch validates
+    // against the live set anyway
+    expect(schema.safeParse('anything').success).toBe(true);
+    expect(schema.safeParse('work').success).toBe(true);
+  });
+
+  it('is a strict enum when aliases exist (rejects unknown aliases)', () => {
+    const schema = accountAliasSchemaFor(['work', 'personal']);
+    expect(schema.safeParse('work').success).toBe(true);
+    expect(schema.safeParse('personal').success).toBe(true);
+    expect(schema.safeParse('nope').success).toBe(false);
+    expect(schema.safeParse(123 as unknown as string).success).toBe(false);
+  });
+});
+
+// End-to-end: a real process on a truly empty registry. Guards the two invariants
+// that no in-process test can reach (the account snapshot is non-empty in-suite):
+// the bootstrap/diagnostic CLIs must RUN, and the SERVER must REFUSE (BR-4).
+describe('empty registry, end-to-end via the CLI (gap #23)', () => {
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const srcIndex = path.join(repoRoot, 'src', 'index.ts');
+
+  // Run the built entry through tsx (reflects src, no dist dependency) on a fresh
+  // config home, with MCP_GOOGLE_MULTI_ENV pointed at an EMPTY file so a stray
+  // repo-root .env can't leak accounts in. stdin is closed so the server can't hang.
+  function runCli(args: string[]): { status: number | null; out: string } {
+    const home = mkdtempSync(path.join(tmpdir(), 'mcp-gm-e2e-'));
+    const emptyEnv = path.join(home, 'empty.env');
+    writeFileSync(emptyEnv, '');
+    const env = { ...process.env } as NodeJS.ProcessEnv;
+    for (const k of ['GOOGLE_ACCOUNTS', 'GOOGLE_ADMIN_ACCOUNTS', 'GOOGLE_OPTIONAL_SCOPES', 'GOOGLE_DEFAULT_ACCOUNT']) delete env[k];
+    env.XDG_CONFIG_HOME = home;
+    env.TOKEN_STORE_PATH = path.join(home, 'tokens');
+    env.MCP_GOOGLE_MULTI_ENV = emptyEnv;
+    // cwd = repoRoot so `--import tsx` resolves from node_modules; MCP_GOOGLE_MULTI_ENV
+    // (an empty file) already bypasses all .env search tiers, so no repo .env leaks.
+    const r = spawnSync(process.execPath, ['--import', 'tsx', srcIndex, ...args], {
+      cwd: repoRoot,
+      env,
+      input: '',
+      encoding: 'utf8',
+      timeout: 60_000,
+    });
+    return { status: r.status, out: `${r.stdout ?? ''}${r.stderr ?? ''}` };
+  }
+
+  it('`doctor` RUNS and reports the missing accounts (no module-load crash)', () => {
+    const { status, out } = runCli(['doctor']);
+    // The full report rendered — proof the process reached main(), not an
+    // import-time exit — and the Config section flags the empty registry.
+    expect(out).toMatch(/Runtime/);
+    expect(out).toMatch(/No accounts configured/i);
+    expect(status).toBe(1); // Overall FAIL
+  });
+
+  it('`account import` RUNS on an empty registry (bootstraps a fresh machine)', () => {
+    const { out } = runCli(['account', 'import', path.join(tmpdir(), 'does-not-exist.enc')]);
+    // The import CLI executed and reported the missing bundle, rather than dying
+    // at module load with the no-accounts error.
+    expect(out).toMatch(/E_NOT_FOUND/);
+    expect(out).not.toMatch(/E_NO_ACCOUNTS_CONFIGURED/);
+  });
+
+  it('the SERVER still REFUSES to boot on an empty registry (BR-4)', () => {
+    const { status, out } = runCli([]); // no subcommand => server path
+    expect(status).not.toBe(0);
+    expect(out).toMatch(/E_NO_ACCOUNTS_CONFIGURED/);
+  });
+});

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -240,7 +240,9 @@ describe('ToolRegistry', () => {
     const schemaOf = (n: string) => tools.find((t) => t.name === n)!.inputSchema.properties.account;
 
     expect(schemaOf('gmail_search').anyOf).toBeDefined();
-    expect((schemaOf('gmail_search').anyOf![0] as { enum: string[] }).enum).toEqual(['test', '*']);
+    // '*' is listed first so the enum tuple is statically non-empty (empty-safe
+    // for a fresh install); order is cosmetic, the accepted set is unchanged.
+    expect((schemaOf('gmail_search').anyOf![0] as { enum: string[] }).enum).toEqual(['*', 'test']);
     expect(schemaOf('gmail_send').enum).toEqual(['test']);
     expect(schemaOf('drive_download').enum).toEqual(['test']);
     expect(schemaOf('google_api_call').enum).toEqual(['test']);


### PR DESCRIPTION
## Fresh-install fix (follow-up #23, surfaced by B19)

A brand-new install (zero accounts) crashed **every** CLI at module load: `index.ts`'s eager `import './accounts.js'` ran `resolveAccounts()` at exit-severity, which `failStartup()`'d on an empty registry **before** `main()` could dispatch. So `doctor` (which is meant to *report* the missing accounts), `account import` (meant to bootstrap a fresh machine), `reset`, `migrate-config`, and `config check` all died with `E_NO_ACCOUNTS_CONFIGURED` instead of running.

### Fix
- **`resolveAccounts()`**: an empty registry is non-fatal at `'exit'`/module-load severity (returns an empty `AccountSet`). It **still throws** on the dispatch reload (`'throw'`), so a mid-session emptied `config.json` keeps the last-good set (**BR-7**). `AccountSet.aliases` relaxed to `string[]`.
- **Shared empty-safe `accountAliasSchema`** (`z.enum` when aliases exist, else `z.string`) replaces every `z.enum(ACCOUNTS)` across the 15 curated tool files, `generated/_shared.ts`, and `drive_transfer`'s required enum — `z.enum([])` throws at schema-build (module load), which would re-break the same CLIs. `fanout` reordered to `z.enum(['*', ...ACCOUNTS])` to stay statically non-empty.
- **The server still refuses to boot empty (BR-4)**: a new `assertServerAccountsConfigured()` runs on the stdio/http path *after* every CLI branch returns.

### Verified end-to-end (subprocess tests)
`doctor` + `account import` **RUN** on an empty registry; the **server REFUSES**.

### Tests / gates
`tests/empty-registry.test.ts` (unit: resolveAccounts empty/throw/normal, `accountAliasSchemaFor` empty/enum; + 3 hermetic subprocess CLI checks). Updated `config-registry` + `registry` expectations for the moved contract and enum order. Local: `typecheck` ✓ · `lint` ✓ · `test` ✓ (673) · `build` ✓.

Reviewed via a 4-lens adversarial workflow (correctness / BR-4 security / schema-contract / completeness): **0 findings**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)