### PR TITLE
feat: log successful /mcp dispatches and OAuth completions

### DIFF
--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -65,6 +65,14 @@ export function hostAllowed(host: string | undefined, allowed: string[]): boolea
   return allowed.includes(host) || allowed.includes(bare);
 }
 
+/** JSON-RPC method name(s) for an observability log line — no params, no PII. */
+export function jsonRpcMethod(body: unknown): string {
+  const one = (b: unknown): string | undefined =>
+    b && typeof b === 'object' && 'method' in b ? String((b as { method: unknown }).method) : undefined;
+  if (Array.isArray(body)) return body.map(one).filter(Boolean).join(',') || 'batch';
+  return one(body) ?? 'unknown';
+}
+
 
 export class HttpTransportHost {
   private httpServer?: Server;
@@ -239,6 +247,10 @@ export class HttpTransportHost {
           } else {
             res.destroy();
           }
+        } else if (outcome === 'done') {
+          // Success path: close the observability gap (failures already log; a
+          // completed dispatch logged nothing). Method only — no params, no PII.
+          this.log(`200 /mcp method=${jsonRpcMethod(body)}`);
         }
       } finally {
         if (timer) clearTimeout(timer);

--- a/src/oauth-as.ts
+++ b/src/oauth-as.ts
@@ -384,6 +384,7 @@ export function buildAuthServer(config: AuthServerConfig, deps: AuthServerDeps =
         return errorPage(res, 403, 'access_denied', 'the Google account you signed in with is not the one configured for this alias');
       }
       deps.writeToken?.(st.alias, exchanged.tokens);
+      log(`callback ok flow=alias_reauth alias=${st.alias}`);
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(`<!doctype html><meta charset=utf-8><p>Re-authenticated "${st.alias}". You can close this window.</p>`);
       return true;
@@ -403,6 +404,7 @@ export function buildAuthServer(config: AuthServerConfig, deps: AuthServerDeps =
       secret,
       nowSec(),
     );
+    log('callback ok flow=owner_gate');
     const sep = st.redirect_uri.includes('?') ? '&' : '?';
     const s = st.client_state ? `&state=${encodeURIComponent(st.client_state)}` : '';
     return redirect(res, `${st.redirect_uri}${sep}code=${encodeURIComponent(authzCode)}${s}&iss=${iss}`);
@@ -438,12 +440,14 @@ export function buildAuthServer(config: AuthServerConfig, deps: AuthServerDeps =
       }
       const access = await signAccessToken({ base, secret, iat: nowSec(), ttlSec: accessTtl });
       const refreshToken = refresh.issue(now());
+      log('token issued grant=authorization_code');
       return json(res, 200, { access_token: access, token_type: 'Bearer', expires_in: accessTtl, refresh_token: refreshToken, scope: 'mcp:use' });
     }
     if (grant === 'refresh_token') {
       const next = refresh.rotate(form.refresh_token ?? '', now());
       if (!next) return json(res, 400, { error: 'invalid_grant', message: 'unknown or rotated refresh token' });
       const access = await signAccessToken({ base, secret, iat: nowSec(), ttlSec: accessTtl });
+      log('token issued grant=refresh_token');
       return json(res, 200, { access_token: access, token_type: 'Bearer', expires_in: accessTtl, refresh_token: next, scope: 'mcp:use' });
     }
     return json(res, 400, { error: 'unsupported_grant_type', message: 'authorization_code or refresh_token only' });

--- a/tests/http-transport.test.ts
+++ b/tests/http-transport.test.ts
@@ -7,6 +7,7 @@ import {
   parseOwnerEmails,
   originAllowed,
   hostAllowed,
+  jsonRpcMethod,
   type Authenticator,
 } from '../src/http-transport.js';
 
@@ -32,6 +33,14 @@ describe('http-transport pure helpers', () => {
     expect(hostAllowed('evil.example', allowed)).toBe(false);
     expect(hostAllowed(undefined, allowed)).toBe(false);
     expect(hostAllowed('anything', [])).toBe(true); // no allowlist configured
+  });
+
+  it('jsonRpcMethod: method name only, batch-aware, never throws on junk', () => {
+    expect(jsonRpcMethod({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { secret: 'x' } })).toBe('tools/call');
+    expect(jsonRpcMethod([{ method: 'a' }, { method: 'b' }])).toBe('a,b');
+    expect(jsonRpcMethod({})).toBe('unknown');
+    expect(jsonRpcMethod(null)).toBe('unknown');
+    expect(jsonRpcMethod('nonsense')).toBe('unknown');
   });
 
 });
@@ -65,7 +74,7 @@ function makeServer(): McpServer {
 
 async function startHost(
   authenticate: Authenticator = () => ({ ok: true }),
-  extra: { dispatchTimeoutMs?: number } = {},
+  extra: { dispatchTimeoutMs?: number; log?: (line: string) => void } = {},
 ): Promise<number> {
   const config = { ...resolveHttpConfig({ MCP_TRANSPORT: 'http' }), port: 0 };
   const host = new HttpTransportHost({ server: makeServer(), config, version: '9.9.9', ownerConfigured: true, authenticate, ...extra });
@@ -243,5 +252,19 @@ describe('HttpTransportHost (BV-3: stateless dispatch)', () => {
     });
     expect(after.status).toBe(200);
     expect(JSON.parse(after.text).result.tools).toBeDefined();
+  });
+
+  it('logs a concise success line on a completed dispatch (method only, no PII)', async () => {
+    const logs: string[] = [];
+    const port = await startHost(() => ({ ok: true }), { log: (l) => logs.push(l) });
+    await request(port, 'POST', '/mcp', { headers: { accept: MCP_ACCEPT }, body: initBody });
+    await request(port, 'POST', '/mcp', {
+      headers: { accept: MCP_ACCEPT },
+      body: { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+    });
+    expect(logs).toContain('200 /mcp method=initialize');
+    expect(logs).toContain('200 /mcp method=tools/list');
+    // no params / arguments / secrets leak into the log
+    expect(logs.join('\n')).not.toMatch(/params|arguments|protocolVersion/);
   });
 });

--- a/tests/oauth-as.test.ts
+++ b/tests/oauth-as.test.ts
@@ -57,7 +57,7 @@ async function start(depOverrides: Partial<AuthServerDeps> = {}): Promise<number
   );
   const server = new McpServer({ name: 'as-test', version: '0' });
   server.registerTool('ping', { description: 'p', inputSchema: {} }, async () => ({ content: [{ type: 'text' as const, text: 'pong' }] }));
-  const host = new HttpTransportHost({ server, config: cfg, version: '0', ownerConfigured: true, authenticate: as.authenticate, routes: as.routes });
+  const host = new HttpTransportHost({ server, config: cfg, version: '0', ownerConfigured: true, authenticate: as.authenticate, routes: as.routes, log: deps.log });
   await host.start();
   hosts.push(host);
   return host.address()!.port;
@@ -152,6 +152,38 @@ describe('happy path (legs A + B)', () => {
     const ref = JSON.parse((await req(port, 'POST', '/token', form({ grant_type: 'refresh_token', refresh_token: tok.refresh_token }))).text);
     expect(ref.access_token).toBeTruthy();
     expect(ref.refresh_token).not.toBe(tok.refresh_token);
+  });
+});
+
+describe('success-path observability (logs completions, not just failures)', () => {
+  it('logs /callback owner_gate, /token (both grants), and the /mcp dispatch — no PII', async () => {
+    const logs: string[] = [];
+    const port = await start({ log: (l) => logs.push(l) });
+    const state = stateFrom((await req(port, 'GET', `/authorize?${authorizeQuery()}`)).headers.location as string);
+    const cb = await req(port, 'GET', `/callback?code=owner-code&state=${encodeURIComponent(state)}`);
+    const code = new URL(cb.headers.location as string).searchParams.get('code')!;
+    const tok = JSON.parse((await req(port, 'POST', '/token', form({ grant_type: 'authorization_code', code, redirect_uri: REDIRECT, code_verifier: verifier, resource: `${BASE}/mcp` }))).text);
+    await req(port, 'POST', '/mcp', {
+      headers: { authorization: `Bearer ${tok.access_token}`, 'content-type': 'application/json', accept: 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'c', version: '0' } } }),
+    });
+    await req(port, 'POST', '/token', form({ grant_type: 'refresh_token', refresh_token: tok.refresh_token }));
+
+    expect(logs).toContain('callback ok flow=owner_gate');
+    expect(logs).toContain('token issued grant=authorization_code');
+    expect(logs).toContain('token issued grant=refresh_token');
+    expect(logs).toContain('200 /mcp method=initialize');
+    // never leak the owner email, Google tokens, or the minted access/refresh values
+    expect(logs.join('\n')).not.toMatch(/owner@x|g-rt|g-at|access_token|Bearer/);
+  });
+
+  it('logs the /callback alias_reauth completion by alias (no email)', async () => {
+    const logs: string[] = [];
+    const port = await start({ log: (l) => logs.push(l) });
+    const state = stateFrom((await req(port, 'GET', `/authorize?${authorizeQuery({ flow: 'alias_reauth', alias: 'work' })}`)).headers.location as string);
+    await req(port, 'GET', `/callback?code=work-code&state=${encodeURIComponent(state)}`);
+    expect(logs).toContain('callback ok flow=alias_reauth alias=work');
+    expect(logs.join('\n')).not.toMatch(/work@x\.example/);
   });
 });
 


### PR DESCRIPTION
## Close the success-path observability gap (follow-up #24)

The HTTP host logged **only failures** (401/403/504). A completed `/mcp` dispatch or a finished OAuth leg logged nothing, so a working connection was invisible (during B13 verification the only success signal was the `mcp-tokens.enc` mtime).

### Adds (always-on, PII-free)
- **transport**: `200 /mcp method=<jsonrpc method>` on a completed dispatch — method name only (new exported `jsonRpcMethod` helper; no params, batch-aware).
- **oauth-as**: a completion line per success — `callback ok flow=owner_gate`, `callback ok flow=alias_reauth alias=<alias>`, `token issued grant=authorization_code|refresh_token`. **No emails, no code/token values** (the alias is a local charset-restricted label).

Always-on to match the existing always-on failure lines (single-owner / low-QPS server). Tests assert the lines are emitted **and** that no email / `Bearer` / token value leaks into them.

### Gates
`typecheck` ✓ · `lint` ✓ · `test` ✓ (677, +4) · `build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)