### PR TITLE
Merge dev into v6 (sync before the v6 -> dev promotion)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -704,9 +704,9 @@
       }
     },
     "node_modules/@googleapis/admin": {
-      "version": "32.0.0",
-      "resolved": "https://registry.npmjs.org/@googleapis/admin/-/admin-32.0.0.tgz",
-      "integrity": "sha512-OzdRZF9lXm7AYGEKSpx8gjDV3Kv6ktIHA+f73cDIP1xrjBelnV1wgjTos8IMXBgoDX5r4c3HpTbLDBtllsf6rA==",
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/admin/-/admin-32.1.0.tgz",
+      "integrity": "sha512-nDwRKj0Fb6WdNftKMMYSdd7lQo4yeJj0DhoyQYoHmFTrbqJo8YBFWj+G6sZvHPhHm/LYDa3m4F+qpoiTbZOnIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "googleapis-common": "^8.0.0"
@@ -728,9 +728,9 @@
       }
     },
     "node_modules/@googleapis/chat": {
-      "version": "46.0.0",
-      "resolved": "https://registry.npmjs.org/@googleapis/chat/-/chat-46.0.0.tgz",
-      "integrity": "sha512-v4CJMirIYUIsWQbW9jFtOY0K2GFG1KeBdZCssJYMxL9xv42xoWoUe6h1s2WVylhfC1X7uUMvi75CtWLRkEnGWw==",
+      "version": "46.0.1",
+      "resolved": "https://registry.npmjs.org/@googleapis/chat/-/chat-46.0.1.tgz",
+      "integrity": "sha512-/Ikl54jZGMYYqT8I667S+38OaoQVkgnD8In6VCA/1zoaccMOKepeF8A5OBveE7z9pFJVkQQYdv8kx8HNHdN93A==",
       "license": "Apache-2.0",
       "dependencies": {
         "googleapis-common": "^8.0.0"
@@ -812,9 +812,9 @@
       }
     },
     "node_modules/@googleapis/searchconsole": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@googleapis/searchconsole/-/searchconsole-7.0.0.tgz",
-      "integrity": "sha512-iZhfs7BHgpmd53z2DGBK/N4F9/am0a063W8dt6QneeUXFwmCD0KU1A7U/P/xsyX5UhYRKWi0BCP3cKQjzIGOwA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/searchconsole/-/searchconsole-7.1.0.tgz",
+      "integrity": "sha512-aTfAhAJqqA7b85EJLOLEJKG1jukrmCbfb5GFPAwt88rCzqnNgTktTXFpPmVZX7bqLw4YjhP2+bxGHAw22PMrkw==",
       "license": "Apache-2.0",
       "dependencies": {
         "googleapis-common": "^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "@googleapis/admin": "^32.0.0",
+        "@googleapis/admin": "^33.0.0",
         "@googleapis/calendar": "^16.0.0",
-        "@googleapis/chat": "^46.0.0",
+        "@googleapis/chat": "^47.0.0",
         "@googleapis/docs": "^10.0.0",
-        "@googleapis/drive": "^21.0.0",
+        "@googleapis/drive": "^22.0.0",
         "@googleapis/forms": "^7.0.0",
         "@googleapis/gmail": "^18.0.0",
         "@googleapis/meet": "^5.0.0",
@@ -704,9 +704,9 @@
       }
     },
     "node_modules/@googleapis/admin": {
-      "version": "32.1.0",
-      "resolved": "https://registry.npmjs.org/@googleapis/admin/-/admin-32.1.0.tgz",
-      "integrity": "sha512-nDwRKj0Fb6WdNftKMMYSdd7lQo4yeJj0DhoyQYoHmFTrbqJo8YBFWj+G6sZvHPhHm/LYDa3m4F+qpoiTbZOnIg==",
+      "version": "33.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/admin/-/admin-33.0.0.tgz",
+      "integrity": "sha512-WnWQEbCki+NKSlNk93Krghj/12ysi+gqxpvcSb+MJvglfUoDKARBzdSgH6zZ+30C/0RAz2z+tslu1niXtvTTnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "googleapis-common": "^8.0.0"
@@ -728,9 +728,9 @@
       }
     },
     "node_modules/@googleapis/chat": {
-      "version": "46.0.1",
-      "resolved": "https://registry.npmjs.org/@googleapis/chat/-/chat-46.0.1.tgz",
-      "integrity": "sha512-/Ikl54jZGMYYqT8I667S+38OaoQVkgnD8In6VCA/1zoaccMOKepeF8A5OBveE7z9pFJVkQQYdv8kx8HNHdN93A==",
+      "version": "47.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/chat/-/chat-47.0.0.tgz",
+      "integrity": "sha512-vM4mV5/2SAhBDZ2hcou/g55ekgMW1bqxYxG+hxH9j49hywkMl+tWLhc07jB4NRMTRl0/WS7CrCzwFmXGZHy59Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "googleapis-common": "^8.0.0"
@@ -752,9 +752,9 @@
       }
     },
     "node_modules/@googleapis/drive": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@googleapis/drive/-/drive-21.0.0.tgz",
-      "integrity": "sha512-vebQpAqn+FZcmDWh1TEQTcYdkKftcSaHc7kO2ZxrINBb+ZMcFu1UybD3+maeqdLs60HrRDYwyzJ6TgZ7/Vn2Rg==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/drive/-/drive-22.0.0.tgz",
+      "integrity": "sha512-u21JQPR5mGKt8OqjsDndb+l5b44IXCKTum+P1Q1rlWmi2pUNZqcNeq7csx06xlwj+UeZv5/ZhhhAjziVZu86Dg==",
       "license": "Apache-2.0",
       "dependencies": {
         "googleapis-common": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -60,11 +60,11 @@
     "gen:coverage": "tsx scripts/gen-coverage.ts"
   },
   "dependencies": {
-    "@googleapis/admin": "^32.0.0",
+    "@googleapis/admin": "^33.0.0",
     "@googleapis/calendar": "^16.0.0",
-    "@googleapis/chat": "^46.0.0",
+    "@googleapis/chat": "^47.0.0",
     "@googleapis/docs": "^10.0.0",
-    "@googleapis/drive": "^21.0.0",
+    "@googleapis/drive": "^22.0.0",
     "@googleapis/forms": "^7.0.0",
     "@googleapis/gmail": "^18.0.0",
     "@googleapis/meet": "^5.0.0",


### PR DESCRIPTION
Syncs v6 with the current default branch (`dev`) ahead of the v6 -> dev promotion, so v6 is a clean superset before that merge.

- Brings in the `googleapis` group Dependabot bumps that landed on dev (#176, #177).
- Keeps v6's own security bumps (fast-uri/hono/qs/js-yaml, #180).
- `package.json` and `package-lock.json` auto-merged with no conflicts (dev touched `dependencies`, v6 touched `overrides`/`devDependencies`); `npm install` made no further lockfile changes.

Validated on the merge: `build` clean, full test suite green (696 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)